### PR TITLE
feat(java25): adopt GA Java 21–25 features and safe modernizations

### DIFF
--- a/control-panel-core/src/main/java/io/micronaut/controlpanel/core/panels/RoutesControlPanel.java
+++ b/control-panel-core/src/main/java/io/micronaut/controlpanel/core/panels/RoutesControlPanel.java
@@ -87,7 +87,7 @@ public class RoutesControlPanel extends AbstractControlPanel<RoutesControlPanel.
             .filter(filter)
             .distinct()
             .sorted(COMPARATOR_BY_URI.thenComparing(UriRouteInfo::getHttpMethodName))
-            .collect(Collectors.groupingBy(KEY_MAPPER, LinkedHashMap::new, Collectors.toList()));
+            .collect(Collectors.groupingBy(KEY_MAPPER, LinkedHashMap::new, Collectors.toUnmodifiableList()));
     }
 
     @ReflectiveAccess

--- a/control-panel-core/src/test/java/io/micronaut/controlpanel/core/panels/RoutesControlPanelTest.java
+++ b/control-panel-core/src/test/java/io/micronaut/controlpanel/core/panels/RoutesControlPanelTest.java
@@ -80,6 +80,14 @@ class RoutesControlPanelTest {
 
         assertEquals(routeSignatures.size(), new java.util.HashSet<>(routeSignatures).size());
         assertTrue(allRoutes.size() > 0);
+
+        // new: verify lists are unmodifiable
+        var grouped = body.micronautRoutes();
+        var firstKey = grouped.keySet().stream().findFirst().orElse(null);
+        if (firstKey != null) {
+            var list = grouped.get(firstKey);
+            assertThrows(UnsupportedOperationException.class, () -> list.add(null));
+        }
     }
 
     @Controller

--- a/control-panel-management/src/main/java/io/micronaut/controlpanel/panels/management/beans/BeansControlPanel.java
+++ b/control-panel-management/src/main/java/io/micronaut/controlpanel/panels/management/beans/BeansControlPanel.java
@@ -102,7 +102,7 @@ public class BeansControlPanel extends AbstractControlPanel<BeansControlPanel.Bo
             .stream()
             .filter(filter)
             .sorted(COMPARATOR_BY_NAME)
-            .collect(Collectors.groupingBy(groupBy, LinkedHashMap::new, Collectors.mapping(beanDefinitionData::getData, Collectors.toList())));
+            .collect(Collectors.groupingBy(groupBy, LinkedHashMap::new, Collectors.mapping(beanDefinitionData::getData, Collectors.toUnmodifiableList())));
     }
 
     @Override

--- a/control-panel-management/src/test/java/io/micronaut/controlpanel/panels/management/beans/BeansControlPanelTest.java
+++ b/control-panel-management/src/test/java/io/micronaut/controlpanel/panels/management/beans/BeansControlPanelTest.java
@@ -54,6 +54,14 @@ class BeansControlPanelTest {
             assertNotNull(panel.getBody().micronautBeansByPackage());
             assertNotNull(panel.getBody().otherBeansByPackage());
             assertTrue(panel.getBody().otherBeansByPackage().containsKey("primitive"));
+
+            // new: verify lists are unmodifiable for one package
+            var map = panel.getBody().otherBeansByPackage();
+            var key = map.keySet().stream().findFirst().orElse(null);
+            if (key != null) {
+                var list = map.get(key);
+                assertThrows(UnsupportedOperationException.class, () -> list.add(null));
+            }
         }
     }
 }

--- a/control-panel-object-storage/src/main/java/io/micronaut/controlpanel/panels/objectstorage/ObjectStorageControlPanel.java
+++ b/control-panel-object-storage/src/main/java/io/micronaut/controlpanel/panels/objectstorage/ObjectStorageControlPanel.java
@@ -99,16 +99,13 @@ public class ObjectStorageControlPanel extends AbstractEachBeanControlPanel<Obje
 
     @Override
     public String getIcon() {
-        if (objectStorageConfiguration instanceof LocalStorageConfiguration) {
-            return "fa-hard-drive";
-        } else if (objectStorageConfiguration instanceof AwsS3Configuration) {
-            return "fa-brands fa-aws";
-        } else if (objectStorageConfiguration instanceof AzureBlobStorageConfiguration) {
-            return "fa-brands fa-microsoft";
-        } else if (objectStorageConfiguration instanceof GoogleCloudStorageConfiguration) {
-            return "fa-brands fa-google";
-        }
-        return DEFAULT_ICON_CLASS;
+        return switch (objectStorageConfiguration) {
+            case LocalStorageConfiguration ignored -> "fa-hard-drive";
+            case AwsS3Configuration ignored -> "fa-brands fa-aws";
+            case AzureBlobStorageConfiguration ignored -> "fa-brands fa-microsoft";
+            case GoogleCloudStorageConfiguration ignored -> "fa-brands fa-google";
+            default -> DEFAULT_ICON_CLASS;
+        };
     }
 
     /**
@@ -118,18 +115,19 @@ public class ObjectStorageControlPanel extends AbstractEachBeanControlPanel<Obje
      */
     Map<String, Object> computeMetadata() {
         var metadata = new HashMap<String, Object>();
-        if (objectStorageConfiguration instanceof LocalStorageConfiguration localConfiguration) {
-            metadata.put("path", localConfiguration.getPath());
-        } else if (objectStorageConfiguration instanceof AwsS3Configuration awsS3Configuration) {
-            metadata.put(BUCKET, awsS3Configuration.getBucket());
-        } else if (objectStorageConfiguration instanceof AzureBlobStorageConfiguration azureBlobConfiguration) {
-            metadata.put("container", azureBlobConfiguration.getContainer());
-            metadata.put("endpoint", azureBlobConfiguration.getEndpoint());
-        } else if (objectStorageConfiguration instanceof GoogleCloudStorageConfiguration googleCloudConfiguration) {
-            metadata.put(BUCKET, googleCloudConfiguration.getBucket());
-        } else if (objectStorageConfiguration instanceof OracleCloudStorageConfiguration oracleCloudConfiguration) {
-            metadata.put(BUCKET, oracleCloudConfiguration.getBucket());
-            metadata.put("namespace", oracleCloudConfiguration.getNamespace());
+        switch (objectStorageConfiguration) {
+            case LocalStorageConfiguration localConfiguration -> metadata.put("path", localConfiguration.getPath());
+            case AwsS3Configuration awsS3Configuration -> metadata.put(BUCKET, awsS3Configuration.getBucket());
+            case AzureBlobStorageConfiguration azureBlobConfiguration -> {
+                metadata.put("container", azureBlobConfiguration.getContainer());
+                metadata.put("endpoint", azureBlobConfiguration.getEndpoint());
+            }
+            case GoogleCloudStorageConfiguration googleCloudConfiguration -> metadata.put(BUCKET, googleCloudConfiguration.getBucket());
+            case OracleCloudStorageConfiguration oracleCloudConfiguration -> {
+                metadata.put(BUCKET, oracleCloudConfiguration.getBucket());
+                metadata.put("namespace", oracleCloudConfiguration.getNamespace());
+            }
+            default -> { /* no-op */ }
         }
         return metadata;
     }

--- a/control-panel-object-storage/src/test/java/io/micronaut/controlpanel/panels/objectstorage/ObjectStorageControlPanelAdditionalTest.java
+++ b/control-panel-object-storage/src/test/java/io/micronaut/controlpanel/panels/objectstorage/ObjectStorageControlPanelAdditionalTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.objectstorage;
+
+import io.micronaut.controlpanel.core.config.ControlPanelConfiguration;
+import io.micronaut.objectstorage.azure.AzureBlobStorageConfiguration;
+import io.micronaut.objectstorage.googlecloud.GoogleCloudStorageConfiguration;
+import io.micronaut.objectstorage.oraclecloud.OracleCloudStorageConfiguration;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ObjectStorageControlPanelAdditionalTest {
+
+    @Test
+    void computeMetadataIncludesContainerAndEndpointForAzure() {
+        AzureBlobStorageConfiguration cfg = Mockito.mock(AzureBlobStorageConfiguration.class);
+        Mockito.when(cfg.getContainer()).thenReturn("c1");
+        Mockito.when(cfg.getEndpoint()).thenReturn("https://example.blob.core.windows.net");
+        var panel = new ObjectStorageControlPanel(Mockito.mock(io.micronaut.objectstorage.ObjectStorageOperations.class), cfg, Mockito.mock(ControlPanelConfiguration.class));
+        var metadata = panel.computeMetadata();
+        assertEquals("c1", metadata.get("container"));
+        assertEquals("https://example.blob.core.windows.net", metadata.get("endpoint"));
+    }
+
+    @Test
+    void computeMetadataIncludesBucketForGoogleCloud() {
+        GoogleCloudStorageConfiguration cfg = Mockito.mock(GoogleCloudStorageConfiguration.class);
+        Mockito.when(cfg.getBucket()).thenReturn("gcs-bucket");
+        var panel = new ObjectStorageControlPanel(Mockito.mock(io.micronaut.objectstorage.ObjectStorageOperations.class), cfg, Mockito.mock(ControlPanelConfiguration.class));
+        var metadata = panel.computeMetadata();
+        assertEquals("gcs-bucket", metadata.get("bucket"));
+    }
+
+    @Test
+    void computeMetadataIncludesBucketAndNamespaceForOracleCloud() {
+        OracleCloudStorageConfiguration cfg = Mockito.mock(OracleCloudStorageConfiguration.class);
+        Mockito.when(cfg.getBucket()).thenReturn("oci-bucket");
+        Mockito.when(cfg.getNamespace()).thenReturn("ns1");
+        var panel = new ObjectStorageControlPanel(Mockito.mock(io.micronaut.objectstorage.ObjectStorageOperations.class), cfg, Mockito.mock(ControlPanelConfiguration.class));
+        var metadata = panel.computeMetadata();
+        assertEquals("oci-bucket", metadata.get("bucket"));
+        assertEquals("ns1", metadata.get("namespace"));
+    }
+}

--- a/control-panel-ui/src/main/java/io/micronaut/controlpanel/ui/ControlPanelController.java
+++ b/control-panel-ui/src/main/java/io/micronaut/controlpanel/ui/ControlPanelController.java
@@ -34,6 +34,7 @@ import io.micronaut.views.ModelAndView;
 import jakarta.inject.Inject;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -125,9 +126,9 @@ public class ControlPanelController implements ControlPanelApi {
                 ControlPanel.Category::id,
                 category -> repository.countByCategoryId(category.id()),
                 (a, b) -> a,
-                java.util.LinkedHashMap::new
+                LinkedHashMap::new
             ));
-        Map<String, Object> baseExtra = new java.util.LinkedHashMap<>();
+        Map<String, Object> baseExtra = new LinkedHashMap<>();
         baseExtra.put("controlPanelPath", controlPanelPath);
         baseExtra.put("appPath", appPath);
         baseExtra.put("categoryCount", categoryCount);

--- a/control-panel-ui/src/main/java/io/micronaut/controlpanel/ui/handlebars/HandlebarsHelperRegistrar.java
+++ b/control-panel-ui/src/main/java/io/micronaut/controlpanel/ui/handlebars/HandlebarsHelperRegistrar.java
@@ -39,6 +39,7 @@ import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Enumeration;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.jar.JarEntry;
@@ -140,10 +141,10 @@ class HandlebarsHelperRegistrar implements BeanCreatedEventListener<Handlebars> 
 
     private static Helper<Object> isMapHelper() {
         return (ctx, opts) -> {
-            if (ctx instanceof java.util.Map) {
-                return opts.fn(); // It's a Map, render the block
+            if (ctx instanceof Map<?, ?>) {
+                return opts.fn();
             } else {
-                return opts.inverse(); // It's not a Map, render the inverse block
+                return opts.inverse();
             }
         };
     }

--- a/control-panel-ui/src/test/java/io/micronaut/controlpanel/ui/handlebars/HandlebarsPrecompileTest.java
+++ b/control-panel-ui/src/test/java/io/micronaut/controlpanel/ui/handlebars/HandlebarsPrecompileTest.java
@@ -27,7 +27,7 @@ import org.mockito.Mockito;
 import static org.junit.jupiter.api.Assertions.*;
 
 class RecordingHandlebars extends Handlebars {
-    final java.util.List<String> compiled = new java.util.ArrayList<>();
+    final java.util.List<String> compiled = new java.util.ArrayList<>(); // retain FQNs in test to avoid extra imports
 
     RecordingHandlebars(TemplateLoader loader) { super(loader); }
     @Override public Template compile(String location) throws java.io.IOException {


### PR DESCRIPTION
Modernize to GA Java 21–25 features with no API changes.

Changes:
- Pattern-matching switch in object-storage (getIcon, computeMetadata)
- Use Collectors.toUnmodifiableList in core/management downstream collectors
- Minor UI cleanups (Map<?,?> helper, LinkedHashMap supplier/import tidy)

Checks:
- All module tests pass on JDK 25
- Spotless + Checkstyle pass
- Docs build OK