### PR TITLE
docs: fix control panel guide details

### DIFF
--- a/src/main/docs/guide/controlPanels/kafka.adoc
+++ b/src/main/docs/guide/controlPanels/kafka.adoc
@@ -26,6 +26,7 @@ You can disable it by setting:
 ----
 micronaut:
   control-panel:
-    kafka-streams:
-      enabled: false
+    panels:
+      kafka-streams:
+        enabled: false
 ----

--- a/src/main/docs/guide/controlPanels/management.adoc
+++ b/src/main/docs/guide/controlPanels/management.adoc
@@ -5,7 +5,7 @@ dependency:io.micronaut.controlpanel:micronaut-control-panel-management[scope=de
 Note that you also need the
 https://docs.micronaut.io/latest/guide/#management[Management] module:
 
-dependency:io.micronaut.:micronaut-management[scope=runtimeOnly]
+dependency:io.micronaut:micronaut-management[scope=runtimeOnly]
 
 The following panels are available:
 

--- a/src/main/docs/guide/controlPanels/objectStorage.adoc
+++ b/src/main/docs/guide/controlPanels/objectStorage.adoc
@@ -19,7 +19,7 @@ The control panel supports all object storage systems provided by Micronaut Obje
 * **Google Cloud Storage** - Google Cloud Platform
 * **Oracle Cloud Storage** - Oracle Cloud Infrastructure
 
-The control panel is automatically enabled when you include the `control-panel-object-storage` module in your project. You can disable it by setting:
+The control panel is automatically enabled when you include the `micronaut-control-panel-object-storage` module in your project. You can disable it by setting:
 
 [configuration]
 ----

--- a/src/main/docs/guide/custom.adoc
+++ b/src/main/docs/guide/custom.adoc
@@ -51,7 +51,7 @@ There are some values for the UI that can be configured:
 include::doc-examples/example-java/src/main/resources/application.yml[tags=control-panel]
 ----
 
-<1> Title to be displayed in the control panel headeer.
+<1> Title to be displayed in the control panel header.
 <2> Icon class (from Font Awesome) of the control panel.
 <3> The order in which the control panel will be displayed in the UI.
 
@@ -62,8 +62,8 @@ https://micronaut-projects.github.io/micronaut-views/latest/guide/[Micronaut Vie
 https://micronaut-projects.github.io/micronaut-views/latest/guide/#handlebars[Handlebars.java] templates.
 
 Each control panel needs to provide 2 views: one for the control panel list, that can contain a summary of the
-information to be displayed, and another one for the detailed view. The must be placed in a `views/<panel-name>` directory
-on the classpath, and names `body.hbs` and `detail.hbs`, respectively. For example, in the above example:
+information to be displayed, and another one for the detailed view. They must be placed in a `views/<panel-name>` directory
+on the classpath, and named `body.hbs` and `detail.hbs`, respectively. For example, in the above example:
 
 .`src/main/resources/views/my-application/body.hbs`.
 [source, html]


### PR DESCRIPTION
## Summary

- Fix the management module dependency coordinate in the Control Panel guide.
- Correct the Kafka Streams panel disable-property example to use the per-panel `micronaut.control-panel.panels.kafka-streams.enabled` prefix.
- Clean up small user-facing wording issues in custom panel and object storage guide sections.

## Validation

- `./gradlew publishGuide`
- `./gradlew docs`
- `./gradlew :micronaut-control-panel-kafka:test --tests io.micronaut.controlpanel.panels.kafka.KafkaStreamsControlPanelTest`
- `./gradlew :micronaut-doc-examples:micronaut-example-java:test --tests example.MyApplicationControlPanelTest`

## Paperclip

DEV-302 Weekly User Guide Review: Micronaut Control Panel

---
###### ✨ This message was AI-generated using gpt-5.5
