### PR TITLE
fix: prefer project modules in control panel builds

### DIFF
--- a/buildSrc/src/main/kotlin/io.micronaut.build.internal.control-panel-example.gradle.kts
+++ b/buildSrc/src/main/kotlin/io.micronaut.build.internal.control-panel-example.gradle.kts
@@ -20,6 +20,10 @@ micronaut {
     testRuntime = MicronautTestRuntime.JUNIT_5
 }
 
+configurations.configureEach {
+    resolutionStrategy.preferProjectModules()
+}
+
 tasks.register<JavaExec>("playwrightCodegen") {
     mainClass.set("com.microsoft.playwright.CLI")
     classpath = sourceSets.test.get().runtimeClasspath

--- a/buildSrc/src/main/kotlin/io.micronaut.build.internal.control-panel-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/io.micronaut.build.internal.control-panel-module.gradle.kts
@@ -5,6 +5,10 @@ repositories {
     mavenCentral()
 }
 
+configurations.configureEach {
+    resolutionStrategy.preferProjectModules()
+}
+
 val mn = versionCatalogs.named("mn")
 
 dependencies {


### PR DESCRIPTION
## Summary\n- Prefer local Gradle project modules in Control Panel convention plugins\n- Prevent imported platform BOM constraints from resolving in-repo modules to the previously released 2.0.0-M2 artifacts after the branch moved to 2.0.0-SNAPSHOT\n- Fixes CI classpath mixing that caused the example UI/E2E tests to exercise stale published Control Panel modules\n\n## Verification\n- `NODE_OPTIONS= ./gradlew -q :micronaut-doc-examples:micronaut-example-java:dependencyInsight --dependency micronaut-control-panel --configuration runtimeClasspath` confirms Control Panel artifacts resolve to local projects\n- `NODE_OPTIONS= ./gradlew -q :micronaut-doc-examples:micronaut-example-java:compileTestJava :micronaut-doc-examples:micronaut-example-java:compileTestGroovy`\n- `NODE_OPTIONS= ./gradlew -q cM`\n- `NODE_OPTIONS= ./gradlew -q spotlessCheck`\n- `git diff --check`\n\n## Screenshots\nNot applicable: build logic/classpath resolution fix only; no UI-visible change.\n