### PR TITLE
Include publication metadata in release artifact ZIP

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,19 +63,24 @@ jobs:
       - name: Generate subject
         id: hash
         run: |
-          # Find the artifact JAR and POM files in the local repository.
-          ARTIFACTS=$(find build/repo/${{ steps.publish.outputs.group }}/*/${{ steps.publish.outputs.version }}/* \
-              -type f \( \( -iname "*.jar" -not -iname "*-javadoc.jar" -not -iname "*-sources.jar" \) -or -iname "*.pom" \))
-          # Compute the hashes for the artifacts.
+          # Find all files in the local publication repository.
+          mapfile -d '' ARTIFACTS < <(find build/repo/${{ steps.publish.outputs.group }}/*/${{ steps.publish.outputs.version }}/* \
+              -type f -print0 | sort -z)
+          if [[ ${#ARTIFACTS[@]} -eq 0 ]]; then
+            echo "No publication artifacts found" >&2
+            exit 1
+          fi
+          # Compute the hashes for the publication artifacts.
+          HASHES=$(sha256sum "${ARTIFACTS[@]}" | base64 -w0)
           # Set the hash as job output for debugging.
-          echo "artifacts-sha256=$(sha256sum $ARTIFACTS | base64 -w0)" >> "$GITHUB_OUTPUT"
+          echo "artifacts-sha256=$HASHES" >> "$GITHUB_OUTPUT"
           # Store the hash in a file, which is uploaded as a workflow artifact.
-          sha256sum $ARTIFACTS | base64 -w0 > artifacts-sha256
+          echo -n "$HASHES" > artifacts-sha256
       - name: Upload build artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: gradle-build-outputs
-          path: build/repo/${{ steps.publish.outputs.group }}/*/${{ steps.publish.outputs.version }}/*
+          path: build/repo
           retention-days: 5
       - name: Upload artifacts-sha256
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -166,8 +171,8 @@ jobs:
       - name: Create artifacts archive
         shell: bash
         run: |
-          find build/repo -type f \( \( -iname "*.jar" -not -iname "*-javadoc.jar" -not \
-              -iname "*-sources.jar" \) -or -iname "*.pom" \) | xargs zip artifacts.zip
+          cd build/repo
+          find . -type f -printf '%P\n' | sort | zip -q -@ ../../artifacts.zip
       - name: Upload assets
         # Upload the artifacts to the existing release. Note that the SLSA provenance will
         # attest to each artifact file and not the aggregated ZIP file.


### PR DESCRIPTION
## Summary

- include the full local publication repository in the release `artifacts.zip`
- preserve Maven repository-relative paths by uploading `build/repo` as the artifact root before the release job downloads it
- hash the full publication file set for SLSA subjects instead of only the main JAR/POM subset

## Context

This is the module-level trial requested from micronaut-projects/micronaut-project-template#691 before syncing the workflow change broadly. It supports validating the milestone release behavior for micronaut-projects/micronaut-build#771.

## Verification

- `git diff --check`
- bash parse checks for the changed `Generate subject` and `Create artifacts archive` scripts after substituting fixture values
- focused local fixture modeled upload/download/archive flow and confirmed 12 representative files were zipped under `io/micronaut/controlpanel/micronaut-control-panel/2.0.0-M1/`, including signatures, checksums, module metadata, sources, javadocs, POM, and main JAR files

---
###### ✨ This message was AI-generated using gpt-5.5