### PR TITLE
docs: check contributing guidelines before PR handoff

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ This repository builds the Micronaut Control Panel libraries and example applica
 ## Contributing Guidelines
 
 - Before opening or updating a pull request, read this repository's `CONTRIBUTING.md` and follow every repo-specific PR requirement it names.
-- Treat contributor-checklist items as handoff requirements. If a requirement is not applicable, state that explicitly in the PR description or handoff note.
+- Treat requirements in `CONTRIBUTING.md` and any PR template checklist items, if present, as handoff requirements. If a requirement is not applicable, state that explicitly in the PR description or handoff note.
 - For UI-visible changes, include screenshots in the PR description as required by `CONTRIBUTING.md`; if screenshots cannot be provided, explain why and describe the browser or visual verification that was performed.
 
 ## UI Design System

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,12 @@ This repository builds the Micronaut Control Panel libraries and example applica
 - Keep controllers, panels, templates, and tests in the package/domain already used by the module.
 - Prefer targeted module tests for code changes. Run the full `check` task only when shared behavior, build logic, or cross-module contracts changed.
 
+## Contributing Guidelines
+
+- Before opening or updating a pull request, read this repository's `CONTRIBUTING.md` and follow every repo-specific PR requirement it names.
+- Treat contributor-checklist items as handoff requirements. If a requirement is not applicable, state that explicitly in the PR description or handoff note.
+- For UI-visible changes, include screenshots in the PR description as required by `CONTRIBUTING.md`; if screenshots cannot be provided, explain why and describe the browser or visual verification that was performed.
+
 ## UI Design System
 
 - The Control Panel UI follows [shadcn/ui](https://ui.shadcn.com/) component and block patterns, implemented with server-rendered Handlebars templates, static CSS, and small JavaScript helpers rather than React runtime components.


### PR DESCRIPTION
## Summary
- Add a root `AGENTS.md` check to read repository `CONTRIBUTING.md` or maintainer contribution guidance before PR handoff.
- Require agents to treat contributor checklist items as handoff requirements.
- Call out UI-visible changes so screenshots or equivalent visual evidence are included when repository guidance requires them.

## Validation
- `git diff --check`

## CI
- Commit uses `[skip ci]` because this changes only Markdown agent guidance that repository builds do not exercise.

Paperclip: DEV-349

---
###### ✨ This message was AI-generated using gpt-5.5
