### PR TITLE
Enable authorized control panel access by default

### DIFF
--- a/control-panel-core/src/main/java/io/micronaut/controlpanel/core/security/ControlPanelSecurityConfiguration.java
+++ b/control-panel-core/src/main/java/io/micronaut/controlpanel/core/security/ControlPanelSecurityConfiguration.java
@@ -22,6 +22,8 @@ import io.micronaut.core.bind.annotation.Bindable;
 /**
  * Security configuration for the control panel HTTP surface.
  *
+ * @param access the configured access mode
+ * @param role role required when authorized access is enabled
  * @author Álvaro Sánchez-Mariscal
  * @since 2.0.0
  */
@@ -32,19 +34,47 @@ public record ControlPanelSecurityConfiguration(
      *
      * @return the configured access mode
      */
-    @Bindable(defaultValue = "ANONYMOUS")
-    Access access
+    @Bindable(defaultValue = DEFAULT_ACCESS)
+    Access access,
+
+    /**
+     * Role required when {@link Access#AUTHORIZED} mode is active.
+     *
+     * @return the configured role
+     */
+    @Bindable(defaultValue = DEFAULT_ROLE)
+    String role
 ) {
 
     public static final String PREFIX = ControlPanelModuleConfiguration.PREFIX + ".security";
     public static final String PROPERTY_ACCESS = PREFIX + ".access";
-    public static final String DEFAULT_ACCESS = "ANONYMOUS";
+    public static final String PROPERTY_ROLE = PREFIX + ".role";
+    public static final String DEFAULT_ACCESS = "AUTHORIZED";
+    public static final String DEFAULT_ROLE = "ROLE_CONTROL_PANEL";
+
+    /**
+     * Creates configuration with the default control panel role.
+     *
+     * @param access the configured access mode
+     */
+    public ControlPanelSecurityConfiguration(Access access) {
+        this(access, DEFAULT_ROLE);
+    }
+
+    public ControlPanelSecurityConfiguration {
+        if (access == Access.AUTHORIZED && role.isBlank()) {
+            throw new IllegalArgumentException(
+                "Control panel security role cannot be blank when authorized access is enabled"
+            );
+        }
+    }
 
     /**
      * Available access modes for the control panel HTTP surface.
      */
     enum Access {
         ANONYMOUS,
-        AUTHENTICATED
+        AUTHENTICATED,
+        AUTHORIZED
     }
 }

--- a/control-panel-core/src/main/java/io/micronaut/controlpanel/core/security/ControlPanelSecurityRule.java
+++ b/control-panel-core/src/main/java/io/micronaut/controlpanel/core/security/ControlPanelSecurityRule.java
@@ -50,12 +50,14 @@ public final class ControlPanelSecurityRule implements SecurityRule<HttpRequest<
     static final int ORDER = ConfigurationInterceptUrlMapRule.ORDER + 50;
 
     private final ControlPanelSecurityConfiguration.Access access;
+    private final String role;
     private final List<String> protectedRoutePrefixes;
 
     public ControlPanelSecurityRule(ControlPanelSecurityConfiguration securityConfiguration,
                                     ControlPanelModuleConfiguration moduleConfiguration,
                                     HttpServerConfiguration serverConfiguration) {
         this.access = securityConfiguration.access();
+        this.role = securityConfiguration.role();
         String applicationPath = Optional.ofNullable(serverConfiguration.getContextPath()).orElse("");
         String controlPanelPath = computeControlPanelPath(applicationPath, moduleConfiguration.getPath());
         List<String> prefixes = new ArrayList<>();
@@ -72,7 +74,15 @@ public final class ControlPanelSecurityRule implements SecurityRule<HttpRequest<
         if (request == null || !matches(request.getPath())) {
             return Publishers.just(SecurityRuleResult.UNKNOWN);
         }
-        if (access == ControlPanelSecurityConfiguration.Access.ANONYMOUS || authentication != null) {
+        if (access == ControlPanelSecurityConfiguration.Access.ANONYMOUS) {
+            return Publishers.just(SecurityRuleResult.ALLOWED);
+        }
+        if (access == ControlPanelSecurityConfiguration.Access.AUTHENTICATED && authentication != null) {
+            return Publishers.just(SecurityRuleResult.ALLOWED);
+        }
+        if (access == ControlPanelSecurityConfiguration.Access.AUTHORIZED
+            && authentication != null
+            && authentication.getRoles().contains(role)) {
             return Publishers.just(SecurityRuleResult.ALLOWED);
         }
         return Publishers.just(SecurityRuleResult.REJECTED);

--- a/control-panel-core/src/test/java/io/micronaut/controlpanel/core/security/ControlPanelSecurityConfigurationTest.java
+++ b/control-panel-core/src/test/java/io/micronaut/controlpanel/core/security/ControlPanelSecurityConfigurationTest.java
@@ -21,12 +21,25 @@ import org.junit.jupiter.api.Test;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class ControlPanelSecurityConfigurationTest {
 
     @Test
-    void defaultsToAnonymousAccess() {
+    void defaultsToAuthorizedAccessWithDefaultRole() {
         try (ApplicationContext context = ApplicationContext.run()) {
+            ControlPanelSecurityConfiguration configuration = context.getBean(ControlPanelSecurityConfiguration.class);
+
+            assertEquals(ControlPanelSecurityConfiguration.Access.AUTHORIZED, configuration.access());
+            assertEquals(ControlPanelSecurityConfiguration.DEFAULT_ROLE, configuration.role());
+        }
+    }
+
+    @Test
+    void bindsAnonymousAccess() {
+        try (ApplicationContext context = ApplicationContext.run(Map.of(
+            ControlPanelSecurityConfiguration.PROPERTY_ACCESS, "ANONYMOUS"
+        ))) {
             ControlPanelSecurityConfiguration configuration = context.getBean(ControlPanelSecurityConfiguration.class);
 
             assertEquals(ControlPanelSecurityConfiguration.Access.ANONYMOUS, configuration.access());
@@ -42,5 +55,26 @@ class ControlPanelSecurityConfigurationTest {
 
             assertEquals(ControlPanelSecurityConfiguration.Access.AUTHENTICATED, configuration.access());
         }
+    }
+
+    @Test
+    void bindsAuthorizedAccessAndCustomRole() {
+        try (ApplicationContext context = ApplicationContext.run(Map.of(
+            ControlPanelSecurityConfiguration.PROPERTY_ACCESS, "AUTHORIZED",
+            ControlPanelSecurityConfiguration.PROPERTY_ROLE, "ROLE_ADMIN"
+        ))) {
+            ControlPanelSecurityConfiguration configuration = context.getBean(ControlPanelSecurityConfiguration.class);
+
+            assertEquals(ControlPanelSecurityConfiguration.Access.AUTHORIZED, configuration.access());
+            assertEquals("ROLE_ADMIN", configuration.role());
+        }
+    }
+
+    @Test
+    void rejectsBlankRoleWhenAuthorizedAccessIsEnabled() {
+        assertThrows(IllegalArgumentException.class, () -> new ControlPanelSecurityConfiguration(
+            ControlPanelSecurityConfiguration.Access.AUTHORIZED,
+            " "
+        ));
     }
 }

--- a/control-panel-core/src/test/java/io/micronaut/controlpanel/core/security/ControlPanelSecurityRuleTest.java
+++ b/control-panel-core/src/test/java/io/micronaut/controlpanel/core/security/ControlPanelSecurityRuleTest.java
@@ -67,6 +67,40 @@ class ControlPanelSecurityRuleTest {
     }
 
     @Test
+    void authorizedModeRejectsAnonymousControlPanelRequests() {
+        ControlPanelSecurityRule rule = newRule(ControlPanelSecurityConfiguration.Access.AUTHORIZED, null);
+
+        assertEquals(SecurityRuleResult.REJECTED, check(rule, HttpRequest.GET("/control-panel"), null));
+        assertEquals(SecurityRuleResult.REJECTED, check(rule, HttpRequest.GET("/control-panel/routes"), null));
+    }
+
+    @Test
+    void authorizedModeRejectsAuthenticatedUsersWithoutTheConfiguredRole() {
+        ControlPanelSecurityRule rule = newRule(ControlPanelSecurityConfiguration.Access.AUTHORIZED, null);
+        Authentication authentication = Authentication.build("sherlock", Set.of("ROLE_USER"), Map.of());
+
+        assertEquals(SecurityRuleResult.REJECTED, check(rule, HttpRequest.GET("/control-panel"), authentication));
+        assertEquals(SecurityRuleResult.REJECTED, check(rule, HttpRequest.DELETE("/control-panel" + ControlPanelSecurityPaths.CACHE_PATH + "/demo"), authentication));
+    }
+
+    @Test
+    void authorizedModeAllowsAuthenticatedUsersWithTheDefaultRole() {
+        ControlPanelSecurityRule rule = newRule(ControlPanelSecurityConfiguration.Access.AUTHORIZED, null);
+        Authentication authentication = Authentication.build("sherlock", Set.of(ControlPanelSecurityConfiguration.DEFAULT_ROLE), Map.of());
+
+        assertEquals(SecurityRuleResult.ALLOWED, check(rule, HttpRequest.GET("/control-panel"), authentication));
+        assertEquals(SecurityRuleResult.ALLOWED, check(rule, HttpRequest.GET("/control-panel" + ControlPanelSecurityPaths.OBJECT_STORAGE_PATH + "/local/object"), authentication));
+    }
+
+    @Test
+    void authorizedModeAllowsAuthenticatedUsersWithTheCustomRole() {
+        ControlPanelSecurityRule rule = newRule(ControlPanelSecurityConfiguration.Access.AUTHORIZED, null, ControlPanelModuleConfiguration.DEFAULT_PATH, "ROLE_ADMIN");
+        Authentication authentication = Authentication.build("sherlock", Set.of("ROLE_ADMIN"), Map.of());
+
+        assertEquals(SecurityRuleResult.ALLOWED, check(rule, HttpRequest.GET("/control-panel"), authentication));
+    }
+
+    @Test
     void nonControlPanelRoutesRemainUnknown() {
         ControlPanelSecurityRule rule = newRule(ControlPanelSecurityConfiguration.Access.AUTHENTICATED, null);
 
@@ -92,7 +126,14 @@ class ControlPanelSecurityRuleTest {
     private static ControlPanelSecurityRule newRule(ControlPanelSecurityConfiguration.Access access,
                                                     String contextPath,
                                                     String controlPanelPath) {
-        ControlPanelSecurityConfiguration securityConfiguration = new ControlPanelSecurityConfiguration(access);
+        return newRule(access, contextPath, controlPanelPath, ControlPanelSecurityConfiguration.DEFAULT_ROLE);
+    }
+
+    private static ControlPanelSecurityRule newRule(ControlPanelSecurityConfiguration.Access access,
+                                                    String contextPath,
+                                                    String controlPanelPath,
+                                                    String role) {
+        ControlPanelSecurityConfiguration securityConfiguration = new ControlPanelSecurityConfiguration(access, role);
         ControlPanelModuleConfiguration moduleConfiguration = new ControlPanelModuleConfiguration() {
             @Override
             public boolean isEnabled() {

--- a/control-panel-ui/src/test/java/io/micronaut/controlpanel/ui/ControlPanelSecurityTest.java
+++ b/control-panel-ui/src/test/java/io/micronaut/controlpanel/ui/ControlPanelSecurityTest.java
@@ -47,7 +47,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class ControlPanelSecurityTest {
 
     @Test
-    void anonymousAccessIsAllowedByDefaultWhenSecurityIsEnabled() {
+    void authorizedAccessIsRequiredByDefaultWhenSecurityIsEnabled() {
         try (EmbeddedServer server = ApplicationContext.run(EmbeddedServer.class, Map.of(
             "spec.name", "ControlPanelSecurityTest",
             "micronaut.security.enabled", true,
@@ -55,9 +55,22 @@ class ControlPanelSecurityTest {
         ))) {
             HttpClient client = server.getApplicationContext().createBean(HttpClient.class, server.getURL());
 
-            assertEquals(HttpStatus.OK, client.toBlocking().exchange(ControlPanelModuleConfiguration.DEFAULT_PATH).status());
+            HttpClientResponseException anonymous = assertThrows(
+                HttpClientResponseException.class,
+                () -> client.toBlocking().exchange(ControlPanelModuleConfiguration.DEFAULT_PATH)
+            );
+            assertEquals(HttpStatus.UNAUTHORIZED, anonymous.getStatus());
+
+            HttpClientResponseException missingRole = assertThrows(
+                HttpClientResponseException.class,
+                () -> client.toBlocking().exchange(
+                    authenticatedRequest(HttpRequest.GET(ControlPanelModuleConfiguration.DEFAULT_PATH))
+                )
+            );
+            assertEquals(HttpStatus.FORBIDDEN, missingRole.getStatus());
+
             assertEquals(HttpStatus.OK, client.toBlocking().exchange(
-                authenticatedRequest(HttpRequest.GET(ControlPanelModuleConfiguration.DEFAULT_PATH))
+                authenticatedRequest(HttpRequest.GET(ControlPanelModuleConfiguration.DEFAULT_PATH), "controlpanel", "password")
             ).status());
 
             client.close();
@@ -98,6 +111,32 @@ class ControlPanelSecurityTest {
         ))) {
             HttpClient client = server.getApplicationContext().createBean(HttpClient.class, server.getURL());
             assertEquals(HttpStatus.OK, client.toBlocking().exchange(ControlPanelModuleConfiguration.DEFAULT_PATH).status());
+
+            client.close();
+        }
+    }
+
+    @Test
+    void authorizedAccessUsesTheConfiguredRoleWhenSecurityIsEnabled() {
+        try (EmbeddedServer server = ApplicationContext.run(EmbeddedServer.class, Map.of(
+            "spec.name", "ControlPanelSecurityTest",
+            "micronaut.security.enabled", true,
+            "micronaut.security.basic-auth.enabled", true,
+            ControlPanelSecurityConfiguration.PROPERTY_ROLE, "ROLE_ADMIN"
+        ))) {
+            HttpClient client = server.getApplicationContext().createBean(HttpClient.class, server.getURL());
+
+            HttpClientResponseException missingRole = assertThrows(
+                HttpClientResponseException.class,
+                () -> client.toBlocking().exchange(
+                    authenticatedRequest(HttpRequest.GET(ControlPanelModuleConfiguration.DEFAULT_PATH), "controlpanel", "password")
+                )
+            );
+            assertEquals(HttpStatus.FORBIDDEN, missingRole.getStatus());
+
+            assertEquals(HttpStatus.OK, client.toBlocking().exchange(
+                authenticatedRequest(HttpRequest.GET(ControlPanelModuleConfiguration.DEFAULT_PATH), "admin", "password")
+            ).status());
 
             client.close();
         }
@@ -265,6 +304,9 @@ class ControlPanelSecurityTest {
             if ("password".equals(authRequest.getSecret())) {
                 if ("admin".equals(authRequest.getIdentity())) {
                     return AuthenticationResponse.success("admin", List.of("ROLE_ADMIN"));
+                }
+                if ("controlpanel".equals(authRequest.getIdentity())) {
+                    return AuthenticationResponse.success("controlpanel", List.of(ControlPanelSecurityConfiguration.DEFAULT_ROLE));
                 }
                 if ("user".equals(authRequest.getIdentity())) {
                     return AuthenticationResponse.success("user", List.of("ROLE_USER"));

--- a/doc-examples/example-java/src/main/resources/application-secured.yml
+++ b/doc-examples/example-java/src/main/resources/application-secured.yml
@@ -1,4 +1,4 @@
-#tag::control-panel-authenticated[]
+#tag::control-panel-authorized[]
 micronaut:
   security:
     enabled: true
@@ -7,7 +7,8 @@ micronaut:
   control-panel:
     enabled: true
     security:
-      access: authenticated
+      access: authorized
+      role: ROLE_CONTROL_PANEL
 
 endpoints:
   env:
@@ -17,4 +18,4 @@ endpoints:
   loggers:
     enabled: true
     write-sensitive: false
-#end::control-panel-authenticated[]
+#end::control-panel-authorized[]

--- a/src/main/docs/guide/controlPanels/management.adoc
+++ b/src/main/docs/guide/controlPanels/management.adoc
@@ -16,55 +16,49 @@ The following panels are available:
 
 === Protecting The Control Panel
 
-By default, control panel routes remain anonymously accessible for development and test workflows. Only enable the
-control panel in trusted environments unless you also protect the control-panel-owned HTTP surface with Micronaut
-Security.
+When Micronaut Security is active, control panel routes are protected by default. The default access mode is
+`micronaut.control-panel.security.access=AUTHORIZED`, which requires an authenticated user with
+`ROLE_CONTROL_PANEL`.
 
-If your application already uses Micronaut Security, you can require authenticated access without turning the module
-into a separate OAuth client. Your existing Micronaut Security authentication mechanism authenticates the browser
-request.
+If your application already uses Micronaut Security, the control panel does not become a separate OAuth client. Your
+existing Micronaut Security authentication mechanism authenticates the browser request, and the control panel fallback
+rule authorizes the UI and helper-controller routes.
 
-The following example requires an authenticated user before the UI or helper controllers can be reached:
+The following example shows the default role-protected mode explicitly:
 
 [configuration]
 ----
-include::doc-examples/example-java/src/main/resources/application-secured.yml[tags=control-panel-authenticated]
+include::doc-examples/example-java/src/main/resources/application-secured.yml[tags=control-panel-authorized]
 ----
 
 This secures the control panel routes themselves with
-`micronaut.control-panel.security.access=AUTHENTICATED`. Management endpoint security remains under the normal
-Micronaut management configuration for your application.
+`micronaut.control-panel.security.access=AUTHORIZED` and
+`micronaut.control-panel.security.role=ROLE_CONTROL_PANEL`. You can change the role if your application uses a
+different administrative role:
 
-`AUTHENTICATED` requires a logged-in user, but it does not choose an application role for you. To restrict the control
-panel to administrators, configure role-based access with Micronaut Security in the host application. Host
-`intercept-url-map` rules run before the control-panel fallback rule, so they can require a role such as `ROLE_ADMIN`
-for the UI and helper controller routes:
-
-.Configuring role-based access for the control panel
 [configuration]
 ----
 micronaut:
-  security:
-    intercept-url-map:
-      - pattern: /control-panel/**
-        access:
-          - ROLE_ADMIN
-      - pattern: /control-panel/cache-control-panel-controller/**
-        access:
-          - ROLE_ADMIN
-      - pattern: /control-panel/datasource-control-panel-controller/**
-        access:
-          - ROLE_ADMIN
-      - pattern: /control-panel/object-storage-control-panel-controller/**
-        access:
-          - ROLE_ADMIN
+  control-panel:
+    security:
+      role: ROLE_ADMIN
 ----
 
-If you customize `micronaut.control-panel.path`, use that path instead of `/control-panel/**` in the UI rule.
+Management endpoint security remains under the normal Micronaut management configuration for your application.
 
-Applications that include Micronaut Security still default to
-`micronaut.control-panel.security.access=ANONYMOUS`. Keep that default only in trusted development or test
-environments.
+The `AUTHENTICATED` mode requires any logged-in user, but does not require a specific role. The `ANONYMOUS` mode keeps
+the UI and helper controllers anonymously reachable. Use these modes only for trusted development or test environments:
+
+[configuration]
+----
+micronaut:
+  control-panel:
+    security:
+      access: AUTHENTICATED
+----
+
+Host `intercept-url-map` rules run before the control-panel fallback rule, so host rules can still be stricter than the
+configured control panel access mode.
 
 === Application Health
 
@@ -83,8 +77,8 @@ endpoints:
     details-visible: AUTHENTICATED
 ----
 
-With the default `micronaut.control-panel.security.access=ANONYMOUS`, anonymous control-panel requests continue to see
-the anonymous health view.
+If you opt into `micronaut.control-panel.security.access=ANONYMOUS`, anonymous control-panel requests continue to see the
+anonymous health view.
 
 === Environment Properties
 
@@ -122,7 +116,7 @@ This will show all values apart from those that contain the words `password`, `c
 
 This panel displays all the beans, and their relationships, grouped by packages. It relies on the
 https://docs.micronaut.io/latest/guide/#beansEndpoint[Beans Endpoint] to display all the bean definitions. Keep the
-authenticated control-panel access when you do not want to expose that information to anonymous users.
+role-protected control-panel access when you do not want to expose that information to anonymous users.
 
 === Disabled Beans
 


### PR DESCRIPTION
## Summary
- Add `AUTHORIZED` as the default `micronaut.control-panel.security.access` mode.
- Add configurable `micronaut.control-panel.security.role`, defaulting to `ROLE_CONTROL_PANEL`.
- Preserve explicit `ANONYMOUS` and `AUTHENTICATED` modes while keeping host `intercept-url-map` rules authoritative.
- Update focused tests, secured example configuration, and management guide docs for the secure default.

## Verification
- `git diff --check origin/2.0.x..HEAD`
- `./gradlew --rerun-tasks :micronaut-control-panel-core:test --tests io.micronaut.controlpanel.core.security.ControlPanelSecurityConfigurationTest --tests io.micronaut.controlpanel.core.security.ControlPanelSecurityRuleTest :micronaut-control-panel-ui:test --tests io.micronaut.controlpanel.ui.ControlPanelSecurityTest --tests io.micronaut.controlpanel.ui.ControlPanelControllerPathTest`

## Release Targeting
Selected Micronaut organization projects: `5.0.0-M3` and `5.0.0 Release`. Ambiguity note from QA intake: later release boards also exist, but these are the earliest matching target boards for this branch.

Fixes #536

---
###### ✨ This message was AI-generated using GPT-5
