### PR TITLE
Show Kafka Streams runtime state

### DIFF
--- a/control-panel-kafka/build.gradle.kts
+++ b/control-panel-kafka/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
 
     compileOnly(mnKafka.micronaut.kafka)
     compileOnly(mnKafka.micronaut.kafka.streams)
+    compileOnly(mn.micronaut.management)
 
     testImplementation(mnTest.micronaut.test.junit5)
     testImplementation(mnTest.mockito.core)
@@ -26,6 +27,7 @@ dependencies {
     testAnnotationProcessor(mn.micronaut.inject.java)
     testImplementation(mnKafka.micronaut.kafka)
     testImplementation(mnKafka.micronaut.kafka.streams)
+    testImplementation(mn.micronaut.management)
     testImplementation(mnSerde.micronaut.serde.jackson)
     testImplementation(mn.micronaut.http.server.netty)
     testImplementation(mn.micronaut.http.client)

--- a/control-panel-kafka/src/main/java/io/micronaut/controlpanel/panels/kafka/HealthKafkaStreamsRuntimeStateResolver.java
+++ b/control-panel-kafka/src/main/java/io/micronaut/controlpanel/panels/kafka/HealthKafkaStreamsRuntimeStateResolver.java
@@ -78,7 +78,7 @@ final class HealthKafkaStreamsRuntimeStateResolver implements KafkaStreamsRuntim
 
     private HealthResult readVisibleHealth() {
         Publisher<HealthResult> health = healthEndpoint.getHealth(null);
-        return health == null ? null : Mono.from(health).block();
+        return Mono.from(health).block();
     }
 
     private static HealthResult kafkaStreamsHealth(HealthResult health) {

--- a/control-panel-kafka/src/main/java/io/micronaut/controlpanel/panels/kafka/HealthKafkaStreamsRuntimeStateResolver.java
+++ b/control-panel-kafka/src/main/java/io/micronaut/controlpanel/panels/kafka/HealthKafkaStreamsRuntimeStateResolver.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.kafka;
+
+import io.micronaut.configuration.kafka.streams.ConfiguredStreamBuilder;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.health.HealthStatus;
+import io.micronaut.management.endpoint.health.HealthEndpoint;
+import io.micronaut.management.health.indicator.HealthResult;
+import jakarta.inject.Singleton;
+import org.apache.kafka.streams.StreamsConfig;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Mono;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.Set;
+
+/**
+ * Resolves Kafka Streams runtime state from the visible Micronaut Health endpoint result.
+ */
+@Internal
+@Singleton
+@Requires(classes = HealthEndpoint.class)
+@Requires(beans = HealthEndpoint.class)
+final class HealthKafkaStreamsRuntimeStateResolver implements KafkaStreamsRuntimeStateResolver {
+
+    static final String UNAVAILABLE_MESSAGE = "Runtime state is unavailable because Kafka Streams health details are hidden, disabled, or not present.";
+
+    private static final String KAFKA_STREAMS = "kafkaStreams";
+
+    private final HealthEndpoint healthEndpoint;
+
+    HealthKafkaStreamsRuntimeStateResolver(HealthEndpoint healthEndpoint) {
+        this.healthEndpoint = healthEndpoint;
+    }
+
+    @Override
+    public KafkaStreamsRuntimeState resolve(String beanName, ConfiguredStreamBuilder builder) {
+        HealthResult health = readVisibleHealth();
+        if (health == null) {
+            return KafkaStreamsRuntimeState.unavailable(UNAVAILABLE_MESSAGE);
+        }
+        return resolve(beanName, builder, health);
+    }
+
+    static KafkaStreamsRuntimeState resolve(String beanName, ConfiguredStreamBuilder builder, HealthResult health) {
+        HealthResult kafkaStreams = kafkaStreamsHealth(health);
+        if (kafkaStreams == null) {
+            return KafkaStreamsRuntimeState.unavailable(UNAVAILABLE_MESSAGE);
+        }
+        HealthResult application = applicationHealth(kafkaStreams, candidates(beanName, builder));
+        if (application == null) {
+            return KafkaStreamsRuntimeState.unavailable(UNAVAILABLE_MESSAGE);
+        }
+        return stateFromApplicationHealth(application);
+    }
+
+    private HealthResult readVisibleHealth() {
+        Publisher<HealthResult> health = healthEndpoint.getHealth(null);
+        return health == null ? null : Mono.from(health).block();
+    }
+
+    private static HealthResult kafkaStreamsHealth(HealthResult health) {
+        if (KAFKA_STREAMS.equals(normalizeKey(health.getName()))) {
+            return health;
+        }
+        Object details = health.getDetails();
+        if (details instanceof Map<?, ?> detailsMap) {
+            Object value = findValue(detailsMap, KAFKA_STREAMS);
+            if (value instanceof HealthResult result) {
+                return result;
+            }
+        }
+        return null;
+    }
+
+    private static HealthResult applicationHealth(HealthResult kafkaStreams, Set<String> candidates) {
+        Object details = kafkaStreams.getDetails();
+        if (!(details instanceof Map<?, ?> applications)) {
+            return null;
+        }
+        for (String candidate : candidates) {
+            Object value = findValue(applications, candidate);
+            if (value instanceof HealthResult result) {
+                return result;
+            }
+        }
+        return null;
+    }
+
+    private static KafkaStreamsRuntimeState stateFromApplicationHealth(HealthResult application) {
+        String status = statusName(application.getStatus());
+        Object details = application.getDetails();
+        if (!(details instanceof Map<?, ?> detailsMap)) {
+            return KafkaStreamsRuntimeState.available(status, null, List.of());
+        }
+        String message = stringValue(detailsMap.get("error"));
+        List<KafkaStreamsRuntimeState.ThreadState> threads = new ArrayList<>();
+        for (Object value : detailsMap.values()) {
+            if (value instanceof Map<?, ?> threadMap && threadMap.containsKey("threadName")) {
+                threads.add(threadState(threadMap));
+            }
+        }
+        return KafkaStreamsRuntimeState.available(status, message, threads);
+    }
+
+    private static KafkaStreamsRuntimeState.ThreadState threadState(Map<?, ?> threadMap) {
+        return new KafkaStreamsRuntimeState.ThreadState(
+                stringValue(threadMap.get("threadName")),
+                stringValue(threadMap.get("threadState")),
+                stringValue(threadMap.get("adminClientId")),
+                stringValue(threadMap.get("consumerClientId")),
+                stringValue(threadMap.get("restoreConsumerClientId")),
+                stringList(threadMap.get("producerClientIds")),
+                false,
+                taskSummary(threadMap.get("activeTasks")),
+                taskSummary(threadMap.get("standbyTasks"))
+        );
+    }
+
+    private static KafkaStreamsRuntimeState.TaskSummary taskSummary(Object value) {
+        if (!(value instanceof Map<?, ?> taskMap)) {
+            return KafkaStreamsRuntimeState.TaskSummary.empty();
+        }
+        return new KafkaStreamsRuntimeState.TaskSummary(
+                stringValue(taskMap.get("taskId")),
+                stringList(taskMap.get("partitions")),
+                false,
+                0
+        );
+    }
+
+    private static Set<String> candidates(String beanName, ConfiguredStreamBuilder builder) {
+        Properties properties = builder.getConfiguration();
+        Set<String> candidates = new LinkedHashSet<>();
+        candidates.add(properties.getProperty(StreamsConfig.APPLICATION_ID_CONFIG));
+        candidates.add(properties.getProperty(StreamsConfig.CLIENT_ID_CONFIG));
+        candidates.add(builder.getName());
+        candidates.add(beanName);
+        candidates.removeIf(value -> value == null || value.isBlank());
+        return candidates;
+    }
+
+    private static Object findValue(Map<?, ?> map, String key) {
+        for (Map.Entry<?, ?> entry : map.entrySet()) {
+            if (key.equals(normalizeKey(stringValue(entry.getKey())))) {
+                return entry.getValue();
+            }
+        }
+        return null;
+    }
+
+    private static String normalizeKey(String key) {
+        if (key == null) {
+            return null;
+        }
+        return StringUtils.trimToNull(key.endsWith("()") ? key.substring(0, key.length() - 2) : key);
+    }
+
+    private static String statusName(HealthStatus status) {
+        return status == null ? null : status.getName();
+    }
+
+    private static List<String> stringList(Object value) {
+        if (value instanceof Collection<?> collection) {
+            return collection.stream()
+                    .map(HealthKafkaStreamsRuntimeStateResolver::stringValue)
+                    .filter(Objects::nonNull)
+                    .toList();
+        }
+        String single = stringValue(value);
+        return single == null ? List.of() : List.of(single);
+    }
+
+    private static String stringValue(Object value) {
+        return value == null ? null : String.valueOf(value);
+    }
+}

--- a/control-panel-kafka/src/main/java/io/micronaut/controlpanel/panels/kafka/HealthKafkaStreamsRuntimeStateResolver.java
+++ b/control-panel-kafka/src/main/java/io/micronaut/controlpanel/panels/kafka/HealthKafkaStreamsRuntimeStateResolver.java
@@ -20,6 +20,7 @@ import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.health.HealthStatus;
+import io.micronaut.http.context.ServerRequestContext;
 import io.micronaut.management.endpoint.health.HealthEndpoint;
 import io.micronaut.management.health.indicator.HealthResult;
 import jakarta.inject.Singleton;
@@ -27,6 +28,7 @@ import org.apache.kafka.streams.StreamsConfig;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 
+import java.security.Principal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashSet;
@@ -77,7 +79,10 @@ final class HealthKafkaStreamsRuntimeStateResolver implements KafkaStreamsRuntim
     }
 
     private HealthResult readVisibleHealth() {
-        Publisher<HealthResult> health = healthEndpoint.getHealth(null);
+        Principal principal = ServerRequestContext.currentRequest()
+                .flatMap(request -> request.getUserPrincipal(Principal.class))
+                .orElse(null);
+        Publisher<HealthResult> health = healthEndpoint.getHealth(principal);
         return Mono.from(health).block();
     }
 
@@ -133,7 +138,6 @@ final class HealthKafkaStreamsRuntimeStateResolver implements KafkaStreamsRuntim
                 stringValue(threadMap.get("consumerClientId")),
                 stringValue(threadMap.get("restoreConsumerClientId")),
                 stringList(threadMap.get("producerClientIds")),
-                false,
                 taskSummary(threadMap.get("activeTasks")),
                 taskSummary(threadMap.get("standbyTasks"))
         );
@@ -143,12 +147,7 @@ final class HealthKafkaStreamsRuntimeStateResolver implements KafkaStreamsRuntim
         if (!(value instanceof Map<?, ?> taskMap)) {
             return KafkaStreamsRuntimeState.TaskSummary.empty();
         }
-        return new KafkaStreamsRuntimeState.TaskSummary(
-                stringValue(taskMap.get("taskId")),
-                stringList(taskMap.get("partitions")),
-                false,
-                0
-        );
+        return new KafkaStreamsRuntimeState.TaskSummary(stringValue(taskMap.get("taskId")), stringList(taskMap.get("partitions")));
     }
 
     private static Set<String> candidates(String beanName, ConfiguredStreamBuilder builder) {

--- a/control-panel-kafka/src/main/java/io/micronaut/controlpanel/panels/kafka/KafkaStreamsControlPanel.java
+++ b/control-panel-kafka/src/main/java/io/micronaut/controlpanel/panels/kafka/KafkaStreamsControlPanel.java
@@ -50,17 +50,22 @@ public class KafkaStreamsControlPanel extends AbstractEachBeanControlPanel<Kafka
     private static final String HTML_BREAK = "&lt;br/&gt;";
 
     private final String beanName;
-    private final Body body;
+    private final ConfiguredStreamBuilder builder;
+    private final KafkaStreamsRuntimeStateResolver runtimeStateResolver;
+    private final String mermaid;
+    private final int subTopologies;
 
     public KafkaStreamsControlPanel(@Parameter String beanName,
                                     ConfiguredStreamBuilder builder,
+                                    KafkaStreamsRuntimeStateResolver runtimeStateResolver,
                                     @Named(NAME) ControlPanelConfiguration configuration) {
         super(NAME, configuration);
         this.beanName = beanName;
+        this.builder = builder;
+        this.runtimeStateResolver = runtimeStateResolver;
         TopologyDescription description = builder.build(builder.getConfiguration()).describe();
-        String mermaid = generateMermaidFromDescription(description);
-        int subTopologies = computeSubTopologies(description);
-        this.body = new Body(mermaid, subTopologies);
+        this.mermaid = generateMermaidFromDescription(description);
+        this.subTopologies = computeSubTopologies(description);
     }
 
     @Override
@@ -75,7 +80,7 @@ public class KafkaStreamsControlPanel extends AbstractEachBeanControlPanel<Kafka
 
     @Override
     public Body getBody() {
-        return body;
+        return new Body(mermaid, subTopologies, runtimeStateResolver.resolve(beanName, builder));
     }
 
     @Override
@@ -90,7 +95,7 @@ public class KafkaStreamsControlPanel extends AbstractEachBeanControlPanel<Kafka
 
     @Override
     public String getBadge() {
-        return String.valueOf(body.subTopologies());
+        return String.valueOf(subTopologies);
     }
 
     static int computeSubTopologies(@Nullable TopologyDescription description) {
@@ -216,7 +221,8 @@ public class KafkaStreamsControlPanel extends AbstractEachBeanControlPanel<Kafka
      *
      * @param mermaid       Mermaid diagram for the topology
      * @param subTopologies count of sub-topologies
+     * @param runtimeState  Kafka Streams runtime state exposed through Micronaut Health
      */
     @ReflectiveAccess
-    public record Body(String mermaid, int subTopologies) { }
+    public record Body(String mermaid, int subTopologies, KafkaStreamsRuntimeState runtimeState) { }
 }

--- a/control-panel-kafka/src/main/java/io/micronaut/controlpanel/panels/kafka/KafkaStreamsRuntimeState.java
+++ b/control-panel-kafka/src/main/java/io/micronaut/controlpanel/panels/kafka/KafkaStreamsRuntimeState.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.kafka;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.ReflectiveAccess;
+
+import java.util.List;
+
+/**
+ * Runtime state exposed by Micronaut Health for a Kafka Streams application.
+ */
+@Internal
+@ReflectiveAccess
+public record KafkaStreamsRuntimeState(boolean available,
+                                       String status,
+                                       String message,
+                                       List<ThreadState> threads,
+                                       boolean hasThreads) {
+
+    private static final String STATUS_UNKNOWN = "UNKNOWN";
+
+    static KafkaStreamsRuntimeState unavailable(String message) {
+        return new KafkaStreamsRuntimeState(false, STATUS_UNKNOWN, message, List.of(), false);
+    }
+
+    static KafkaStreamsRuntimeState available(String status, String message, List<ThreadState> threads) {
+        List<ThreadState> threadStates = List.copyOf(threads);
+        return new KafkaStreamsRuntimeState(true, emptyToUnknown(status), message, threadStates, !threadStates.isEmpty());
+    }
+
+    private static String emptyToUnknown(String status) {
+        return status == null || status.isBlank() ? STATUS_UNKNOWN : status;
+    }
+
+    @ReflectiveAccess
+    public record ThreadState(String name,
+                              String state,
+                              String adminClientId,
+                              String consumerClientId,
+                              String restoreConsumerClientId,
+                              List<String> producerClientIds,
+                              boolean hasProducerClientIds,
+                              TaskSummary activeTasks,
+                              TaskSummary standbyTasks) {
+
+        public ThreadState {
+            producerClientIds = producerClientIds == null ? List.of() : List.copyOf(producerClientIds);
+            hasProducerClientIds = !producerClientIds.isEmpty();
+            activeTasks = activeTasks == null ? TaskSummary.empty() : activeTasks;
+            standbyTasks = standbyTasks == null ? TaskSummary.empty() : standbyTasks;
+        }
+    }
+
+    @ReflectiveAccess
+    public record TaskSummary(String taskId,
+                              List<String> partitions,
+                              boolean available,
+                              int partitionCount) {
+
+        public TaskSummary {
+            partitions = partitions == null ? List.of() : List.copyOf(partitions);
+            available = taskId != null || !partitions.isEmpty();
+            partitionCount = partitions.size();
+        }
+
+        static TaskSummary empty() {
+            return new TaskSummary(null, List.of(), false, 0);
+        }
+    }
+}

--- a/control-panel-kafka/src/main/java/io/micronaut/controlpanel/panels/kafka/KafkaStreamsRuntimeState.java
+++ b/control-panel-kafka/src/main/java/io/micronaut/controlpanel/panels/kafka/KafkaStreamsRuntimeState.java
@@ -22,6 +22,12 @@ import java.util.List;
 
 /**
  * Runtime state exposed by Micronaut Health for a Kafka Streams application.
+ *
+ * @param available whether runtime details are visible through Health
+ * @param status health status for the Kafka Streams application
+ * @param message optional runtime-state message
+ * @param threads stream thread runtime details
+ * @param hasThreads whether stream thread details are present
  */
 @Internal
 @ReflectiveAccess
@@ -46,6 +52,19 @@ public record KafkaStreamsRuntimeState(boolean available,
         return status == null || status.isBlank() ? STATUS_UNKNOWN : status;
     }
 
+    /**
+     * Runtime state for one Kafka Streams thread.
+     *
+     * @param name stream thread name
+     * @param state stream thread state
+     * @param adminClientId admin client identifier
+     * @param consumerClientId consumer client identifier
+     * @param restoreConsumerClientId restore consumer client identifier
+     * @param producerClientIds producer client identifiers
+     * @param hasProducerClientIds whether producer client identifiers are present
+     * @param activeTasks active task summary
+     * @param standbyTasks standby task summary
+     */
     @ReflectiveAccess
     public record ThreadState(String name,
                               String state,
@@ -65,6 +84,14 @@ public record KafkaStreamsRuntimeState(boolean available,
         }
     }
 
+    /**
+     * Summary of a Kafka Streams task set.
+     *
+     * @param taskId task identifier
+     * @param partitions task partitions reported by Health
+     * @param available whether task details are present
+     * @param partitionCount number of reported partitions
+     */
     @ReflectiveAccess
     public record TaskSummary(String taskId,
                               List<String> partitions,

--- a/control-panel-kafka/src/main/java/io/micronaut/controlpanel/panels/kafka/KafkaStreamsRuntimeState.java
+++ b/control-panel-kafka/src/main/java/io/micronaut/controlpanel/panels/kafka/KafkaStreamsRuntimeState.java
@@ -82,6 +82,17 @@ public record KafkaStreamsRuntimeState(boolean available,
             activeTasks = activeTasks == null ? TaskSummary.empty() : activeTasks;
             standbyTasks = standbyTasks == null ? TaskSummary.empty() : standbyTasks;
         }
+
+        ThreadState(String name,
+                    String state,
+                    String adminClientId,
+                    String consumerClientId,
+                    String restoreConsumerClientId,
+                    List<String> producerClientIds,
+                    TaskSummary activeTasks,
+                    TaskSummary standbyTasks) {
+            this(name, state, adminClientId, consumerClientId, restoreConsumerClientId, producerClientIds, false, activeTasks, standbyTasks);
+        }
     }
 
     /**
@@ -104,8 +115,12 @@ public record KafkaStreamsRuntimeState(boolean available,
             partitionCount = partitions.size();
         }
 
+        TaskSummary(String taskId, List<String> partitions) {
+            this(taskId, partitions, false, 0);
+        }
+
         static TaskSummary empty() {
-            return new TaskSummary(null, List.of(), false, 0);
+            return new TaskSummary(null, List.of());
         }
     }
 }

--- a/control-panel-kafka/src/main/java/io/micronaut/controlpanel/panels/kafka/KafkaStreamsRuntimeStateResolver.java
+++ b/control-panel-kafka/src/main/java/io/micronaut/controlpanel/panels/kafka/KafkaStreamsRuntimeStateResolver.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.kafka;
+
+import io.micronaut.configuration.kafka.streams.ConfiguredStreamBuilder;
+import io.micronaut.core.annotation.Internal;
+
+/**
+ * Resolves optional Kafka Streams runtime state for the Kafka Streams control panel.
+ */
+@Internal
+interface KafkaStreamsRuntimeStateResolver {
+
+    KafkaStreamsRuntimeState resolve(String beanName, ConfiguredStreamBuilder builder);
+}

--- a/control-panel-kafka/src/main/java/io/micronaut/controlpanel/panels/kafka/UnavailableKafkaStreamsRuntimeStateResolver.java
+++ b/control-panel-kafka/src/main/java/io/micronaut/controlpanel/panels/kafka/UnavailableKafkaStreamsRuntimeStateResolver.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.kafka;
+
+import io.micronaut.configuration.kafka.streams.ConfiguredStreamBuilder;
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Requires(missingBeans = KafkaStreamsRuntimeStateResolver.class)
+final class UnavailableKafkaStreamsRuntimeStateResolver implements KafkaStreamsRuntimeStateResolver {
+
+    @Override
+    public KafkaStreamsRuntimeState resolve(String beanName, ConfiguredStreamBuilder builder) {
+        return KafkaStreamsRuntimeState.unavailable("Runtime state is unavailable because Micronaut Health details are not visible.");
+    }
+}

--- a/control-panel-kafka/src/main/resources/views/kafka-streams/body.hbs
+++ b/control-panel-kafka/src/main/resources/views/kafka-streams/body.hbs
@@ -1,3 +1,11 @@
 <p class="card-text">
     <strong>{{badge}}</strong> sub-topologies in this Kafka Streams application.
 </p>
+<p class="card-text">
+    <strong>Runtime</strong>:
+    {{#if body.runtimeState.available}}
+        <span class="badge badge-primary">{{body.runtimeState.status}}</span>
+    {{else}}
+        <span class="badge badge-secondary">Unavailable</span>
+    {{/if}}
+</p>

--- a/control-panel-kafka/src/main/resources/views/kafka-streams/detail.hbs
+++ b/control-panel-kafka/src/main/resources/views/kafka-streams/detail.hbs
@@ -1,3 +1,68 @@
+<h5>Runtime state</h5>
+{{#if body.runtimeState.available}}
+    <p>
+        <strong>Status</strong>: <span class="badge badge-primary">{{body.runtimeState.status}}</span>
+        {{#if body.runtimeState.message}}
+            <span>{{body.runtimeState.message}}</span>
+        {{/if}}
+    </p>
+    {{#if body.runtimeState.hasThreads}}
+        <ul>
+        {{#each body.runtimeState.threads as |thread|}}
+            <li title="{{thread.name}}">
+                <strong>Thread</strong>:
+                <code>{{abbreviate thread.name 50}}</code> <span class="badge badge-primary">{{thread.state}}</span>
+            </li>
+            <ul>
+                {{#if thread.adminClientId}}
+                    <li title="{{thread.adminClientId}}"><strong>Admin Client ID</strong>: <code>{{abbreviate thread.adminClientId 40}}</code></li>
+                {{/if}}
+                {{#if thread.consumerClientId}}
+                    <li title="{{thread.consumerClientId}}"><strong>Consumer Client ID</strong>: <code>{{abbreviate thread.consumerClientId 40}}</code></li>
+                {{/if}}
+                {{#if thread.restoreConsumerClientId}}
+                    <li title="{{thread.restoreConsumerClientId}}"><strong>Restore Consumer Client ID</strong>: <code>{{abbreviate thread.restoreConsumerClientId 40}}</code></li>
+                {{/if}}
+                {{#if thread.hasProducerClientIds}}
+                    <li><strong>Producer Client IDs</strong>:</li>
+                    <ul>
+                        {{#each thread.producerClientIds as |producerClientId|}}
+                            <li title="{{producerClientId}}"><code>{{abbreviate producerClientId 30}}</code></li>
+                        {{/each}}
+                    </ul>
+                {{/if}}
+                <li><strong>Active tasks</strong>:</li>
+                {{#if thread.activeTasks.available}}
+                    <ul>
+                        {{#if thread.activeTasks.taskId}}
+                            <li><strong>Task ID</strong>: <code>{{thread.activeTasks.taskId}}</code></li>
+                        {{/if}}
+                        <li><strong>Partition/topic</strong>: {{thread.activeTasks.partitionCount}}</li>
+                    </ul>
+                {{else}}
+                    <p>No active task information reported.</p>
+                {{/if}}
+                <li><strong>Stand-by tasks</strong>:</li>
+                {{#if thread.standbyTasks.available}}
+                    <ul>
+                        {{#if thread.standbyTasks.taskId}}
+                            <li><strong>Task ID</strong>: <code>{{thread.standbyTasks.taskId}}</code></li>
+                        {{/if}}
+                        <li><strong>Partition/topic</strong>: {{thread.standbyTasks.partitionCount}}</li>
+                    </ul>
+                {{else}}
+                    <p>No standby task information reported.</p>
+                {{/if}}
+            </ul>
+        {{/each}}
+        </ul>
+    {{else}}
+        <p>No stream thread details are available for this Kafka Streams application.</p>
+    {{/if}}
+{{else}}
+    <p>{{body.runtimeState.message}}</p>
+{{/if}}
+
 <h5>Kafka Streams Topology</h5>
 <pre id="kafkaStreamsMermaidCode" style="display:none;">{{{ body.mermaid }}}</pre>
 <div id="kafkaStreamsDiagram" class="mermaid"></div>

--- a/control-panel-kafka/src/main/resources/views/kafka-streams/detail.hbs
+++ b/control-panel-kafka/src/main/resources/views/kafka-streams/detail.hbs
@@ -12,48 +12,54 @@
             <li title="{{thread.name}}">
                 <strong>Thread</strong>:
                 <code>{{abbreviate thread.name 50}}</code> <span class="badge badge-primary">{{thread.state}}</span>
+                <ul>
+                    {{#if thread.adminClientId}}
+                        <li title="{{thread.adminClientId}}"><strong>Admin Client ID</strong>: <code>{{abbreviate thread.adminClientId 40}}</code></li>
+                    {{/if}}
+                    {{#if thread.consumerClientId}}
+                        <li title="{{thread.consumerClientId}}"><strong>Consumer Client ID</strong>: <code>{{abbreviate thread.consumerClientId 40}}</code></li>
+                    {{/if}}
+                    {{#if thread.restoreConsumerClientId}}
+                        <li title="{{thread.restoreConsumerClientId}}"><strong>Restore Consumer Client ID</strong>: <code>{{abbreviate thread.restoreConsumerClientId 40}}</code></li>
+                    {{/if}}
+                    {{#if thread.hasProducerClientIds}}
+                        <li>
+                            <strong>Producer Client IDs</strong>:
+                            <ul>
+                                {{#each thread.producerClientIds as |producerClientId|}}
+                                    <li title="{{producerClientId}}"><code>{{abbreviate producerClientId 30}}</code></li>
+                                {{/each}}
+                            </ul>
+                        </li>
+                    {{/if}}
+                    <li>
+                        <strong>Active tasks</strong>:
+                        {{#if thread.activeTasks.available}}
+                            <ul>
+                                {{#if thread.activeTasks.taskId}}
+                                    <li><strong>Task ID</strong>: <code>{{thread.activeTasks.taskId}}</code></li>
+                                {{/if}}
+                                <li><strong>Partition/topic</strong>: {{thread.activeTasks.partitionCount}}</li>
+                            </ul>
+                        {{else}}
+                            <span>No active task information reported.</span>
+                        {{/if}}
+                    </li>
+                    <li>
+                        <strong>Stand-by tasks</strong>:
+                        {{#if thread.standbyTasks.available}}
+                            <ul>
+                                {{#if thread.standbyTasks.taskId}}
+                                    <li><strong>Task ID</strong>: <code>{{thread.standbyTasks.taskId}}</code></li>
+                                {{/if}}
+                                <li><strong>Partition/topic</strong>: {{thread.standbyTasks.partitionCount}}</li>
+                            </ul>
+                        {{else}}
+                            <span>No standby task information reported.</span>
+                        {{/if}}
+                    </li>
+                </ul>
             </li>
-            <ul>
-                {{#if thread.adminClientId}}
-                    <li title="{{thread.adminClientId}}"><strong>Admin Client ID</strong>: <code>{{abbreviate thread.adminClientId 40}}</code></li>
-                {{/if}}
-                {{#if thread.consumerClientId}}
-                    <li title="{{thread.consumerClientId}}"><strong>Consumer Client ID</strong>: <code>{{abbreviate thread.consumerClientId 40}}</code></li>
-                {{/if}}
-                {{#if thread.restoreConsumerClientId}}
-                    <li title="{{thread.restoreConsumerClientId}}"><strong>Restore Consumer Client ID</strong>: <code>{{abbreviate thread.restoreConsumerClientId 40}}</code></li>
-                {{/if}}
-                {{#if thread.hasProducerClientIds}}
-                    <li><strong>Producer Client IDs</strong>:</li>
-                    <ul>
-                        {{#each thread.producerClientIds as |producerClientId|}}
-                            <li title="{{producerClientId}}"><code>{{abbreviate producerClientId 30}}</code></li>
-                        {{/each}}
-                    </ul>
-                {{/if}}
-                <li><strong>Active tasks</strong>:</li>
-                {{#if thread.activeTasks.available}}
-                    <ul>
-                        {{#if thread.activeTasks.taskId}}
-                            <li><strong>Task ID</strong>: <code>{{thread.activeTasks.taskId}}</code></li>
-                        {{/if}}
-                        <li><strong>Partition/topic</strong>: {{thread.activeTasks.partitionCount}}</li>
-                    </ul>
-                {{else}}
-                    <p>No active task information reported.</p>
-                {{/if}}
-                <li><strong>Stand-by tasks</strong>:</li>
-                {{#if thread.standbyTasks.available}}
-                    <ul>
-                        {{#if thread.standbyTasks.taskId}}
-                            <li><strong>Task ID</strong>: <code>{{thread.standbyTasks.taskId}}</code></li>
-                        {{/if}}
-                        <li><strong>Partition/topic</strong>: {{thread.standbyTasks.partitionCount}}</li>
-                    </ul>
-                {{else}}
-                    <p>No standby task information reported.</p>
-                {{/if}}
-            </ul>
         {{/each}}
         </ul>
     {{else}}

--- a/control-panel-kafka/src/test/java/io/micronaut/controlpanel/panels/kafka/KafkaStreamsControlPanelTest.java
+++ b/control-panel-kafka/src/test/java/io/micronaut/controlpanel/panels/kafka/KafkaStreamsControlPanelTest.java
@@ -28,11 +28,14 @@ import org.apache.kafka.streams.state.Stores;
 import io.micronaut.configuration.kafka.streams.ConfiguredStreamBuilder;
 import io.micronaut.controlpanel.core.config.ControlPanelConfiguration;
 import io.micronaut.health.HealthStatus;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.context.ServerRequestContext;
 import io.micronaut.management.endpoint.health.HealthEndpoint;
 import io.micronaut.management.health.indicator.HealthResult;
 import org.mockito.Mockito;
 import reactor.core.publisher.Mono;
 
+import java.security.Principal;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -266,6 +269,32 @@ final class KafkaStreamsControlPanelTest {
     }
 
     @Test
+    void testRuntimeStateUsesCurrentRequestPrincipalForHealthDetails() {
+        ConfiguredStreamBuilder builder = configuredStreamBuilder("orders-streams", "orders-client");
+        HealthResult health = HealthResult.builder("composite", HealthStatus.UP)
+                .details(Map.of(
+                        "kafkaStreams", HealthResult.builder("kafkaStreams", HealthStatus.UP)
+                                .details(Map.of("orders-streams", HealthResult.builder("orders-streams", HealthStatus.UP).build()))
+                                .build()
+                ))
+                .build();
+        Principal principal = () -> "sherlock";
+        HealthEndpoint endpoint = Mockito.mock(HealthEndpoint.class);
+        Mockito.when(endpoint.getHealth(principal)).thenReturn(Mono.just(health));
+        HttpRequest<?> request = HttpRequest.GET("/control-panel/kafka-streams/default");
+        request.setUserPrincipal(principal);
+
+        KafkaStreamsRuntimeState state = ServerRequestContext.with(
+                request,
+                (java.util.function.Supplier<KafkaStreamsRuntimeState>) () ->
+                        new HealthKafkaStreamsRuntimeStateResolver(endpoint).resolve("default", builder)
+        );
+
+        Assertions.assertTrue(state.available());
+        Mockito.verify(endpoint).getHealth(principal);
+    }
+
+    @Test
     void testRuntimeStateMatchesClientIdAndNormalizedHealthKeys() {
         ConfiguredStreamBuilder builder = configuredStreamBuilder("orders-streams", "orders-client");
         HealthResult health = HealthResult.builder("kafkaStreams()", HealthStatus.DOWN)
@@ -371,7 +400,6 @@ final class KafkaStreamsControlPanelTest {
                 null,
                 null,
                 null,
-                false,
                 null,
                 null
         );

--- a/control-panel-kafka/src/test/java/io/micronaut/controlpanel/panels/kafka/KafkaStreamsControlPanelTest.java
+++ b/control-panel-kafka/src/test/java/io/micronaut/controlpanel/panels/kafka/KafkaStreamsControlPanelTest.java
@@ -12,9 +12,11 @@ package io.micronaut.controlpanel.panels.kafka;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.TopologyDescription;
 import org.apache.kafka.streams.processor.RecordContext;
+import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.TopicNameExtractor;
 import org.apache.kafka.streams.processor.api.Processor;
 import org.apache.kafka.streams.processor.api.ProcessorContext;
@@ -23,6 +25,13 @@ import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.Stores;
+import io.micronaut.configuration.kafka.streams.ConfiguredStreamBuilder;
+import io.micronaut.health.HealthStatus;
+import io.micronaut.management.health.indicator.HealthResult;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 
 final class KafkaStreamsControlPanelTest {
 
@@ -173,6 +182,69 @@ final class KafkaStreamsControlPanelTest {
     }
 
     @Test
+    void testRuntimeStateMapsVisibleKafkaStreamsHealthDetails() {
+        ConfiguredStreamBuilder builder = configuredStreamBuilder("orders-streams", "orders-client");
+        HealthResult health = HealthResult.builder("composite", HealthStatus.UP)
+                .details(Map.of(
+                        "kafkaStreams", HealthResult.builder("kafkaStreams", HealthStatus.UP)
+                                .details(Map.of(
+                                        "orders-streams", HealthResult.builder("orders-streams", HealthStatus.UP)
+                                                .details(Map.of(
+                                                        "orders-thread-1", Map.of(
+                                                                "threadName", "orders-thread-1",
+                                                                "threadState", "RUNNING",
+                                                                "adminClientId", "orders-admin",
+                                                                "consumerClientId", "orders-consumer",
+                                                                "restoreConsumerClientId", "orders-restore",
+                                                                "producerClientIds", List.of("orders-producer-1", "orders-producer-2"),
+                                                                "activeTasks", Map.of(
+                                                                        "taskId", new TaskId(0, 1),
+                                                                        "partitions", List.of("orders-0", "orders-1")
+                                                                ),
+                                                                "standbyTasks", Map.of(
+                                                                        "taskId", new TaskId(1, 0),
+                                                                        "partitions", List.of("orders-standby-0")
+                                                                )
+                                                        )
+                                                ))
+                                                .build()
+                                ))
+                                .build()
+                ))
+                .build();
+
+        KafkaStreamsRuntimeState state = HealthKafkaStreamsRuntimeStateResolver.resolve("default", builder, health);
+
+        Assertions.assertTrue(state.available());
+        Assertions.assertEquals("UP", state.status());
+        Assertions.assertEquals(1, state.threads().size());
+        KafkaStreamsRuntimeState.ThreadState thread = state.threads().getFirst();
+        Assertions.assertEquals("orders-thread-1", thread.name());
+        Assertions.assertEquals("RUNNING", thread.state());
+        Assertions.assertEquals("orders-admin", thread.adminClientId());
+        Assertions.assertEquals("orders-consumer", thread.consumerClientId());
+        Assertions.assertEquals("orders-restore", thread.restoreConsumerClientId());
+        Assertions.assertEquals(List.of("orders-producer-1", "orders-producer-2"), thread.producerClientIds());
+        Assertions.assertEquals("0_1", thread.activeTasks().taskId());
+        Assertions.assertEquals(2, thread.activeTasks().partitionCount());
+        Assertions.assertEquals("1_0", thread.standbyTasks().taskId());
+        Assertions.assertEquals(1, thread.standbyTasks().partitionCount());
+    }
+
+    @Test
+    void testRuntimeStateUnavailableWhenHealthDetailsAreAbsent() {
+        ConfiguredStreamBuilder builder = configuredStreamBuilder("orders-streams", "orders-client");
+        HealthResult health = HealthResult.builder("composite", HealthStatus.UP).build();
+
+        KafkaStreamsRuntimeState state = HealthKafkaStreamsRuntimeStateResolver.resolve("default", builder, health);
+
+        Assertions.assertFalse(state.available());
+        Assertions.assertEquals("UNKNOWN", state.status());
+        Assertions.assertTrue(state.threads().isEmpty());
+        Assertions.assertEquals(HealthKafkaStreamsRuntimeStateResolver.UNAVAILABLE_MESSAGE, state.message());
+    }
+
+    @Test
     void testHyphenLabelBreaks() {
         Topology topology = new Topology();
         topology.addSource("KSTREAM-SOURCE-0", "a-b");
@@ -209,5 +281,13 @@ final class KafkaStreamsControlPanelTest {
                 Serdes.String()
         );
         topology.addStateStore(storeBuilder, processors);
+    }
+
+    private static ConfiguredStreamBuilder configuredStreamBuilder(String applicationId, String clientId) {
+        Properties properties = new Properties();
+        properties.setProperty(StreamsConfig.APPLICATION_ID_CONFIG, applicationId);
+        properties.setProperty(StreamsConfig.CLIENT_ID_CONFIG, clientId);
+        properties.setProperty(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        return new ConfiguredStreamBuilder(properties);
     }
 }

--- a/control-panel-kafka/src/test/java/io/micronaut/controlpanel/panels/kafka/KafkaStreamsControlPanelTest.java
+++ b/control-panel-kafka/src/test/java/io/micronaut/controlpanel/panels/kafka/KafkaStreamsControlPanelTest.java
@@ -26,12 +26,17 @@ import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.Stores;
 import io.micronaut.configuration.kafka.streams.ConfiguredStreamBuilder;
+import io.micronaut.controlpanel.core.config.ControlPanelConfiguration;
 import io.micronaut.health.HealthStatus;
+import io.micronaut.management.endpoint.health.HealthEndpoint;
 import io.micronaut.management.health.indicator.HealthResult;
+import org.mockito.Mockito;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
 
 final class KafkaStreamsControlPanelTest {
 
@@ -232,6 +237,86 @@ final class KafkaStreamsControlPanelTest {
     }
 
     @Test
+    void testRuntimeStateReadsVisibleHealthEndpointDetails() {
+        ConfiguredStreamBuilder builder = configuredStreamBuilder("orders-streams", "orders-client");
+        HealthResult health = HealthResult.builder("composite", HealthStatus.UP)
+                .details(Map.of(
+                        "kafkaStreams", HealthResult.builder("kafkaStreams", HealthStatus.UP)
+                                .details(Map.of(
+                                        "orders-streams", HealthResult.builder("orders-streams", HealthStatus.UP)
+                                                .details(Map.of(
+                                                        "orders-thread-1", Map.of(
+                                                                "threadName", "orders-thread-1",
+                                                                "threadState", "RUNNING"
+                                                        )
+                                                ))
+                                                .build()
+                                ))
+                                .build()
+                ))
+                .build();
+        HealthEndpoint endpoint = Mockito.mock(HealthEndpoint.class);
+        Mockito.when(endpoint.getHealth(null)).thenReturn(Mono.just(health));
+
+        KafkaStreamsRuntimeState state = new HealthKafkaStreamsRuntimeStateResolver(endpoint).resolve("default", builder);
+
+        Assertions.assertTrue(state.available());
+        Assertions.assertEquals("UP", state.status());
+        Assertions.assertEquals("orders-thread-1", state.threads().getFirst().name());
+    }
+
+    @Test
+    void testRuntimeStateMatchesClientIdAndNormalizedHealthKeys() {
+        ConfiguredStreamBuilder builder = configuredStreamBuilder("orders-streams", "orders-client");
+        HealthResult health = HealthResult.builder("kafkaStreams()", HealthStatus.DOWN)
+                .details(Map.of(
+                        "orders-client()", HealthResult.builder("orders-client", HealthStatus.DOWN)
+                                .details(Map.of("error", "thread stopped"))
+                                .build()
+                ))
+                .build();
+
+        KafkaStreamsRuntimeState state = HealthKafkaStreamsRuntimeStateResolver.resolve("default", builder, health);
+
+        Assertions.assertTrue(state.available());
+        Assertions.assertEquals("DOWN", state.status());
+        Assertions.assertEquals("thread stopped", state.message());
+        Assertions.assertFalse(state.hasThreads());
+    }
+
+    @Test
+    void testRuntimeStateHandlesPartialThreadDetailsDefensively() {
+        ConfiguredStreamBuilder builder = configuredStreamBuilder("orders-streams", "orders-client");
+        HealthResult health = HealthResult.builder("composite", HealthStatus.UP)
+                .details(Map.of(
+                        "kafkaStreams", HealthResult.builder("kafkaStreams", HealthStatus.UP)
+                                .details(Map.of(
+                                        "default", HealthResult.builder("default", HealthStatus.UP)
+                                                .details(Map.of(
+                                                        "orders-thread-1", Map.of(
+                                                                "threadName", "orders-thread-1",
+                                                                "threadState", "REBALANCING",
+                                                                "producerClientIds", "orders-producer",
+                                                                "activeTasks", "unexpected",
+                                                                "standbyTasks", Map.of("partitions", "orders-0")
+                                                        )
+                                                ))
+                                                .build()
+                                ))
+                                .build()
+                ))
+                .build();
+
+        KafkaStreamsRuntimeState state = HealthKafkaStreamsRuntimeStateResolver.resolve("default", builder, health);
+
+        KafkaStreamsRuntimeState.ThreadState thread = state.threads().getFirst();
+        Assertions.assertEquals(List.of("orders-producer"), thread.producerClientIds());
+        Assertions.assertFalse(thread.activeTasks().available());
+        Assertions.assertTrue(thread.standbyTasks().available());
+        Assertions.assertEquals(1, thread.standbyTasks().partitionCount());
+    }
+
+    @Test
     void testRuntimeStateUnavailableWhenHealthDetailsAreAbsent() {
         ConfiguredStreamBuilder builder = configuredStreamBuilder("orders-streams", "orders-client");
         HealthResult health = HealthResult.builder("composite", HealthStatus.UP).build();
@@ -242,6 +327,62 @@ final class KafkaStreamsControlPanelTest {
         Assertions.assertEquals("UNKNOWN", state.status());
         Assertions.assertTrue(state.threads().isEmpty());
         Assertions.assertEquals(HealthKafkaStreamsRuntimeStateResolver.UNAVAILABLE_MESSAGE, state.message());
+    }
+
+    @Test
+    void testUnavailableRuntimeStateResolverReturnsUnavailableState() {
+        KafkaStreamsRuntimeState state = new UnavailableKafkaStreamsRuntimeStateResolver()
+                .resolve("default", configuredStreamBuilder("orders-streams", "orders-client"));
+
+        Assertions.assertFalse(state.available());
+        Assertions.assertEquals("UNKNOWN", state.status());
+        Assertions.assertEquals("Runtime state is unavailable because Micronaut Health details are not visible.", state.message());
+    }
+
+    @Test
+    void testControlPanelResolvesRuntimeStateForEachBodyCall() {
+        AtomicInteger calls = new AtomicInteger();
+        ConfiguredStreamBuilder builder = configuredStreamBuilder("orders-streams", "orders-client");
+        KafkaStreamsRuntimeStateResolver resolver = (beanName, streamBuilder) ->
+                KafkaStreamsRuntimeState.available("UP-" + calls.incrementAndGet(), null, List.of());
+        KafkaStreamsControlPanel panel = new KafkaStreamsControlPanel(
+                "default",
+                builder,
+                resolver,
+                new ControlPanelConfiguration(KafkaStreamsControlPanel.NAME)
+        );
+
+        KafkaStreamsControlPanel.Body first = panel.getBody();
+        KafkaStreamsControlPanel.Body second = panel.getBody();
+
+        Assertions.assertEquals("Kafka Streams: default", panel.getTitle());
+        Assertions.assertEquals("0", panel.getBadge());
+        Assertions.assertEquals("UP-1", first.runtimeState().status());
+        Assertions.assertEquals("UP-2", second.runtimeState().status());
+        Assertions.assertEquals("flowchart LR\nEMPTY[No topology detected]", first.mermaid());
+    }
+
+    @Test
+    void testRuntimeStateModelNormalizesNullCollectionsAndBlankStatus() {
+        KafkaStreamsRuntimeState.ThreadState thread = new KafkaStreamsRuntimeState.ThreadState(
+                "orders-thread-1",
+                "RUNNING",
+                null,
+                null,
+                null,
+                null,
+                false,
+                null,
+                null
+        );
+
+        KafkaStreamsRuntimeState state = KafkaStreamsRuntimeState.available(" ", null, List.of(thread));
+
+        Assertions.assertEquals("UNKNOWN", state.status());
+        Assertions.assertTrue(state.hasThreads());
+        Assertions.assertFalse(thread.hasProducerClientIds());
+        Assertions.assertFalse(thread.activeTasks().available());
+        Assertions.assertFalse(thread.standbyTasks().available());
     }
 
     @Test

--- a/src/main/docs/guide/controlPanels/kafka.adoc
+++ b/src/main/docs/guide/controlPanels/kafka.adoc
@@ -6,6 +6,7 @@ Features include:
 
 * Visualize the stream processing topology using Mermaid diagrams.
 * View the number of sub-topologies as a badge.
+* View Kafka Streams runtime state when Micronaut Management exposes Kafka Streams health details.
 * Automatically generated from the configured `ConfiguredStreamBuilder` beans.
 
 To get started, add the following module as a development-time dependency:
@@ -30,3 +31,25 @@ micronaut:
       kafka-streams:
         enabled: false
 ----
+
+=== Runtime State
+
+The Kafka Streams panel always renders the topology from the configured `ConfiguredStreamBuilder`.
+When Micronaut Management and the Micronaut Kafka Streams health indicator expose details to the current Control Panel request path, the detail page also shows runtime state for the matching Kafka Streams application.
+The runtime section includes the health status, stream thread names and states, client IDs, producer client IDs, and active or standby task information when those values are present in the Health endpoint response.
+
+Runtime state is optional.
+If Health details are hidden, disabled, or unavailable, the Kafka Streams panel still renders the topology diagram and shows an unavailable runtime-state message.
+The Kafka panel only reads the visible `HealthEndpoint` result; it does not query Kafka brokers directly or bypass Health endpoint detail visibility.
+
+For local development, enable Health details in the environment where the Control Panel is available:
+
+[configuration]
+----
+endpoints:
+  health:
+    details-visible: ANONYMOUS
+----
+
+Only expose anonymous Health details in development or another trusted environment-specific configuration.
+The runtime-state section is intended for quick development diagnostics and is not a replacement for Micrometer metrics, consumer lag monitoring, or a full Kafka monitoring product.

--- a/src/main/docs/guide/controlPanels/kafka.adoc
+++ b/src/main/docs/guide/controlPanels/kafka.adoc
@@ -40,16 +40,17 @@ The runtime section includes the health status, stream thread names and states, 
 
 Runtime state is optional.
 If Health details are hidden, disabled, or unavailable, the Kafka Streams panel still renders the topology diagram and shows an unavailable runtime-state message.
-The Kafka panel only reads the visible `HealthEndpoint` result; it does not query Kafka brokers directly or bypass Health endpoint detail visibility.
+The Kafka Streams panel only reads the visible `HealthEndpoint` result; it does not query Kafka brokers directly or bypass Health endpoint detail visibility.
 
-For local development, enable Health details in the environment where the Control Panel is available:
+For local development with an authenticated Control Panel, authenticated Health details can be shown to authenticated users:
 
 [configuration]
 ----
 endpoints:
   health:
-    details-visible: ANONYMOUS
+    details-visible: AUTHENTICATED
 ----
 
+If the Control Panel itself is intentionally anonymous in a trusted local environment, use `ANONYMOUS` instead.
 Only expose anonymous Health details in development or another trusted environment-specific configuration.
 The runtime-state section is intended for quick development diagnostics and is not a replacement for Micrometer metrics, consumer lag monitoring, or a full Kafka monitoring product.


### PR DESCRIPTION
## Summary

- Add optional Kafka Streams runtime state sourced from visible Micronaut Health details.
- Render compact runtime status on the Kafka Streams card and status/thread/client/task details on the detail view while preserving the Mermaid topology.
- Document Health detail prerequisites, authenticated/anonymous development configuration, fallback behavior, and the metrics/lag-monitoring non-goal.

## Issue Linkage

Paperclip issue: DEV-371.

No linked GitHub issue exists for this Paperclip issue, so there is no GitHub closing keyword or issue-author reviewer to apply.

## Verification

- `./gradlew :micronaut-control-panel-kafka:check --rerun-tasks` (18 tests)
- `./gradlew :micronaut-control-panel-kafka:test --rerun-tasks` (18 tests)
- `./gradlew :micronaut-control-panel-kafka:checkstyleMain --rerun-tasks`
- `./gradlew spotlessCheck`
- `./gradlew docs`
- `git diff --check origin/2.0.x...HEAD`

## UI Evidence

![Kafka Streams runtime-state UI evidence](https://raw.githubusercontent.com/micronaut-projects/micronaut-control-panel/9f0594a0bc80fc09673c6a764cf4a33c670529e1/assets/pr-548/2603b53aca84/kafka-streams-runtime-state-evidence.png)

Targeted static render showing the new Kafka Streams runtime status, thread/client/task details, topology section, and unavailable fallback.

## Release Metadata

- Label: `type: enhancement`
- Target branch: `2.0.x`
- Organization projects: `5.0.0-M3` and `5.0.0 Release`
- Ambiguity note: Control Panel targets `2.0.0`, while open Micronaut organization projects are platform-release boards; because this branch is already on Micronaut 5-era dependencies, the best-fit project set is the open 5.0.0 prerelease/GA boards.

---
###### ✨ This message was AI-generated using gpt-5
