### PR TITLE
Align release artifact provenance subjects

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,14 +64,15 @@ jobs:
         id: hash
         run: |
           # Find all files in the local publication repository.
-          mapfile -d '' ARTIFACTS < <(find build/repo/${{ steps.publish.outputs.group }}/*/${{ steps.publish.outputs.version }}/* \
-              -type f -print0 | sort -z)
+          cd build/repo
+          mapfile -d '' ARTIFACTS < <(find . -type f -printf '%P\0' | sort -z)
           if [[ ${#ARTIFACTS[@]} -eq 0 ]]; then
             echo "No publication artifacts found" >&2
             exit 1
           fi
           # Compute the hashes for the publication artifacts.
-          HASHES=$(sha256sum "${ARTIFACTS[@]}" | base64 -w0)
+          HASHES=$(sha256sum -- "${ARTIFACTS[@]}" | base64 -w0)
+          cd ../..
           # Set the hash as job output for debugging.
           echo "artifacts-sha256=$HASHES" >> "$GITHUB_OUTPUT"
           # Store the hash in a file, which is uploaded as a workflow artifact.


### PR DESCRIPTION
## Summary

- align Control Panel release provenance subject generation with the final artifact ZIP file set
- hash every regular file under `build/repo` using repository-relative paths, including Maven metadata outside version directories
- keep `artifacts.zip` and the decoded SLSA subject filenames in the same sorted path space

## Context

Follow-up to #528 for the module-level trial requested from micronaut-projects/micronaut-project-template#691. The previous Control Panel change zipped the full `build/repo` contents, but still generated SLSA subjects from only `build/repo/${group}/*/${version}/*`. That left files such as `io/micronaut/controlpanel/micronaut-control-panel/maven-metadata.xml` inside `artifacts.zip` without subject coverage.

Related to micronaut-projects/micronaut-build#771.

The already-triggered `v2.0.0-M1` release run was started from the pre-fix merge commit, so it should not be treated as proof of the fixed provenance behavior. After this PR merges, the milestone release trial should be rerun from a tag or release that includes this commit.

Release project note: QA identified `5.1.0 Release` as the best-fit project because the synced issue is already on that board, with an ambiguity note that maintainers may revisit active `5.0.0` boards if they schedule this workflow-template change with that release train.

## Verification

- `git diff --check`
- `.github/workflows/release.yml` parsed with Python/PyYAML
- focused local fixture confirmed decoded `artifacts-sha256` filenames exactly match `zipinfo -1 artifacts.zip`, including `maven-metadata.xml` and `maven-metadata.xml.sha256` outside the version directory
- `actionlint` is unavailable in this environment

---
###### ✨ This message was AI-generated using gpt-5.5