### PR TITLE
Add application info control panel

### DIFF
--- a/control-panel-core/src/test/java/io/micronaut/controlpanel/core/DefaultControlPanelRepositoryTest.java
+++ b/control-panel-core/src/test/java/io/micronaut/controlpanel/core/DefaultControlPanelRepositoryTest.java
@@ -49,14 +49,14 @@ class DefaultControlPanelRepositoryTest {
     void itCanFindAll() {
         ControlPanelRepository repository = ctx.getBean(ControlPanelRepository.class);
         var panels = repository.findAll();
-        assertEquals(7, panels.size());
+        assertEquals(8, panels.size());
     }
 
     @Test
     void itCanFindAllByCategoryMain() {
         ControlPanelRepository repository = ctx.getBean(ControlPanelRepository.class);
         var panels = repository.findAllByCategory(ControlPanel.Category.MAIN.id());
-        assertEquals(4, panels.size());
+        assertEquals(5, panels.size());
     }
 
     @Test
@@ -67,7 +67,7 @@ class DefaultControlPanelRepositoryTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"routes", "beans", "env", "loggers", "health", "test"})
+    @ValueSource(strings = {"routes", "beans", "env", "info", "loggers", "health", "test"})
     void itCanFindOneByNamePresent(String controlPanelName) {
         ControlPanelRepository repository = ctx.getBean(ControlPanelRepository.class);
         assertTrue(repository.findByName(controlPanelName).isPresent());
@@ -111,7 +111,7 @@ class DefaultControlPanelRepositoryTest {
     void itCanCountByCategoryIdMain() {
         ControlPanelRepository repository = ctx.getBean(ControlPanelRepository.class);
         long count = repository.countByCategoryId(ControlPanel.Category.MAIN.id());
-        assertEquals(4L, count);
+        assertEquals(5L, count);
     }
 
     @Test

--- a/control-panel-management/src/main/java/io/micronaut/controlpanel/panels/management/InfoControlPanel.java
+++ b/control-panel-management/src/main/java/io/micronaut/controlpanel/panels/management/InfoControlPanel.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.management;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.controlpanel.core.AbstractControlPanel;
+import io.micronaut.controlpanel.core.config.ControlPanelConfiguration;
+import io.micronaut.core.annotation.ReflectiveAccess;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.management.endpoint.info.InfoAggregator;
+import io.micronaut.management.endpoint.info.InfoEndpoint;
+import io.micronaut.management.endpoint.info.InfoSource;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+import reactor.core.publisher.Mono;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Control panel that displays information from the application info endpoint.
+ *
+ * @since 2.0.0
+ */
+@Singleton
+@Requires(beans = InfoEndpoint.class)
+@Requires(property = InfoControlPanel.ENABLED_PROPERTY, notEquals = StringUtils.FALSE)
+public class InfoControlPanel extends AbstractControlPanel<InfoControlPanel.Body> {
+
+    public static final String NAME = InfoEndpoint.NAME;
+    public static final String ENABLED_PROPERTY = ControlPanelConfiguration.PREFIX + "." + NAME + ".enabled";
+
+    private final InfoAggregator<Map<String, Object>> infoAggregator;
+    private final InfoSource[] infoSources;
+
+    public InfoControlPanel(InfoAggregator<Map<String, Object>> infoAggregator,
+                            InfoSource[] infoSources,
+                            @Named(NAME) ControlPanelConfiguration configuration) {
+        super(NAME, configuration);
+        this.infoAggregator = infoAggregator;
+        this.infoSources = infoSources;
+    }
+
+    @Override
+    public Body getBody() {
+        Map<String, Object> info = Mono.from(infoAggregator.aggregate(infoSources)).block();
+        if (info == null || info.isEmpty()) {
+            return new Body(List.of(), List.of(), List.of());
+        }
+        List<InfoNode> sections = toNodes(info);
+        return new Body(sections, toRows(sections), toSummaryItems(info));
+    }
+
+    private static List<InfoNode> toNodes(Map<String, Object> values) {
+        List<InfoNode> nodes = new ArrayList<>(values.size());
+        values.forEach((name, value) -> nodes.add(toNode(name, value)));
+        return nodes;
+    }
+
+    private static InfoNode toNode(String name, Object value) {
+        if (value instanceof Map<?, ?> map) {
+            Map<String, Object> values = new LinkedHashMap<>();
+            map.forEach((key, mapValue) -> values.put(String.valueOf(key), mapValue));
+            return new InfoNode(name, displayName(name), emptyValue(values), toNodes(values));
+        }
+        if (value instanceof Iterable<?> iterable) {
+            List<InfoNode> children = new ArrayList<>();
+            int index = 0;
+            for (Object element : iterable) {
+                children.add(toNode(String.valueOf(index), element));
+                index++;
+            }
+            return new InfoNode(name, displayName(name), emptyValue(children), children);
+        }
+        return new InfoNode(name, displayName(name), String.valueOf(value), List.of());
+    }
+
+    private static String emptyValue(Map<String, Object> values) {
+        return values.isEmpty() ? "(empty)" : null;
+    }
+
+    private static String emptyValue(List<InfoNode> values) {
+        return values.isEmpty() ? "(empty)" : null;
+    }
+
+    private static String displayName(String name) {
+        if (name.chars().allMatch(Character::isDigit)) {
+            return "[" + name + "]";
+        }
+        String normalized = name.replace('-', ' ').replace('_', ' ').replace('.', ' ');
+        StringBuilder result = new StringBuilder(normalized.length());
+        for (int i = 0; i < normalized.length(); i++) {
+            char current = normalized.charAt(i);
+            if (i > 0 && Character.isUpperCase(current) && Character.isLowerCase(normalized.charAt(i - 1))) {
+                result.append(' ');
+            }
+            result.append(current);
+        }
+        String[] words = result.toString().trim().split("\\s+");
+        StringBuilder title = new StringBuilder(result.length());
+        for (String word : words) {
+            if (!word.isEmpty()) {
+                if (!title.isEmpty()) {
+                    title.append(' ');
+                }
+                title.append(Character.toUpperCase(word.charAt(0)));
+                if (word.length() > 1) {
+                    title.append(word.substring(1).toLowerCase(Locale.ENGLISH));
+                }
+            }
+        }
+        return title.toString();
+    }
+
+    private static List<InfoRow> toRows(List<InfoNode> sections) {
+        List<InfoRow> rows = new ArrayList<>();
+        for (InfoNode section : sections) {
+            addRows(rows, section, section.displayName(), null, 0);
+        }
+        return rows;
+    }
+
+    private static void addRows(List<InfoRow> rows, InfoNode node, String section, String key, int depth) {
+        String rowKey = key == null ? node.displayName() : key;
+        if (node.value() != null) {
+            rows.add(new InfoRow(section, rowKey, node.value(), depth));
+        }
+        for (InfoNode child : node.children()) {
+            String childKey = key == null ? child.displayName() : key + " / " + child.displayName();
+            addRows(rows, child, section, childKey, depth + 1);
+        }
+    }
+
+    private static List<SummaryItem> toSummaryItems(Map<String, Object> info) {
+        List<SummaryItem> items = new ArrayList<>();
+        addSummaryItem(items, "Name", false, valueAt(info, "application.name", "app.name", "demo.name", "build.name"));
+        addSummaryItem(items, "Version", false, valueAt(info, "application.version", "app.version", "build.version", "version"));
+        addSummaryItem(items, "Commit", true, valueAt(info, "git.commit.id.abbrev", "git.commit.id", "git.commit"));
+        addSummaryItem(items, "Branch", true, valueAt(info, "git.branch"));
+        addSummaryItem(items, "Build time", false, valueAt(info, "build.time", "build.timestamp"));
+        return items;
+    }
+
+    private static void addSummaryItem(List<SummaryItem> items, String label, boolean code, Object value) {
+        if (value != null) {
+            items.add(new SummaryItem(label, String.valueOf(value), code));
+        }
+    }
+
+    private static Object valueAt(Map<String, Object> info, String... paths) {
+        for (String path : paths) {
+            Object value = valueAt(info, path);
+            if (value != null) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    private static Object valueAt(Map<String, Object> info, String path) {
+        Object current = info;
+        for (String segment : path.split("\\.")) {
+            if (!(current instanceof Map<?, ?> map)) {
+                return null;
+            }
+            current = map.get(segment);
+            if (current == null) {
+                return null;
+            }
+        }
+        return current instanceof Map<?, ?> || current instanceof Iterable<?> ? null : current;
+    }
+
+    /**
+     * Represents the body of this control panel.
+     *
+     * @param sections the top-level info sections
+     * @param rows flattened scalar info rows
+     * @param summaryItems common high-value metadata rows
+     */
+    @ReflectiveAccess
+    public record Body(List<InfoNode> sections, List<InfoRow> rows, List<SummaryItem> summaryItems) { }
+
+    /**
+     * Represents a single info node rendered by the recursive templates.
+     *
+     * @param name the original node name
+     * @param displayName the display name
+     * @param value the scalar value
+     * @param children nested child nodes
+     */
+    @ReflectiveAccess
+    public record InfoNode(String name, String displayName, String value, List<InfoNode> children) { }
+
+    /**
+     * Represents a flattened info row rendered by the detail template.
+     *
+     * @param section the top-level info section
+     * @param key the nested key path inside the section
+     * @param value the scalar value
+     * @param depth the nesting depth
+     */
+    @ReflectiveAccess
+    public record InfoRow(String section, String key, String value, int depth) { }
+
+    /**
+     * Represents a high-value metadata item rendered in the summary.
+     *
+     * @param label the summary label
+     * @param value the summary value
+     * @param code whether to render the value as code
+     */
+    @ReflectiveAccess
+    public record SummaryItem(String label, String value, boolean code) { }
+}

--- a/control-panel-management/src/main/resources/micronaut-control-panel/micronaut-control-panel.properties
+++ b/control-panel-management/src/main/resources/micronaut-control-panel/micronaut-control-panel.properties
@@ -12,6 +12,10 @@ micronaut.control-panel.panels.metrics.title = Metrics
 micronaut.control-panel.panels.metrics.icon = fa-chart-line
 micronaut.control-panel.panels.metrics.order = 20
 
+micronaut.control-panel.panels.info.title = Application Info
+micronaut.control-panel.panels.info.icon = fa-info-circle
+micronaut.control-panel.panels.info.order = 30
+
 micronaut.control-panel.panels.loggers.title = Loggers
 micronaut.control-panel.panels.loggers.icon = fa-file-lines
 micronaut.control-panel.panels.loggers.order = 40

--- a/control-panel-management/src/main/resources/views/info/body.hbs
+++ b/control-panel-management/src/main/resources/views/info/body.hbs
@@ -1,0 +1,38 @@
+{{#with controlPanel.body }}
+    {{#if sections}}
+        <div class="cp-info-card-summary">
+            <div>
+                <strong>{{sections.size}}</strong>
+                <span>info sections</span>
+            </div>
+            <div>
+                <strong>{{rows.size}}</strong>
+                <span>values</span>
+            </div>
+        </div>
+        {{#if summaryItems}}
+            <dl class="cp-info-summary-list cp-info-summary-list-compact">
+                {{#each summaryItems}}
+                    <div>
+                        <dt>{{label}}</dt>
+                        <dd>
+                            {{#if code}}
+                                <code class="cp-table-code">{{value}}</code>
+                            {{else}}
+                                {{value}}
+                            {{/if}}
+                        </dd>
+                    </div>
+                {{/each}}
+            </dl>
+        {{else}}
+            <p class="card-text text-muted">
+                Open details to inspect configuration, build, git, and custom InfoSource values.
+            </p>
+        {{/if}}
+    {{else}}
+        <p class="card-text">
+            No application info is available. Add an InfoSource bean or configure `info.*` values.
+        </p>
+    {{/if}}
+{{/with}}

--- a/control-panel-management/src/main/resources/views/info/detail.hbs
+++ b/control-panel-management/src/main/resources/views/info/detail.hbs
@@ -1,0 +1,81 @@
+{{#with controlPanel.body }}
+    {{#if sections}}
+        <div class="cp-info-detail">
+            <aside class="cp-info-sidebar" aria-label="Application info summary">
+                <section class="card cp-info-summary-card">
+                    <div class="card-header cp-card-header">
+                        <h2 class="card-title">Summary</h2>
+                        <span class="badge badge-secondary">InfoEndpoint available</span>
+                    </div>
+                    <div class="card-body">
+                        {{#if summaryItems}}
+                            <dl class="cp-info-summary-list">
+                                {{#each summaryItems}}
+                                    <div>
+                                        <dt>{{label}}</dt>
+                                        <dd>
+                                            {{#if code}}
+                                                <code class="cp-table-code">{{value}}</code>
+                                            {{else}}
+                                                {{value}}
+                                            {{/if}}
+                                        </dd>
+                                    </div>
+                                {{/each}}
+                            </dl>
+                        {{else}}
+                            <p class="text-muted">
+                                No common application, build, or git metadata was found. The full InfoSource output is still available.
+                            </p>
+                        {{/if}}
+                    </div>
+                </section>
+            </aside>
+
+            <section class="card cp-info-values-card">
+                <div class="card-header cp-card-header">
+                    <h2 class="card-title">Info values</h2>
+                    <span class="badge badge-outline">{{rows.size}} values</span>
+                </div>
+                <div class="card-body">
+                    <div class="cp-data-table cp-data-table-unpaged" data-filter-table data-filter-table-unpaged data-filter-table-label="info value" data-filter-table-label-plural="info values">
+                        <div class="cp-data-table-toolbar">
+                            <div class="cp-data-table-summary" data-filter-table-summary>{{rows.size}} info values</div>
+                            <div class="cp-data-table-search">
+                                <input type="text" class="form-control" data-filter-table-search placeholder="Search info values" aria-label="Search info values">
+                            </div>
+                        </div>
+                        <div class="cp-data-table-container cp-info-table-container">
+                            <table class="table cp-data-table-table cp-data-table-fixed cp-info-table">
+                                <thead>
+                                    <tr>
+                                        <th>Section</th>
+                                        <th>Key</th>
+                                        <th>Value</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {{#each rows}}
+                                        <tr data-filter-table-row>
+                                            <td data-label="Section">{{section}}</td>
+                                            <td data-label="Key"><code class="cp-table-code">{{key}}</code></td>
+                                            <td data-label="Value" class="cp-info-value">{{value}}</td>
+                                        </tr>
+                                    {{/each}}
+                                    <tr data-filter-table-empty hidden>
+                                        <td class="cp-data-table-empty-cell" colspan="3">No info values found.</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </section>
+        </div>
+    {{else}}
+        <div class="alert alert-info cp-info-empty-state">
+            <h5><i class="icon fas fa-info-circle"></i> No application info is available</h5>
+            The Info endpoint returned no values. Add an InfoSource bean, configure non-secret `info.*` values, or provide build/git metadata to populate this panel.
+        </div>
+    {{/if}}
+{{/with}}

--- a/control-panel-management/src/test/java/io/micronaut/controlpanel/panels/management/InfoControlPanelTest.java
+++ b/control-panel-management/src/test/java/io/micronaut/controlpanel/panels/management/InfoControlPanelTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.management;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.env.PropertySource;
+import io.micronaut.controlpanel.core.ControlPanelRepository;
+import io.micronaut.controlpanel.core.config.ControlPanelConfiguration;
+import io.micronaut.inject.qualifiers.Qualifiers;
+import io.micronaut.management.endpoint.info.InfoAggregator;
+import io.micronaut.management.endpoint.info.InfoSource;
+import jakarta.inject.Singleton;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class InfoControlPanelTest {
+
+    @Test
+    void itIsConfiguredCorrectlyAndRegistered() {
+        try (ApplicationContext ctx = ApplicationContext.run(Map.of(
+            "endpoints.info.enabled", true,
+            "info.application.name", "Control Panel",
+            "info.application.version", "2.0.0"
+        ))) {
+            InfoControlPanel panel = ctx.getBean(InfoControlPanel.class);
+            assertEquals("Application Info", panel.getTitle());
+            assertEquals("fa-info-circle", panel.getIcon());
+            assertEquals(30, panel.getOrder());
+
+            assertTrue(ctx.getBean(ControlPanelRepository.class).findByName(InfoControlPanel.NAME).isPresent());
+            assertEquals("", panel.getBadge());
+
+            InfoControlPanel.InfoNode application = find(panel.getBody().sections(), "application");
+            assertEquals("Application", application.displayName());
+            assertEquals("Control Panel", find(application.children(), "name").value());
+            assertEquals("2.0.0", find(application.children(), "version").value());
+
+            assertSummaryItem(panel.getBody().summaryItems(), "Name", "Control Panel");
+            assertSummaryItem(panel.getBody().summaryItems(), "Version", "2.0.0");
+        }
+    }
+
+    @Test
+    void itAggregatesCustomNestedInfoSources() {
+        try (ApplicationContext ctx = ApplicationContext.run(Map.of(
+            "endpoints.info.enabled", true,
+            "spec.name", "custom-info"
+        ))) {
+            InfoControlPanel panel = ctx.getBean(InfoControlPanel.class);
+
+            InfoControlPanel.InfoNode custom = find(panel.getBody().sections(), "custom");
+            InfoControlPanel.InfoNode nested = find(custom.children(), "nested");
+            assertEquals("true", find(nested.children(), "enabled").value());
+            assertEquals("one", find(find(custom.children(), "items").children(), "0").value());
+            assertEquals("two", find(find(custom.children(), "items").children(), "1").value());
+            assertEquals("<script>alert(1)</script>", find(custom.children(), "html").value());
+            assertTrue(panel.getBody().rows().stream().anyMatch(row ->
+                "Custom".equals(row.section()) && "Nested / Enabled".equals(row.key()) && "true".equals(row.value())));
+        }
+    }
+
+    @Test
+    void itCanBeDisabled() {
+        try (ApplicationContext ctx = ApplicationContext.run(Map.of(InfoControlPanel.ENABLED_PROPERTY, false))) {
+            ControlPanelConfiguration cfg = ctx.getBean(ControlPanelConfiguration.class, Qualifiers.byName(InfoControlPanel.NAME));
+            assertFalse(cfg.isEnabled());
+            assertFalse(ctx.containsBean(InfoControlPanel.class));
+        }
+    }
+
+    @Test
+    void itIsNotRegisteredWhenInfoEndpointBeanIsAbsent() {
+        try (ApplicationContext ctx = ApplicationContext.run(Map.of("endpoints.info.enabled", false))) {
+            assertFalse(ctx.containsBean(InfoControlPanel.class));
+            assertTrue(ctx.getBean(ControlPanelRepository.class).findByName(InfoControlPanel.NAME).isEmpty());
+        }
+    }
+
+    @Test
+    void itHandlesEmptyInfoOutput() {
+        InfoControlPanel panel = panelFor(Map.of());
+
+        assertTrue(panel.getBody().sections().isEmpty());
+        assertTrue(panel.getBody().summaryItems().isEmpty());
+        assertEquals("", panel.getBadge());
+    }
+
+    @Test
+    void itBuildsReadableNestedNodes() {
+        Map<String, Object> build = new LinkedHashMap<>();
+        build.put("commitId", "abc123");
+        build.put("tags", List.of("local", "test"));
+
+        Map<String, Object> info = new LinkedHashMap<>();
+        info.put("build-info", build);
+
+        InfoControlPanel.InfoNode buildInfo = find(panelFor(info).getBody().sections(), "build-info");
+
+        assertEquals("Build Info", buildInfo.displayName());
+        assertEquals("abc123", find(buildInfo.children(), "commitId").value());
+        assertEquals("[0]", find(find(buildInfo.children(), "tags").children(), "0").displayName());
+    }
+
+    @Test
+    void infoTemplatesDoNotUseRawHandlebarsOutput() throws IOException {
+        assertTemplateDoesNotUseRawOutput("views/info/body.hbs");
+        assertTemplateDoesNotUseRawOutput("views/info/detail.hbs");
+    }
+
+    private static InfoControlPanel panelFor(Map<String, Object> info) {
+        ControlPanelConfiguration configuration = new ControlPanelConfiguration(InfoControlPanel.NAME);
+        configuration.setTitle("Application Info");
+        InfoAggregator<Map<String, Object>> aggregator = sources -> Mono.just(info);
+        return new InfoControlPanel(aggregator, new InfoSource[0], configuration);
+    }
+
+    private static InfoControlPanel.InfoNode find(List<InfoControlPanel.InfoNode> nodes, String name) {
+        return nodes.stream()
+            .filter(node -> name.equals(node.name()))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("Node not found: " + name));
+    }
+
+    private static void assertSummaryItem(List<InfoControlPanel.SummaryItem> items, String label, String value) {
+        assertTrue(items.stream().anyMatch(item -> label.equals(item.label()) && value.equals(item.value())),
+            () -> "Summary item not found: " + label + "=" + value);
+    }
+
+    private static void assertTemplateDoesNotUseRawOutput(String path) throws IOException {
+        try (var inputStream = InfoControlPanelTest.class.getClassLoader().getResourceAsStream(path)) {
+            assertNotNull(inputStream, () -> "Missing template: " + path);
+            String template = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+            assertFalse(template.contains("{{{"), () -> path + " must not use triple-stash raw output");
+            assertFalse(template.contains("{{&"), () -> path + " must not use raw output");
+        }
+    }
+
+    @Factory
+    static class CustomInfoSourceFactory {
+
+        @Singleton
+        @Requires(property = "spec.name", value = "custom-info")
+        InfoSource customInfoSource() {
+            return () -> {
+                Map<String, Object> nested = new LinkedHashMap<>();
+                nested.put("enabled", true);
+
+                Map<String, Object> custom = new LinkedHashMap<>();
+                custom.put("nested", nested);
+                custom.put("items", List.of("one", "two"));
+                custom.put("html", "<script>alert(1)</script>");
+
+                Map<String, Object> info = new LinkedHashMap<>();
+                info.put("custom", custom);
+                return Mono.just(PropertySource.of("custom-info", info));
+            };
+        }
+    }
+}

--- a/control-panel-ui/src/main/resources/static/css/dashboard.css
+++ b/control-panel-ui/src/main/resources/static/css/dashboard.css
@@ -1868,6 +1868,120 @@ dl.row dt {
     color: var(--warning-foreground);
 }
 
+.cp-info-card-summary {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.75rem;
+    margin-bottom: 0.85rem;
+}
+
+.cp-info-card-summary > div {
+    display: grid;
+    gap: 0.1rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--muted);
+    padding: 0.65rem 0.75rem;
+}
+
+.cp-info-card-summary strong {
+    color: var(--foreground);
+    font-size: 1rem;
+    line-height: 1.1;
+}
+
+.cp-info-card-summary span {
+    color: var(--muted-foreground);
+    font-size: 0.75rem;
+}
+
+.cp-info-detail {
+    display: grid;
+    grid-template-columns: minmax(18rem, 0.8fr) minmax(0, 1.4fr);
+    gap: 1rem;
+    align-items: start;
+}
+
+.cp-info-sidebar {
+    display: grid;
+    gap: 1rem;
+    min-width: 0;
+}
+
+.cp-info-summary-card {
+    margin-bottom: 0;
+}
+
+.cp-info-summary-list {
+    display: grid;
+    gap: 0;
+    margin: 0;
+}
+
+.cp-info-summary-list > div {
+    display: grid;
+    grid-template-columns: minmax(6.5rem, 0.42fr) minmax(0, 1fr);
+    gap: 0.75rem;
+    border-bottom: 1px solid var(--border);
+    padding: 0.7rem 0;
+}
+
+.cp-info-summary-list > div:first-child {
+    padding-top: 0;
+}
+
+.cp-info-summary-list > div:last-child {
+    border-bottom: 0;
+    padding-bottom: 0;
+}
+
+.cp-info-summary-list dt {
+    color: var(--muted-foreground);
+    font-weight: 650;
+}
+
+.cp-info-summary-list dd {
+    min-width: 0;
+    margin: 0;
+    overflow-wrap: anywhere;
+}
+
+.cp-info-summary-list-compact {
+    gap: 0.45rem;
+}
+
+.cp-info-summary-list-compact > div {
+    grid-template-columns: minmax(4.5rem, auto) minmax(0, 1fr);
+    gap: 0.5rem;
+    border-bottom: 0;
+    padding: 0;
+    font-size: 0.8125rem;
+}
+
+.cp-info-values-card {
+    min-width: 0;
+    margin-bottom: 0;
+}
+
+.cp-info-table th:first-child,
+.cp-info-table td:first-child {
+    width: 24%;
+}
+
+.cp-info-table th:nth-child(2),
+.cp-info-table td:nth-child(2) {
+    width: 34%;
+}
+
+.cp-info-value {
+    overflow-wrap: anywhere;
+    white-space: pre-wrap;
+}
+
+.cp-info-empty-state {
+    margin-bottom: 0;
+}
+
 .cp-actions-menu {
     position: relative;
     display: inline-flex;
@@ -3196,5 +3310,56 @@ div.mermaid {
 
     .cp-kafka-threads-table td:last-child {
         border-bottom: 0;
+    }
+
+    .cp-info-detail {
+        grid-template-columns: 1fr;
+    }
+
+    .cp-info-summary-list > div {
+        grid-template-columns: 1fr;
+        gap: 0.25rem;
+    }
+
+    .cp-info-table-container {
+        overflow: visible;
+    }
+
+    .cp-info-table,
+    .cp-info-table thead,
+    .cp-info-table tbody,
+    .cp-info-table tr,
+    .cp-info-table th,
+    .cp-info-table td {
+        display: block;
+        width: 100% !important;
+    }
+
+    .cp-info-table thead {
+        position: absolute;
+        left: -9999px;
+    }
+
+    .cp-info-table tr[data-filter-table-row] {
+        border-bottom: 1px solid var(--border);
+        padding: 0.7rem 0;
+    }
+
+    .cp-info-table tr[data-filter-table-row]:last-of-type {
+        border-bottom: 0;
+    }
+
+    .cp-info-table td {
+        display: grid;
+        grid-template-columns: minmax(5.5rem, 0.38fr) minmax(0, 1fr);
+        gap: 0.75rem;
+        border-bottom: 0;
+        padding: 0.25rem 0.75rem;
+    }
+
+    .cp-info-table td::before {
+        content: attr(data-label);
+        color: var(--muted-foreground);
+        font-weight: 650;
     }
 }

--- a/control-panel-ui/src/test/java/io/micronaut/controlpanel/ui/ControlPanelControllerTest.java
+++ b/control-panel-ui/src/test/java/io/micronaut/controlpanel/ui/ControlPanelControllerTest.java
@@ -40,7 +40,7 @@ class ControlPanelControllerTest {
         assertEquals(java.util.Set.of("test"), model.activeEnvironments());
         assertEquals(Model.ContentView.INDEX, model.contentView());
         assertEquals(ControlPanel.Category.MAIN, model.ext().get("currentCategory"));
-        assertEquals(4, ((java.util.Collection<?>) model.ext().get("controlPanels")).size());
+        assertEquals(5, ((java.util.Collection<?>) model.ext().get("controlPanels")).size());
     }
 
     @Test
@@ -52,7 +52,7 @@ class ControlPanelControllerTest {
         assertEquals(java.util.Set.of("test"), model.activeEnvironments());
         assertEquals(Model.ContentView.INDEX, model.contentView());
         assertEquals(categoryId, ((ControlPanel.Category) model.ext().get("currentCategory")).id());
-        assertEquals(4, ((java.util.Collection<?>) model.ext().get("controlPanels")).size());
+        assertEquals(5, ((java.util.Collection<?>) model.ext().get("controlPanels")).size());
 
         var model2 = (Model) controller.byCategory("application").body().getModel().get();
         assertEquals(1, ((java.util.Collection<?>) model2.ext().get("controlPanels")).size());
@@ -76,6 +76,9 @@ class ControlPanelControllerTest {
 
         var modelHealth = (Model) controller.detail("health").body().getModel().get();
         assertEquals(ControlPanel.Category.MAIN.id(), ((ControlPanel.Category) modelHealth.ext().get("currentCategory")).id());
+
+        var modelInfo = (Model) controller.detail("info").body().getModel().get();
+        assertEquals(ControlPanel.Category.MAIN.id(), ((ControlPanel.Category) modelInfo.ext().get("currentCategory")).id());
 
         var modelTest = (Model) controller.detail("test").body().getModel().get();
         assertEquals("application", ((ControlPanel.Category) modelTest.ext().get("currentCategory")).id());

--- a/doc-examples/example-java/src/main/resources/application.yml
+++ b/doc-examples/example-java/src/main/resources/application.yml
@@ -29,6 +29,13 @@ micronaut:
   application:
     name: myApplication
 
+info:
+  demo:
+    name: Micronaut Control Panel Example
+    environment:
+      purpose: Local development
+      owner: Micronaut
+
 ehcache:
   caches:
     my-ehcache:
@@ -47,6 +54,8 @@ endpoints:
     sensitive: false
   health:
     details-visible: ANONYMOUS
+  info:
+    enabled: true
 
 infinispan:
   enabled: false

--- a/doc-examples/example-java/src/test/java/example/e2e/AbstractE2ETest.java
+++ b/doc-examples/example-java/src/test/java/example/e2e/AbstractE2ETest.java
@@ -56,13 +56,13 @@ class AbstractE2ETest {
 
     static Locator controlPanelDetails(final Page page, final String name) {
         return page
-            .locator(".cp-panel-card")
+            .locator(".cp-panel-card, .card")
             .filter(
                 new Locator.FilterOptions()
-                    .setHas(page.getByRole(AriaRole.HEADING, new Page.GetByRoleOptions().setName(nameRegex(name))))
+                    .setHasText(name)
             )
-            .locator(".cp-card-footer")
-            .getByRole(AriaRole.BUTTON);
+            .locator(".cp-card-footer a, .cp-card-footer button, .card-header a, .card-header button")
+            .first();
     }
 
     static Locator categoryLink(final Page page, final String name) {

--- a/doc-examples/example-java/src/test/java/example/e2e/ControlPanelE2ETest.java
+++ b/doc-examples/example-java/src/test/java/example/e2e/ControlPanelE2ETest.java
@@ -35,6 +35,7 @@ class ControlPanelE2ETest extends AbstractE2ETest {
         assertThat(body).containsText("Control Panel");
         assertThat(body).containsText("my-application");
         assertThat(body).containsText("Application Health");
+        assertThat(body).containsText("Application Info");
         assertThat(body).containsText("Environment Properties");
         assertThat(body).containsText("Metrics");
         assertThat(body).containsText("HTTP Routes");
@@ -72,6 +73,21 @@ class ControlPanelE2ETest extends AbstractE2ETest {
         // Sensitive data is still masked
         assertThat(body(page)).containsText("test.password");
         assertThat(body(page)).containsText("*****");
+    }
+
+    @Test
+    void testApplicationInfo(Page page) {
+        page.navigate(baseUrl());
+        controlPanelDetails(page, "Application Info").click();
+
+        assertThat(body(page)).containsText("InfoEndpoint available");
+        assertThat(body(page)).containsText("Demo");
+        assertThat(body(page)).containsText("Micronaut Control Panel Example");
+        assertThat(body(page)).containsText("Local development");
+
+        page.setViewportSize(390, 844);
+        assertThat(page.locator(".cp-info-table td[data-label='Section']").first()).isVisible();
+        assertTrue((Boolean) page.evaluate("() => document.documentElement.scrollWidth <= document.documentElement.clientWidth"));
     }
 
     @Test

--- a/src/main/docs/guide/controlPanels/management.adoc
+++ b/src/main/docs/guide/controlPanels/management.adoc
@@ -14,6 +14,7 @@ dependency:io.micronaut.micrometer:micronaut-micrometer-core[scope=runtimeOnly]
 The following panels are available:
 
 * `health`: Application Health
+* `info`: Application Info
 * `env`: Environment Properties
 * `metrics`: Metrics
 * `beans`: Bean Definitions
@@ -84,6 +85,43 @@ endpoints:
 
 If you opt into `micronaut.control-panel.security.access=ANONYMOUS`, anonymous control-panel requests continue to see the
 anonymous health view.
+
+=== Application Info
+
+This panel displays application information, and relies on the
+https://docs.micronaut.io/latest/guide/#infoEndpoint[Info Endpoint] to display its information. The panel appears when
+the Info endpoint is available and can be disabled independently:
+
+.Disabling the Application Info panel
+[configuration]
+----
+micronaut:
+  control-panel:
+    panels:
+      info:
+        enabled: false
+----
+
+The Info endpoint can expose configuration-backed `info.*` values, build and git metadata, and values from custom
+`InfoSource` beans. Configure it only in environments where the Control Panel should be available:
+
+IMPORTANT: Make sure this is done in an environment-specific configuration file, for example, `application-dev.yml` or
+`application-test.yml`.
+
+.Configuring the Info Endpoint
+[configuration]
+----
+endpoints:
+  info:
+    enabled: true
+
+info:
+  app:
+    name: my-service
+    version: 1.0.0
+----
+
+The panel renders nested maps and lists from `info.*`, git/build property files, and custom `InfoSource` output.
 
 === Environment Properties
 


### PR DESCRIPTION
## Summary
- add a Micronaut Management InfoEndpoint-backed Application Info control panel with nested/custom info rendering and empty-state handling
- add panel defaults, escaped Handlebars templates, docs, and example app coverage
- keep example E2E tests on local Control Panel modules when the platform BOM also provides released Control Panel artifacts

## Issue Linkage
Paperclip issue: `DEV-333`. No linked GitHub issue exists for this Paperclip task, so this PR intentionally does not include a GitHub closing keyword.

## Tests
- `CI=true ./gradlew :micronaut-doc-examples:micronaut-example-java:test --tests 'example.e2e.ControlPanelE2ETest.testApplicationInfo' --tests 'example.e2e.ControlPanelE2ETest.testApplicationHealth'`
- `./gradlew :micronaut-control-panel-management:test --tests 'io.micronaut.controlpanel.panels.management.InfoControlPanelTest'`
- `git diff --check`

## Visual Evidence
Per the repository `CONTRIBUTING.md` requirement for Control Panel UI changes, this PR includes current screenshots captured from `doc-examples/example-java` with headless Playwright. These were refreshed after the DEV-495 UX follow-up at PR head `03861c6`.

Dashboard showing the current Application Info card:

![Current Application Info dashboard](https://raw.githubusercontent.com/micronaut-projects/micronaut-control-panel/81fe90492a793c7600bc5759457d785a9708a7e5/assets/pr-544/03861c6b0c66/dev-333-application-info-dashboard-current.png)

Application Info details view showing summary metadata, the sensitive-data warning, and configuration-backed values:

![Current Application Info details](https://raw.githubusercontent.com/micronaut-projects/micronaut-control-panel/c3c4de14ac5b8d46340d4574c14d9ded35cb191c/assets/pr-544/03861c6b0c66/dev-333-application-info-detail-current.png)

Mobile Application Info details view showing labelled rows without horizontal scrolling:

![Current Application Info mobile](https://raw.githubusercontent.com/micronaut-projects/micronaut-control-panel/911e25e2bfcbe9f7e81696494737c798b83433c0/assets/pr-544/03861c6b0c66/dev-333-application-info-mobile-current.png)

Capture verification: `CI=true ./gradlew :micronaut-doc-examples:micronaut-example-java:test --tests 'example.e2e.ApplicationInfoScreenshotTest'` passed locally on May 11, 2026 with a temporary screenshot-only test; the temporary test was removed after asset upload.

## Release Targeting
Target branch: `2.0.x` / `2.0.0` GA. QA-selected Micronaut organization projects: `5.0.0-M3` and `5.0.0 Release`. Later release boards exist, but these are the selected earliest matching boards unless maintainers retarget.

---
###### ✨ This message was AI-generated using GPT-5