### PR TITLE
Implement metrics control panel

### DIFF
--- a/control-panel-management/build.gradle.kts
+++ b/control-panel-management/build.gradle.kts
@@ -4,8 +4,11 @@ plugins {
 
 dependencies {
     api(projects.micronautControlPanelCore)
+    annotationProcessor(mnSerde.micronaut.serde.processor)
     implementation(mn.micronaut.management)
+    implementation(mnMicrometer.micronaut.micrometer.core)
     implementation(mnReactor.micronaut.reactor)
+    implementation(mnSerde.micronaut.serde.api)
 
     testImplementation(mnTest.micronaut.test.junit5)
     testRuntimeOnly(mnTest.junit.jupiter.engine)

--- a/control-panel-management/src/main/java/io/micronaut/controlpanel/panels/management/MetricsControlPanel.java
+++ b/control-panel-management/src/main/java/io/micronaut/controlpanel/panels/management/MetricsControlPanel.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.management;
+
+import io.micrometer.core.instrument.Measurement;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Statistic;
+import io.micronaut.configuration.metrics.management.endpoint.MetricsEndpoint;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.controlpanel.core.AbstractControlPanel;
+import io.micronaut.controlpanel.core.config.ControlPanelConfiguration;
+import io.micronaut.core.annotation.ReflectiveAccess;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.serde.annotation.Serdeable;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Read-only control panel for browsing Micrometer metrics.
+ *
+ * @author Micronaut Engineer
+ * @since 2.0.0
+ */
+@Singleton
+@Requires(beans = MetricsEndpoint.class)
+@Requires(property = MetricsControlPanel.ENABLED_PROPERTY, notEquals = StringUtils.FALSE)
+public class MetricsControlPanel extends AbstractControlPanel<MetricsControlPanel.Body> {
+
+    static final int DASHBOARD_PREVIEW_LIMIT = 5;
+
+    public static final String NAME = "metrics";
+    public static final String ENABLED_PROPERTY = ControlPanelConfiguration.PREFIX + "." + NAME + ".enabled";
+
+    private final MetricsEndpoint endpoint;
+
+    public MetricsControlPanel(MetricsEndpoint endpoint, @Named(NAME) ControlPanelConfiguration configuration) {
+        super(NAME, configuration);
+        this.endpoint = endpoint;
+    }
+
+    @Override
+    public Body getBody() {
+        List<String> metricNames = getMetricNames(endpoint);
+        return new Body(
+            metricNames,
+            metricNames.stream().limit(DASHBOARD_PREVIEW_LIMIT).toList(),
+            metricNames.isEmpty() ? null : metricNames.get(0)
+        );
+    }
+
+    @Override
+    public String getBadge() {
+        return String.valueOf(getMetricNames(endpoint).size());
+    }
+
+    static List<String> getMetricNames(MetricsEndpoint endpoint) {
+        MetricsEndpoint.MetricNames metricNames = endpoint.listNames();
+        if (metricNames == null || metricNames.getNames() == null) {
+            return List.of();
+        }
+        return List.copyOf(metricNames.getNames());
+    }
+
+    static @Nullable MetricDetail toMetricDetail(MetricsEndpoint.MetricDetails details, @Nullable List<String> selectedTags) {
+        if (details == null) {
+            return null;
+        }
+        List<String> normalizedSelectedTags = selectedTags == null ? List.of() : List.copyOf(selectedTags);
+        List<MetricMeasurement> measurements = details.getMeasurements().stream()
+            .map(sample -> new MetricMeasurement(sample.getStatistic().name(), sample.getValue()))
+            .sorted(Comparator.comparing(MetricMeasurement::statistic))
+            .toList();
+        List<MetricAvailableTag> availableTags = details.getAvailableTags().stream()
+            .map(tag -> new MetricAvailableTag(
+                tag.getTag(),
+                tag.getValues().stream().sorted().collect(Collectors.toList())
+            ))
+            .sorted(Comparator.comparing(MetricAvailableTag::tag))
+            .toList();
+        return new MetricDetail(
+            details.getName(),
+            details.getDescription(),
+            details.getBaseUnit(),
+            measurements,
+            availableTags,
+            normalizedSelectedTags
+        );
+    }
+
+    static @Nullable MetricDetail toMetricDetail(String metricName, Collection<Meter> meters, @Nullable List<String> selectedTags) {
+        if (meters.isEmpty()) {
+            return null;
+        }
+
+        Meter.Id meterId = meters.iterator().next().getId();
+        Map<Statistic, Double> aggregatedMeasurements = new LinkedHashMap<>();
+        Map<String, Set<String>> availableTagsByName = new LinkedHashMap<>();
+        for (Meter meter : meters) {
+            mergeMeasurements(aggregatedMeasurements, meter.measure());
+            mergeAvailableTags(availableTagsByName, meter);
+        }
+
+        List<String> normalizedSelectedTags = selectedTags == null ? List.of() : List.copyOf(selectedTags);
+        normalizedSelectedTags.stream()
+            .map(MetricsControlPanel::tagName)
+            .forEach(availableTagsByName::remove);
+
+        List<MetricMeasurement> measurements = aggregatedMeasurements.entrySet().stream()
+            .map(entry -> new MetricMeasurement(entry.getKey().name(), entry.getValue()))
+            .sorted(Comparator.comparing(MetricMeasurement::statistic))
+            .toList();
+        List<MetricAvailableTag> availableTags = availableTagsByName.entrySet().stream()
+            .map(entry -> new MetricAvailableTag(
+                entry.getKey(),
+                entry.getValue().stream().sorted().collect(Collectors.toList())
+            ))
+            .sorted(Comparator.comparing(MetricAvailableTag::tag))
+            .toList();
+
+        return new MetricDetail(
+            metricName,
+            meterId.getDescription(),
+            meterId.getBaseUnit(),
+            measurements,
+            availableTags,
+            normalizedSelectedTags
+        );
+    }
+
+    private static void mergeMeasurements(Map<Statistic, Double> measurements, Iterable<Measurement> source) {
+        for (Measurement measurement : source) {
+            measurements.merge(
+                measurement.getStatistic(),
+                measurement.getValue(),
+                measurement.getStatistic() == Statistic.MAX ? Math::max : Double::sum
+            );
+        }
+    }
+
+    private static void mergeAvailableTags(Map<String, Set<String>> availableTagsByName, Meter meter) {
+        for (io.micrometer.core.instrument.Tag tag : meter.getId().getTags()) {
+            availableTagsByName.computeIfAbsent(tag.getKey(), ignored -> new java.util.LinkedHashSet<>()).add(tag.getValue());
+        }
+    }
+
+    private static String tagName(String tag) {
+        int separatorIndex = tag.indexOf(':');
+        return separatorIndex >= 0 ? tag.substring(0, separatorIndex) : tag;
+    }
+
+    /**
+     * Data used by the dashboard card and detail page.
+     *
+     * @param metricNames all available metric names, ordered alphabetically
+     * @param previewMetricNames compact preview used on the dashboard card
+     * @param initialMetricName initial metric selected by the detail page
+     */
+    @ReflectiveAccess
+    public record Body(List<String> metricNames,
+                       List<String> previewMetricNames,
+                       @Nullable String initialMetricName) { }
+
+    /**
+     * Serialized metric details returned to the detail page.
+     *
+     * @param name metric name
+     * @param description metric description
+     * @param baseUnit metric base unit
+     * @param measurements current samples
+     * @param availableTags remaining available tags
+     * @param selectedTags currently applied tag filters
+     */
+    @ReflectiveAccess
+    @Serdeable
+    public record MetricDetail(String name,
+                               @Nullable String description,
+                               @Nullable String baseUnit,
+                               List<MetricMeasurement> measurements,
+                               List<MetricAvailableTag> availableTags,
+                               List<String> selectedTags) { }
+
+    /**
+     * A single metric sample.
+     *
+     * @param statistic statistic name
+     * @param value current value
+     */
+    @ReflectiveAccess
+    @Serdeable
+    public record MetricMeasurement(String statistic, Double value) { }
+
+    /**
+     * Remaining values that can be used to refine a metric lookup.
+     *
+     * @param tag tag name
+     * @param values allowed values for the tag
+     */
+    @ReflectiveAccess
+    @Serdeable
+    public record MetricAvailableTag(String tag, List<String> values) { }
+}

--- a/control-panel-management/src/main/java/io/micronaut/controlpanel/panels/management/MetricsControlPanelController.java
+++ b/control-panel-management/src/main/java/io/micronaut/controlpanel/panels/management/MetricsControlPanelController.java
@@ -68,7 +68,7 @@ public class MetricsControlPanelController {
         int separatorIndex = tag.indexOf(':');
         if (separatorIndex < 0) {
             throw new UnsatisfiedArgumentException(
-                Argument.of(List.class, "tags"),
+                Argument.of(List.class, "tag", Argument.STRING),
                 "Tags must be in the form key:value"
             );
         }

--- a/control-panel-management/src/main/java/io/micronaut/controlpanel/panels/management/MetricsControlPanelController.java
+++ b/control-panel-management/src/main/java/io/micronaut/controlpanel/panels/management/MetricsControlPanelController.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.management;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micronaut.configuration.metrics.management.endpoint.MetricsEndpoint;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.controlpanel.core.config.ControlPanelModuleConfiguration;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.bind.exceptions.UnsatisfiedArgumentException;
+import io.micronaut.core.type.Argument;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.QueryValue;
+import io.micronaut.scheduling.TaskExecutors;
+import io.micronaut.scheduling.annotation.ExecuteOn;
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+
+/**
+ * Internal helper controller for metric drill-down requests from the control panel detail page.
+ *
+ * @author Micronaut Engineer
+ * @since 2.0.0
+ */
+@Internal
+@Controller("${" + ControlPanelModuleConfiguration.PROPERTY_PATH + ":" + ControlPanelModuleConfiguration.DEFAULT_PATH + "}/metrics")
+@ExecuteOn(TaskExecutors.BLOCKING)
+@Requires(beans = { MetricsEndpoint.class, MetricsControlPanel.class })
+@Requires(property = MetricsControlPanel.ENABLED_PROPERTY, notEquals = StringUtils.FALSE)
+public class MetricsControlPanelController {
+
+    private final MeterRegistry meterRegistry;
+
+    public MetricsControlPanelController(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+    }
+
+    @Get("/details/{metricName}")
+    public HttpResponse<MetricsControlPanel.MetricDetail> detail(String metricName,
+                                                                 @Nullable @QueryValue List<String> tag) {
+        List<Tag> selectedTags = tag == null ? List.of() : tag.stream()
+            .map(MetricsControlPanelController::toTag)
+            .toList();
+        MetricsControlPanel.MetricDetail details =
+            MetricsControlPanel.toMetricDetail(metricName, meterRegistry.find(metricName).tags(selectedTags).meters(), tag);
+        return details == null ? HttpResponse.notFound() : HttpResponse.ok(details);
+    }
+
+    private static Tag toTag(String tag) {
+        int separatorIndex = tag.indexOf(':');
+        if (separatorIndex < 0) {
+            throw new UnsatisfiedArgumentException(
+                Argument.of(List.class, "tags"),
+                "Tags must be in the form key:value"
+            );
+        }
+        return Tag.of(tag.substring(0, separatorIndex), tag.substring(separatorIndex + 1));
+    }
+}

--- a/control-panel-management/src/main/resources/micronaut-control-panel/micronaut-control-panel.properties
+++ b/control-panel-management/src/main/resources/micronaut-control-panel/micronaut-control-panel.properties
@@ -8,6 +8,10 @@ micronaut.control-panel.panels.env.title = Environment Properties
 micronaut.control-panel.panels.env.icon = fa-sliders
 micronaut.control-panel.panels.env.order = 10
 
+micronaut.control-panel.panels.metrics.title = Metrics
+micronaut.control-panel.panels.metrics.icon = fa-chart-line
+micronaut.control-panel.panels.metrics.order = 35
+
 micronaut.control-panel.panels.loggers.title = Loggers
 micronaut.control-panel.panels.loggers.icon = fa-file-lines
 micronaut.control-panel.panels.loggers.order = 40

--- a/control-panel-management/src/main/resources/views/metrics/body.hbs
+++ b/control-panel-management/src/main/resources/views/metrics/body.hbs
@@ -21,6 +21,12 @@
             {{/each}}
         </ul>
 
+        <div class="d-none" id="metrics-dashboard-data" aria-hidden="true">
+            {{#each metricNames }}
+                <span class="metrics-dashboard-name">{{ this }}</span>
+            {{/each}}
+        </div>
+
         <p class="card-text mb-0">
             <small>Showing {{size previewMetricNames}} of {{size metricNames}}. Open details to inspect samples and tags.</small>
         </p>
@@ -29,9 +35,10 @@
             (function() {
                 const input = document.getElementById('metrics-dashboard-search');
                 const preview = document.getElementById('metrics-dashboard-preview');
-                const metricNames = [
-                    {{#each metricNames }}"{{ this }}"{{#unless @last}}, {{/unless}}{{/each}}
-                ];
+                const metricNames = Array.from(document.querySelectorAll('#metrics-dashboard-data .metrics-dashboard-name'))
+                    .map(function(element) {
+                        return element.textContent;
+                    });
 
                 function escapeHtml(value) {
                     return value

--- a/control-panel-management/src/main/resources/views/metrics/body.hbs
+++ b/control-panel-management/src/main/resources/views/metrics/body.hbs
@@ -1,0 +1,69 @@
+{{#with controlPanel.body }}
+    <p class="card-text">
+        <strong>{{badge}}</strong> metrics available.
+    </p>
+
+    {{#if metricNames}}
+        <div class="form-group mb-2">
+            <label class="sr-only" for="metrics-dashboard-search">Search metrics</label>
+            <input type="search"
+                   class="form-control form-control-sm"
+                   id="metrics-dashboard-search"
+                   placeholder="Search metrics"
+                   autocomplete="off">
+        </div>
+
+        <ul class="list-group list-group-flush mb-2" id="metrics-dashboard-preview">
+            {{#each previewMetricNames }}
+                <li class="list-group-item px-0 py-1 border-top-0">
+                    <code>{{ this }}</code>
+                </li>
+            {{/each}}
+        </ul>
+
+        <p class="card-text mb-0">
+            <small>Showing {{size previewMetricNames}} of {{size metricNames}}. Open details to inspect samples and tags.</small>
+        </p>
+
+        <script>
+            (function() {
+                const input = document.getElementById('metrics-dashboard-search');
+                const preview = document.getElementById('metrics-dashboard-preview');
+                const metricNames = [
+                    {{#each metricNames }}"{{ this }}"{{#unless @last}}, {{/unless}}{{/each}}
+                ];
+
+                function escapeHtml(value) {
+                    return value
+                        .replaceAll('&', '&amp;')
+                        .replaceAll('<', '&lt;')
+                        .replaceAll('>', '&gt;')
+                        .replaceAll('"', '&quot;')
+                        .replaceAll("'", '&#39;');
+                }
+
+                function render(query) {
+                    const normalized = query.trim().toLowerCase();
+                    const matches = normalized.length === 0
+                        ? metricNames.slice(0, 5)
+                        : metricNames.filter(name => name.toLowerCase().includes(normalized)).slice(0, 5);
+
+                    if (matches.length === 0) {
+                        preview.innerHTML = '<li class="list-group-item px-0 py-1 border-top-0 text-muted">No matching metrics.</li>';
+                        return;
+                    }
+
+                    preview.innerHTML = matches
+                        .map(name => '<li class="list-group-item px-0 py-1 border-top-0"><code>' + escapeHtml(name) + '</code></li>')
+                        .join('');
+                }
+
+                input.addEventListener('input', function(event) {
+                    render(event.target.value);
+                });
+            })();
+        </script>
+    {{else}}
+        <p class="card-text text-muted mb-0">No Micrometer metrics are currently registered.</p>
+    {{/if}}
+{{/with}}

--- a/control-panel-management/src/main/resources/views/metrics/detail.hbs
+++ b/control-panel-management/src/main/resources/views/metrics/detail.hbs
@@ -1,0 +1,236 @@
+{{#with controlPanel.body }}
+    <style>
+        .metrics-list {
+            max-height: 32rem;
+            overflow-y: auto;
+        }
+
+        .metrics-list .list-group-item code {
+            white-space: normal;
+        }
+
+        .metrics-detail-card {
+            min-height: 24rem;
+        }
+    </style>
+
+    {{#if metricNames}}
+        <div class="row">
+            <div class="col-lg-4 mb-3">
+                <label for="metrics-search"><strong>Search metrics</strong></label>
+                <input type="search"
+                       class="form-control mb-3"
+                       id="metrics-search"
+                       placeholder="Filter metric names"
+                       autocomplete="off">
+
+                <div class="list-group metrics-list" id="metrics-list">
+                    {{#each metricNames }}
+                        <button type="button"
+                                class="list-group-item list-group-item-action{{#if @first}} active{{/if}}"
+                                data-metric-name="{{ this }}">
+                            <code>{{ this }}</code>
+                        </button>
+                    {{/each}}
+                </div>
+            </div>
+
+            <div class="col-lg-8">
+                <div class="card card-light metrics-detail-card">
+                    <div class="card-body">
+                        <div id="metrics-feedback"></div>
+                        <div id="metrics-detail-content" class="mb-3">
+                            <p class="text-muted mb-0">Loading metric details...</p>
+                        </div>
+                        <div id="metrics-filter-controls"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <script>
+            (function() {
+                const list = document.getElementById('metrics-list');
+                const searchInput = document.getElementById('metrics-search');
+                const detailContent = document.getElementById('metrics-detail-content');
+                const filterControls = document.getElementById('metrics-filter-controls');
+                const feedback = document.getElementById('metrics-feedback');
+                const initialMetricName = {{#if initialMetricName}}"{{ initialMetricName }}"{{else}}null{{/if}};
+                let currentMetric = initialMetricName;
+                let currentSelectedTags = [];
+
+                function escapeHtml(value) {
+                    return String(value)
+                        .replaceAll('&', '&amp;')
+                        .replaceAll('<', '&lt;')
+                        .replaceAll('>', '&gt;')
+                        .replaceAll('"', '&quot;')
+                        .replaceAll("'", '&#39;');
+                }
+
+                function setFeedback(message, level) {
+                    if (!message) {
+                        feedback.innerHTML = '';
+                        return;
+                    }
+                    feedback.innerHTML = '<div class="alert alert-' + level + '">' + message + '</div>';
+                }
+
+                function setActiveMetric(metricName) {
+                    list.querySelectorAll('[data-metric-name]').forEach(function(element) {
+                        element.classList.toggle('active', element.dataset.metricName === metricName);
+                    });
+                }
+
+                function renderDetails(detail) {
+                    const description = detail.description
+                        ? '<p class="mb-2">' + escapeHtml(detail.description) + '</p>'
+                        : '<p class="text-muted mb-2">No description is available for this metric.</p>';
+                    const baseUnit = detail.baseUnit
+                        ? '<span class="badge badge-light">' + escapeHtml(detail.baseUnit) + '</span>'
+                        : '<span class="text-muted">None</span>';
+                    const selectedTags = detail.selectedTags || [];
+                    const selectedBadges = selectedTags.length === 0
+                        ? '<span class="text-muted">None</span>'
+                        : selectedTags.map(function(tag) {
+                            return '<span class="badge badge-primary mr-1">' + escapeHtml(tag) + '</span>';
+                        }).join('');
+                    const measurements = detail.measurements.length === 0
+                        ? '<p class="text-muted mb-0">No measurements are available for this metric.</p>'
+                        : '<table class="table table-sm"><thead><tr><th>Statistic</th><th>Value</th></tr></thead><tbody>' +
+                            detail.measurements.map(function(measurement) {
+                                return '<tr><td><code>' + escapeHtml(measurement.statistic) + '</code></td><td>' + escapeHtml(measurement.value) + '</td></tr>';
+                            }).join('') +
+                            '</tbody></table>';
+
+                    detailContent.innerHTML =
+                        '<h4><code>' + escapeHtml(detail.name) + '</code></h4>' +
+                        description +
+                        '<dl class="row">' +
+                        '<dt class="col-sm-3">Base unit</dt><dd class="col-sm-9">' + baseUnit + '</dd>' +
+                        '<dt class="col-sm-3">Selected tags</dt><dd class="col-sm-9">' + selectedBadges + '</dd>' +
+                        '</dl>' +
+                        '<h5>Measurements</h5>' +
+                        measurements;
+
+                    if (detail.availableTags.length === 0 && selectedTags.length === 0) {
+                        filterControls.innerHTML = '';
+                        return;
+                    }
+
+                    const options = detail.availableTags.map(function(tag) {
+                        const values = tag.values.map(function(value) {
+                            return '<option value="' + escapeHtml(value) + '">' + escapeHtml(value) + '</option>';
+                        }).join('');
+                        return '<div class="form-group col-md-6">' +
+                            '<label for="tag-' + escapeHtml(tag.tag) + '">' + escapeHtml(tag.tag) + '</label>' +
+                            '<select class="form-control metric-tag-filter" id="tag-' + escapeHtml(tag.tag) + '" data-tag-name="' + escapeHtml(tag.tag) + '">' +
+                            '<option value="">Any</option>' +
+                            values +
+                            '</select>' +
+                            '</div>';
+                    }).join('');
+
+                    filterControls.innerHTML =
+                        '<hr>' +
+                        '<h5>Filter by tags</h5>' +
+                        '<form id="metrics-filter-form">' +
+                        '<div class="form-row">' + options + '</div>' +
+                        '<div class="d-flex gap-2">' +
+                        '<button type="submit" class="btn btn-primary mr-2">Apply filters</button>' +
+                        '<button type="button" class="btn btn-secondary" id="metrics-clear-filters">Clear filters</button>' +
+                        '</div>' +
+                        '</form>';
+
+                    document.getElementById('metrics-filter-form').addEventListener('submit', function(event) {
+                        event.preventDefault();
+                        const selected = Array.from(document.querySelectorAll('.metric-tag-filter'))
+                            .filter(function(select) {
+                                return select.value;
+                            })
+                            .map(function(select) {
+                                return select.dataset.tagName + ':' + select.value;
+                            });
+                        loadMetric(currentMetric, selected);
+                    });
+
+                    document.getElementById('metrics-clear-filters').addEventListener('click', function() {
+                        loadMetric(currentMetric, []);
+                    });
+                }
+
+                function loadMetric(metricName, selectedTags) {
+                    if (!metricName) {
+                        detailContent.innerHTML = '<p class="text-muted mb-0">Select a metric to inspect its current samples and available tags.</p>';
+                        filterControls.innerHTML = '';
+                        setFeedback('', 'info');
+                        return;
+                    }
+
+                    currentMetric = metricName;
+                    currentSelectedTags = selectedTags || [];
+                    setActiveMetric(metricName);
+                    setFeedback('', 'info');
+                    detailContent.innerHTML = '<p class="text-muted mb-0">Loading metric details...</p>';
+                    filterControls.innerHTML = '';
+
+                    const params = new URLSearchParams();
+                    currentSelectedTags.forEach(function(tag) {
+                        params.append('tag', tag);
+                    });
+                    const queryString = params.toString();
+                    const url = '{{ext.controlPanelPath}}/metrics/details/' + encodeURIComponent(metricName) + (queryString ? '?' + queryString : '');
+
+                    fetch(url, {
+                        headers: {
+                            'X-Requested-With': 'XMLHttpRequest'
+                        }
+                    })
+                        .then(function(response) {
+                            if (response.status === 404) {
+                                setFeedback('No metric details are available for the selected metric and tag combination.', 'warning');
+                                detailContent.innerHTML = '<p class="text-muted mb-0">Try clearing filters or selecting a different metric.</p>';
+                                return null;
+                            }
+                            if (!response.ok) {
+                                throw new Error('Unable to load metric details.');
+                            }
+                            return response.json();
+                        })
+                        .then(function(detail) {
+                            if (!detail) {
+                                return;
+                            }
+                            renderDetails(detail);
+                        })
+                        .catch(function() {
+                            setFeedback('Metric details could not be loaded right now.', 'danger');
+                            detailContent.innerHTML = '<p class="text-muted mb-0">Retry the request or select a different metric.</p>';
+                        });
+                }
+
+                searchInput.addEventListener('input', function(event) {
+                    const query = event.target.value.trim().toLowerCase();
+                    list.querySelectorAll('[data-metric-name]').forEach(function(element) {
+                        const matches = element.dataset.metricName.toLowerCase().includes(query);
+                        element.classList.toggle('d-none', !matches);
+                    });
+                });
+
+                list.addEventListener('click', function(event) {
+                    const button = event.target.closest('[data-metric-name]');
+                    if (!button) {
+                        return;
+                    }
+                    loadMetric(button.dataset.metricName, []);
+                });
+
+                loadMetric(initialMetricName, []);
+            })();
+        </script>
+    {{else}}
+        <div class="alert alert-info mb-0">
+            No Micrometer metrics are currently registered.
+        </div>
+    {{/if}}
+{{/with}}

--- a/control-panel-management/src/main/resources/views/metrics/detail.hbs
+++ b/control-panel-management/src/main/resources/views/metrics/detail.hbs
@@ -27,8 +27,7 @@
                 <div class="list-group metrics-list" id="metrics-list">
                     {{#each metricNames }}
                         <button type="button"
-                                class="list-group-item list-group-item-action{{#if @first}} active{{/if}}"
-                                data-metric-name="{{ this }}">
+                                class="list-group-item list-group-item-action{{#if @first}} active{{/if}}">
                             <code>{{ this }}</code>
                         </button>
                     {{/each}}
@@ -55,7 +54,8 @@
                 const detailContent = document.getElementById('metrics-detail-content');
                 const filterControls = document.getElementById('metrics-filter-controls');
                 const feedback = document.getElementById('metrics-feedback');
-                const initialMetricName = {{#if initialMetricName}}"{{ initialMetricName }}"{{else}}null{{/if}};
+                const initialMetricButton = list.querySelector('.list-group-item.active');
+                const initialMetricName = initialMetricButton ? metricNameFromElement(initialMetricButton) : null;
                 let currentMetric = initialMetricName;
                 let currentSelectedTags = [];
 
@@ -68,6 +68,11 @@
                         .replaceAll("'", '&#39;');
                 }
 
+                function metricNameFromElement(element) {
+                    const code = element.querySelector('code');
+                    return code ? code.textContent : element.textContent.trim();
+                }
+
                 function setFeedback(message, level) {
                     if (!message) {
                         feedback.innerHTML = '';
@@ -77,8 +82,8 @@
                 }
 
                 function setActiveMetric(metricName) {
-                    list.querySelectorAll('[data-metric-name]').forEach(function(element) {
-                        element.classList.toggle('active', element.dataset.metricName === metricName);
+                    list.querySelectorAll('.list-group-item').forEach(function(element) {
+                        element.classList.toggle('active', metricNameFromElement(element) === metricName);
                     });
                 }
 
@@ -211,18 +216,18 @@
 
                 searchInput.addEventListener('input', function(event) {
                     const query = event.target.value.trim().toLowerCase();
-                    list.querySelectorAll('[data-metric-name]').forEach(function(element) {
-                        const matches = element.dataset.metricName.toLowerCase().includes(query);
+                    list.querySelectorAll('.list-group-item').forEach(function(element) {
+                        const matches = metricNameFromElement(element).toLowerCase().includes(query);
                         element.classList.toggle('d-none', !matches);
                     });
                 });
 
                 list.addEventListener('click', function(event) {
-                    const button = event.target.closest('[data-metric-name]');
+                    const button = event.target.closest('.list-group-item');
                     if (!button) {
                         return;
                     }
-                    loadMetric(button.dataset.metricName, []);
+                    loadMetric(metricNameFromElement(button), []);
                 });
 
                 loadMetric(initialMetricName, []);

--- a/control-panel-management/src/test/java/io/micronaut/controlpanel/panels/management/MetricsControlPanelConfigurationTest.java
+++ b/control-panel-management/src/test/java/io/micronaut/controlpanel/panels/management/MetricsControlPanelConfigurationTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.management;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.controlpanel.core.config.ControlPanelConfiguration;
+import io.micronaut.inject.qualifiers.Qualifiers;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MetricsControlPanelConfigurationTest {
+
+    @Test
+    void itRequiresTheMetricsEndpoint() {
+        try (ApplicationContext ctx = ApplicationContext.run(java.util.Map.of(
+            "endpoints.metrics.enabled", true,
+            "endpoints.metrics.sensitive", false
+        ))) {
+            assertTrue(ctx.containsBean(MetricsControlPanel.class));
+            assertTrue(ctx.containsBean(MetricsControlPanelController.class));
+        }
+    }
+
+    @Test
+    void itCanBeDisabled() {
+        try (ApplicationContext ctx = ApplicationContext.run(java.util.Map.of(
+            MetricsControlPanel.ENABLED_PROPERTY, false,
+            "endpoints.metrics.enabled", true,
+            "endpoints.metrics.sensitive", false
+        ))) {
+            ControlPanelConfiguration cfg = ctx.getBean(ControlPanelConfiguration.class, Qualifiers.byName(MetricsControlPanel.NAME));
+            assertFalse(cfg.isEnabled());
+            assertFalse(ctx.containsBean(MetricsControlPanel.class));
+            assertFalse(ctx.containsBean(MetricsControlPanelController.class));
+        }
+    }
+}

--- a/control-panel-management/src/test/java/io/micronaut/controlpanel/panels/management/MetricsControlPanelControllerTest.java
+++ b/control-panel-management/src/test/java/io/micronaut/controlpanel/panels/management/MetricsControlPanelControllerTest.java
@@ -17,12 +17,14 @@ package io.micronaut.controlpanel.panels.management;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micronaut.core.bind.exceptions.UnsatisfiedArgumentException;
 import io.micronaut.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class MetricsControlPanelControllerTest {
 
@@ -100,6 +102,19 @@ class MetricsControlPanelControllerTest {
         var response = controller.detail("unknown.metric", null);
 
         assertEquals(HttpStatus.NOT_FOUND, response.status());
+    }
+
+    @Test
+    void itReportsInvalidTagsAgainstTheTagQueryArgument() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        MetricsControlPanelController controller = new MetricsControlPanelController(registry);
+
+        UnsatisfiedArgumentException exception = assertThrows(
+            UnsatisfiedArgumentException.class,
+            () -> controller.detail("example.orders.processed", java.util.List.of("invalid-tag"))
+        );
+
+        assertEquals("tag", exception.getArgument().getName());
     }
 
     @Test

--- a/control-panel-management/src/test/java/io/micronaut/controlpanel/panels/management/MetricsControlPanelControllerTest.java
+++ b/control-panel-management/src/test/java/io/micronaut/controlpanel/panels/management/MetricsControlPanelControllerTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.management;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micronaut.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class MetricsControlPanelControllerTest {
+
+    @Test
+    void itReturnsKnownMetricDetails() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        Counter.builder("example.orders.processed")
+            .description("Processed example orders")
+            .baseUnit("orders")
+            .tag("channel", "web")
+            .tag("status", "success")
+            .register(registry)
+            .increment(4);
+        Counter.builder("example.orders.processed")
+            .description("Processed example orders")
+            .baseUnit("orders")
+            .tag("channel", "batch")
+            .tag("status", "failure")
+            .register(registry)
+            .increment();
+
+        MetricsControlPanelController controller = new MetricsControlPanelController(registry);
+
+        var response = controller.detail("example.orders.processed", null);
+
+        assertEquals(HttpStatus.OK, response.status());
+        assertNotNull(response.body());
+        assertEquals("example.orders.processed", response.body().name());
+        assertEquals("Processed example orders", response.body().description());
+        assertEquals("orders", response.body().baseUnit());
+        assertIterableEquals(java.util.List.of(), response.body().selectedTags());
+        assertEquals(1, response.body().measurements().size());
+        assertEquals("COUNT", response.body().measurements().get(0).statistic());
+        assertEquals(2, response.body().availableTags().size());
+        assertEquals("channel", response.body().availableTags().get(0).tag());
+        assertIterableEquals(java.util.List.of("batch", "web"), response.body().availableTags().get(0).values());
+    }
+
+    @Test
+    void itAppliesTagFilters() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        Counter.builder("example.orders.processed")
+            .description("Processed example orders")
+            .baseUnit("orders")
+            .tag("channel", "web")
+            .tag("status", "success")
+            .register(registry)
+            .increment(4);
+        Counter.builder("example.orders.processed")
+            .description("Processed example orders")
+            .baseUnit("orders")
+            .tag("channel", "batch")
+            .tag("status", "failure")
+            .register(registry)
+            .increment();
+
+        MetricsControlPanelController controller = new MetricsControlPanelController(registry);
+
+        var response = controller.detail("example.orders.processed", java.util.List.of("channel:web"));
+
+        assertEquals(HttpStatus.OK, response.status());
+        assertNotNull(response.body());
+        assertIterableEquals(java.util.List.of("channel:web"), response.body().selectedTags());
+        assertEquals(1, response.body().availableTags().size());
+        assertEquals("status", response.body().availableTags().get(0).tag());
+        assertIterableEquals(java.util.List.of("success"), response.body().availableTags().get(0).values());
+        assertEquals(4d, response.body().measurements().get(0).value());
+    }
+
+    @Test
+    void itReturnsNotFoundForUnknownMetrics() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        MetricsControlPanelController controller = new MetricsControlPanelController(registry);
+
+        var response = controller.detail("unknown.metric", null);
+
+        assertEquals(HttpStatus.NOT_FOUND, response.status());
+    }
+
+    @Test
+    void itAppliesTagFiltersWithColonSeparatedValues() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        Counter.builder("example.orders.processed")
+            .description("Processed example orders")
+            .baseUnit("orders")
+            .tag("region", "us:east")
+            .tag("status", "success")
+            .register(registry)
+            .increment(3);
+        Counter.builder("example.orders.processed")
+            .description("Processed example orders")
+            .baseUnit("orders")
+            .tag("region", "eu:west")
+            .tag("status", "success")
+            .register(registry)
+            .increment();
+
+        MetricsControlPanelController controller = new MetricsControlPanelController(registry);
+
+        var response = controller.detail("example.orders.processed", java.util.List.of("region:us:east"));
+
+        assertEquals(HttpStatus.OK, response.status());
+        assertNotNull(response.body());
+        assertIterableEquals(java.util.List.of("region:us:east"), response.body().selectedTags());
+        assertEquals(1, response.body().availableTags().size());
+        assertEquals("status", response.body().availableTags().get(0).tag());
+        assertIterableEquals(java.util.List.of("success"), response.body().availableTags().get(0).values());
+        assertEquals(3d, response.body().measurements().get(0).value());
+    }
+}

--- a/control-panel-management/src/test/java/io/micronaut/controlpanel/panels/management/MetricsControlPanelTest.java
+++ b/control-panel-management/src/test/java/io/micronaut/controlpanel/panels/management/MetricsControlPanelTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.management;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micronaut.configuration.metrics.management.endpoint.MetricsEndpoint;
+import io.micronaut.controlpanel.core.config.ControlPanelConfiguration;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class MetricsControlPanelTest {
+
+    @Test
+    void itBuildsAnOrderedPreviewAndBadge() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        Counter.builder("example.orders.processed")
+            .description("Processed example orders")
+            .baseUnit("orders")
+            .tag("channel", "web")
+            .register(registry)
+            .increment(2);
+        Counter.builder("http.server.requests")
+            .description("HTTP server requests")
+            .tag("method", "GET")
+            .register(registry)
+            .increment();
+
+        MetricsControlPanel panel = new MetricsControlPanel(
+            new MetricsEndpoint(registry, new javax.sql.DataSource[0]),
+            configuration()
+        );
+
+        MetricsControlPanel.Body body = panel.getBody();
+
+        assertEquals("Metrics", panel.getTitle());
+        assertEquals("fa-chart-line", panel.getIcon());
+        assertEquals(35, panel.getOrder());
+        assertEquals("2", panel.getBadge());
+        assertIterableEquals(
+            java.util.List.of("example.orders.processed", "http.server.requests"),
+            body.metricNames()
+        );
+        assertIterableEquals(body.metricNames(), body.previewMetricNames());
+        assertEquals("example.orders.processed", body.initialMetricName());
+    }
+
+    @Test
+    void itHandlesAnEmptyRegistry() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        MetricsControlPanel panel = new MetricsControlPanel(
+            new MetricsEndpoint(registry, new javax.sql.DataSource[0]),
+            configuration()
+        );
+
+        MetricsControlPanel.Body body = panel.getBody();
+
+        assertEquals("0", panel.getBadge());
+        assertIterableEquals(java.util.List.of(), body.metricNames());
+        assertIterableEquals(java.util.List.of(), body.previewMetricNames());
+        assertNull(body.initialMetricName());
+    }
+
+    private static ControlPanelConfiguration configuration() {
+        ControlPanelConfiguration configuration = new ControlPanelConfiguration(MetricsControlPanel.NAME);
+        configuration.setTitle("Metrics");
+        configuration.setIcon("fa-chart-line");
+        configuration.setOrder(35);
+        return configuration;
+    }
+}

--- a/control-panel-ui/src/test/java/io/micronaut/controlpanel/ui/ControlPanelControllerTest.java
+++ b/control-panel-ui/src/test/java/io/micronaut/controlpanel/ui/ControlPanelControllerTest.java
@@ -40,7 +40,7 @@ class ControlPanelControllerTest {
         assertEquals(java.util.Set.of("test"), model.activeEnvironments());
         assertEquals(Model.ContentView.INDEX, model.contentView());
         assertEquals(ControlPanel.Category.MAIN, model.ext().get("currentCategory"));
-        assertEquals(4, ((java.util.Collection<?>) model.ext().get("controlPanels")).size());
+        assertEquals(5, ((java.util.Collection<?>) model.ext().get("controlPanels")).size());
     }
 
     @Test
@@ -52,7 +52,7 @@ class ControlPanelControllerTest {
         assertEquals(java.util.Set.of("test"), model.activeEnvironments());
         assertEquals(Model.ContentView.INDEX, model.contentView());
         assertEquals(categoryId, ((ControlPanel.Category) model.ext().get("currentCategory")).id());
-        assertEquals(4, ((java.util.Collection<?>) model.ext().get("controlPanels")).size());
+        assertEquals(5, ((java.util.Collection<?>) model.ext().get("controlPanels")).size());
 
         var model2 = (Model) controller.byCategory("application").body().getModel().get();
         assertEquals(1, ((java.util.Collection<?>) model2.ext().get("controlPanels")).size());
@@ -76,6 +76,9 @@ class ControlPanelControllerTest {
 
         var modelHealth = (Model) controller.detail("health").body().getModel().get();
         assertEquals(ControlPanel.Category.MAIN.id(), ((ControlPanel.Category) modelHealth.ext().get("currentCategory")).id());
+
+        var modelMetrics = (Model) controller.detail("metrics").body().getModel().get();
+        assertEquals(ControlPanel.Category.MAIN.id(), ((ControlPanel.Category) modelMetrics.ext().get("currentCategory")).id());
 
         var modelTest = (Model) controller.detail("test").body().getModel().get();
         assertEquals("application", ((ControlPanel.Category) modelTest.ext().get("currentCategory")).id());

--- a/control-panel-ui/src/test/java/io/micronaut/controlpanel/ui/handlebars/HandlebarsHelperRegistrarTest.java
+++ b/control-panel-ui/src/test/java/io/micronaut/controlpanel/ui/handlebars/HandlebarsHelperRegistrarTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.Locale;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -143,5 +144,43 @@ class HandlebarsHelperRegistrarTest {
         assertEquals("is map\n", result);
         result = template.apply(java.util.Map.of("myParam", "something else"));
         assertEquals("is not map\n", result);
+    }
+
+    @Test
+    void metricsTemplatesAvoidInlineJavaScriptInterpolationForMetricNames() throws Exception {
+        Handlebars templateHandlebars = configuredHandlebars(new Handlebars());
+        String metricName = "metric\"with\\slash";
+        Map<String, Object> context = Map.of(
+            "controlPanel", Map.of(
+                "badge", "1",
+                "body", Map.of(
+                    "metricNames", java.util.List.of(metricName),
+                    "previewMetricNames", java.util.List.of(metricName),
+                    "initialMetricName", metricName
+                )
+            ),
+            "ext", Map.of("controlPanelPath", "/control-panel")
+        );
+
+        String dashboardHtml = templateHandlebars.compile("views/metrics/body").apply(context);
+        assertTrue(dashboardHtml.contains("id=\"metrics-dashboard-data\""));
+        assertTrue(dashboardHtml.contains("class=\"metrics-dashboard-name\""));
+        assertTrue(dashboardHtml.contains("<code>metric&quot;with\\slash</code>"));
+        assertFalse(dashboardHtml.contains("const metricNames = ["));
+
+        String detailHtml = templateHandlebars.compile("views/metrics/detail").apply(context);
+        assertTrue(detailHtml.contains("const initialMetricButton = list.querySelector('.list-group-item.active');"));
+        assertTrue(detailHtml.contains("function metricNameFromElement(element) {"));
+        assertTrue(detailHtml.contains("<code>metric&quot;with\\slash</code>"));
+        assertFalse(detailHtml.contains("const initialMetricName = \""));
+        assertFalse(detailHtml.contains("data-metric-name="));
+    }
+
+    private Handlebars configuredHandlebars(Handlebars target) {
+        @SuppressWarnings("unchecked")
+        BeanCreatedEvent<Handlebars> event = (BeanCreatedEvent<Handlebars>) Mockito.mock(BeanCreatedEvent.class);
+        Mockito.when(event.getBean()).thenReturn(target);
+        registrar.onCreated(event);
+        return target;
     }
 }

--- a/doc-examples/example-java/build.gradle.kts
+++ b/doc-examples/example-java/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
     runtimeOnly(projects.micronautControlPanelUi)
     implementation(projects.micronautControlPanelManagement)
     implementation(mn.micronaut.management)
+    implementation(mnMicrometer.micronaut.micrometer.core)
 
     // Object Storage
     implementation(projects.micronautControlPanelObjectStorage)

--- a/doc-examples/example-java/src/main/java/example/ExampleMetricsPublisher.java
+++ b/doc-examples/example-java/src/main/java/example/ExampleMetricsPublisher.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.event.StartupEvent;
+import io.micronaut.runtime.event.annotation.EventListener;
+import jakarta.inject.Singleton;
+
+/**
+ * Registers a small tagged metric set so the example app always exposes meaningful metrics in the control panel.
+ */
+@Singleton
+@Requires(beans = MeterRegistry.class)
+class ExampleMetricsPublisher {
+
+    private final MeterRegistry meterRegistry;
+
+    ExampleMetricsPublisher(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+    }
+
+    @EventListener
+    void onStartup(StartupEvent event) {
+        Counter.builder("example.orders.processed")
+            .description("Processed example orders")
+            .baseUnit("orders")
+            .tag("channel", "web")
+            .tag("status", "success")
+            .register(meterRegistry)
+            .increment(4);
+
+        Counter.builder("example.orders.processed")
+            .description("Processed example orders")
+            .baseUnit("orders")
+            .tag("channel", "batch")
+            .tag("status", "failure")
+            .register(meterRegistry)
+            .increment();
+    }
+}

--- a/doc-examples/example-java/src/test/java/example/e2e/ControlPanelE2ETest.java
+++ b/doc-examples/example-java/src/test/java/example/e2e/ControlPanelE2ETest.java
@@ -32,6 +32,7 @@ class ControlPanelE2ETest extends AbstractE2ETest {
         assertThat(body).containsText("Application Health");
         assertThat(body).containsText("Environment Properties");
         assertThat(body).containsText("HTTP Routes");
+        assertThat(body).containsText("Metrics");
         assertThat(body).containsText("Loggers");
 
         //Category links
@@ -131,6 +132,27 @@ class ControlPanelE2ETest extends AbstractE2ETest {
         page.getByRole(AriaRole.CELL, new Page.GetByRoleOptions().setName(nameRegex("Reconfigure"))).first().getByRole(AriaRole.BUTTON).click();
         page.getByLabel("Level:").selectOption("INFO");
         button(page, "Submit").click();
+    }
+
+    @Test
+    void testMetrics(Page page) {
+        page.navigate(baseUrl());
+        controlPanelDetails(page, "Metrics").click();
+
+        assertThat(body(page)).containsText("example.orders.processed");
+        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName(nameRegex("example.orders.processed"))).click();
+
+        assertThat(body(page)).containsText("Processed example orders");
+        assertThat(body(page)).containsText("COUNT");
+        assertThat(body(page)).containsText("channel");
+        assertThat(body(page)).containsText("status");
+
+        page.getByLabel("channel").selectOption("web");
+        button(page, "Apply filters").click();
+
+        assertThat(body(page)).containsText("channel:web");
+        assertThat(body(page)).containsText("COUNT");
+        assertThat(body(page)).containsText("4");
     }
 
     @Test
@@ -255,7 +277,7 @@ class ControlPanelE2ETest extends AbstractE2ETest {
     public static class HeadlessBrowserOptions implements OptionsFactory {
         @Override
         public Options getOptions() {
-            if (System.getenv("CI") == null) {
+            if (System.getenv("CI") == null && System.getenv("DISPLAY") != null) {
                 return new Options().setHeadless(false);
             } else {
                 return new Options();

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ micronaut-reactor = "4.0.0-M1"
 micronaut-serde = "3.0.0-M6"
 micronaut-object-storage = "3.0.0-M2"
 micronaut-cache = "6.0.0-M2"
+micronaut-micrometer = "6.0.1-M1"
 micronaut-sql = "7.0.0-M7"
 micronaut-data = "5.0.0-M5"
 micronaut-testresources = "4.0.0-M1"
@@ -50,6 +51,7 @@ micronaut-reactor = { module = 'io.micronaut.reactor:micronaut-reactor-bom', ver
 micronaut-serde = { module = "io.micronaut.serde:micronaut-serde-bom", version.ref = "micronaut-serde" }
 micronaut-object-storage = { module = "io.micronaut.objectstorage:micronaut-object-storage-bom", version.ref = "micronaut-object-storage" }
 micronaut-cache = { module = "io.micronaut.cache:micronaut-cache-bom", version.ref = "micronaut-cache" }
+micronaut-micrometer = { module = "io.micronaut.micrometer:micronaut-micrometer-bom", version.ref = "micronaut-micrometer" }
 micronaut-sql = { module = "io.micronaut.sql:micronaut-sql-bom", version.ref = "micronaut-sql" }
 micronaut-data = { module = "io.micronaut.data:micronaut-data-bom", version.ref = "micronaut-data" }
 micronaut-testresources = { module = 'io.micronaut.testresources:micronaut-test-resources-bom', version.ref = "micronaut-testresources" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -37,6 +37,7 @@ configure<MicronautBuildSettingsExtension> {
     importMicronautCatalog("micronaut-cache")
     importMicronautCatalog("micronaut-sql")
     importMicronautCatalog("micronaut-data")
+    importMicronautCatalog("micronaut-micrometer")
     importMicronautCatalog("micronaut-testresources")
     importMicronautCatalog("micronaut-openapi")
     importMicronautCatalog("micronaut-kafka")

--- a/src/main/docs/guide/controlPanels/management.adoc
+++ b/src/main/docs/guide/controlPanels/management.adoc
@@ -7,10 +7,15 @@ https://docs.micronaut.io/latest/guide/#management[Management] module:
 
 dependency:io.micronaut.:micronaut-management[scope=runtimeOnly]
 
+For the Metrics panel, you also need Micrometer support on the classpath:
+
+dependency:io.micronaut.micrometer:micronaut-micrometer-core[scope=runtimeOnly]
+
 The following panels are available:
 
 * `health`: Application Health
 * `env`: Environment Properties
+* `metrics`: Metrics
 * `beans`: Bean Definitions
 * `loggers`: Logging Configuration
 
@@ -63,6 +68,29 @@ micronaut:
 
 This will show all values apart from those that contain the words `password`, `credential`, `certificate`, `key`,
 `secret` or `token` anywhere in their name.
+
+=== Metrics
+
+This panel provides a lightweight, read-only Micrometer inspector for development use. It relies on the
+https://micronaut-projects.github.io/micronaut-micrometer/latest/guide/#metricsEndpoint[Metrics Endpoint] to list
+metric names and fetch the current description, base unit, measurements, and available tags for a selected metric.
+
+The panel only appears when Micrometer support is on the classpath and the endpoint bean is present. It does not add
+historical charts or mutation/reset operations, so it complements rather than replaces a full observability stack such
+as Grafana.
+
+To make the panel available in environments where the control panel is enabled, add the Micrometer dependency and
+enable the endpoint if your environment does not already expose it:
+
+IMPORTANT: Make sure this is done in an environment-specific configuration file, for example, `application-dev.yml`.
+
+.Configuring the Metrics Endpoint
+[configuration]
+----
+endpoints:
+  metrics:
+    enabled: true
+----
 
 === Bean Definitions
 

--- a/src/main/docs/guide/quickStart.adoc
+++ b/src/main/docs/guide/quickStart.adoc
@@ -7,6 +7,10 @@ Then, add the control panel modules that you want. For example, if you already h
 
 dependency:io.micronaut.controlpanel:micronaut-control-panel-management[scope=developmentOnly]
 
+If you want to inspect Micrometer metrics in the management module, also add:
+
+dependency:io.micronaut.micrometer:micronaut-micrometer-core[scope=runtimeOnly]
+
 By default, the Control Panel is only enabled in the `dev` or `test` environments. You can change this and other settings
 in your configuration file:
 


### PR DESCRIPTION
Fixes #10

## Summary
- add a read-only Metrics management panel backed by Micrometer
- add templates, tests, example wiring, and docs for the metrics inspector
- fix metric tag filtering when tag values contain `:` and add regression coverage

## Verification
- `./gradlew :micronaut-control-panel-management:test --tests '*MetricsControlPanel*'`
- `./gradlew :micronaut-control-panel-ui:test --tests 'io.micronaut.controlpanel.ui.ControlPanelControllerTest'`
- `CI=1 ./gradlew :micronaut-doc-examples:micronaut-example-java:test --tests 'example.e2e.ControlPanelE2ETest.testMetrics'`

---
###### ✨ This message was AI-generated using gpt-5.4
