### PR TITLE
Refine Kafka Streams runtime state UI

### DIFF
--- a/control-panel-kafka/src/main/java/io/micronaut/controlpanel/panels/kafka/KafkaStreamsRuntimeState.java
+++ b/control-panel-kafka/src/main/java/io/micronaut/controlpanel/panels/kafka/KafkaStreamsRuntimeState.java
@@ -55,8 +55,7 @@ public record KafkaStreamsRuntimeState(boolean available,
     public String statusBadgeClass() {
         return switch (emptyToUnknown(status).toUpperCase(Locale.ROOT)) {
             case "UP" -> "cp-kafka-badge-success";
-            case "DOWN" -> "badge-destructive";
-            case "OUT_OF_SERVICE" -> "cp-kafka-badge-warning";
+            case "DOWN", "OUT_OF_SERVICE" -> "badge-destructive";
             default -> "badge-secondary";
         };
     }

--- a/control-panel-kafka/src/main/java/io/micronaut/controlpanel/panels/kafka/KafkaStreamsRuntimeState.java
+++ b/control-panel-kafka/src/main/java/io/micronaut/controlpanel/panels/kafka/KafkaStreamsRuntimeState.java
@@ -39,6 +39,10 @@ public record KafkaStreamsRuntimeState(boolean available,
                                        boolean hasThreads) {
 
     private static final String STATUS_UNKNOWN = "UNKNOWN";
+    private static final String BADGE_SECONDARY = "badge-secondary";
+    private static final String BADGE_DESTRUCTIVE = "badge-destructive";
+    private static final String BADGE_SUCCESS = "cp-kafka-badge-success";
+    private static final String BADGE_WARNING = "cp-kafka-badge-warning";
 
     static KafkaStreamsRuntimeState unavailable(String message) {
         return new KafkaStreamsRuntimeState(false, STATUS_UNKNOWN, message, List.of(), false);
@@ -54,9 +58,9 @@ public record KafkaStreamsRuntimeState(boolean available,
      */
     public String statusBadgeClass() {
         return switch (emptyToUnknown(status).toUpperCase(Locale.ROOT)) {
-            case "UP" -> "cp-kafka-badge-success";
-            case "DOWN", "OUT_OF_SERVICE" -> "badge-destructive";
-            default -> "badge-secondary";
+            case "UP" -> BADGE_SUCCESS;
+            case "DOWN", "OUT_OF_SERVICE" -> BADGE_DESTRUCTIVE;
+            default -> BADGE_SECONDARY;
         };
     }
 
@@ -128,13 +132,13 @@ public record KafkaStreamsRuntimeState(boolean available,
          */
         public String stateBadgeClass() {
             if (state == null) {
-                return "badge-secondary";
+                return BADGE_SECONDARY;
             }
             return switch (state.toUpperCase(Locale.ROOT)) {
-                case "RUNNING" -> "cp-kafka-badge-success";
-                case "DEAD", "ERROR", "PENDING_SHUTDOWN" -> "badge-destructive";
-                case "CREATED", "STARTING", "PARTITIONS_ASSIGNED", "PARTITIONS_REVOKED", "REBALANCING" -> "cp-kafka-badge-warning";
-                default -> "badge-secondary";
+                case "RUNNING" -> BADGE_SUCCESS;
+                case "DEAD", "ERROR", "PENDING_SHUTDOWN" -> BADGE_DESTRUCTIVE;
+                case "CREATED", "STARTING", "PARTITIONS_ASSIGNED", "PARTITIONS_REVOKED", "REBALANCING" -> BADGE_WARNING;
+                default -> BADGE_SECONDARY;
             };
         }
     }

--- a/control-panel-kafka/src/main/java/io/micronaut/controlpanel/panels/kafka/KafkaStreamsRuntimeState.java
+++ b/control-panel-kafka/src/main/java/io/micronaut/controlpanel/panels/kafka/KafkaStreamsRuntimeState.java
@@ -19,6 +19,7 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.ReflectiveAccess;
 
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Runtime state exposed by Micronaut Health for a Kafka Streams application.
@@ -46,6 +47,35 @@ public record KafkaStreamsRuntimeState(boolean available,
     static KafkaStreamsRuntimeState available(String status, String message, List<ThreadState> threads) {
         List<ThreadState> threadStates = List.copyOf(threads);
         return new KafkaStreamsRuntimeState(true, emptyToUnknown(status), message, threadStates, !threadStates.isEmpty());
+    }
+
+    /**
+     * @return badge class for the overall runtime status
+     */
+    public String statusBadgeClass() {
+        return switch (emptyToUnknown(status).toUpperCase(Locale.ROOT)) {
+            case "UP" -> "cp-kafka-badge-success";
+            case "DOWN" -> "badge-destructive";
+            case "OUT_OF_SERVICE" -> "cp-kafka-badge-warning";
+            default -> "badge-secondary";
+        };
+    }
+
+    /**
+     * @return state class for runtime section rendering
+     */
+    public String sectionStateClass() {
+        if (!available) {
+            return "cp-kafka-runtime--unavailable";
+        }
+        return errorState() ? "cp-kafka-runtime--error" : "cp-kafka-runtime--available";
+    }
+
+    /**
+     * @return whether Health reports a non-healthy status for this Kafka Streams application
+     */
+    public boolean errorState() {
+        return available && ("DOWN".equalsIgnoreCase(status) || "OUT_OF_SERVICE".equalsIgnoreCase(status));
     }
 
     private static String emptyToUnknown(String status) {
@@ -92,6 +122,21 @@ public record KafkaStreamsRuntimeState(boolean available,
                     TaskSummary activeTasks,
                     TaskSummary standbyTasks) {
             this(name, state, adminClientId, consumerClientId, restoreConsumerClientId, producerClientIds, false, activeTasks, standbyTasks);
+        }
+
+        /**
+         * @return badge class for the stream thread state
+         */
+        public String stateBadgeClass() {
+            if (state == null) {
+                return "badge-secondary";
+            }
+            return switch (state.toUpperCase(Locale.ROOT)) {
+                case "RUNNING" -> "cp-kafka-badge-success";
+                case "DEAD", "ERROR", "PENDING_SHUTDOWN" -> "badge-destructive";
+                case "CREATED", "STARTING", "PARTITIONS_ASSIGNED", "PARTITIONS_REVOKED", "REBALANCING" -> "cp-kafka-badge-warning";
+                default -> "badge-secondary";
+            };
         }
     }
 

--- a/control-panel-kafka/src/main/resources/views/kafka-streams/body.hbs
+++ b/control-panel-kafka/src/main/resources/views/kafka-streams/body.hbs
@@ -1,11 +1,15 @@
-<p class="card-text">
-    <strong>{{badge}}</strong> sub-topologies in this Kafka Streams application.
-</p>
-<p class="card-text">
-    <strong>Runtime</strong>:
-    {{#if body.runtimeState.available}}
-        <span class="badge badge-primary">{{body.runtimeState.status}}</span>
-    {{else}}
-        <span class="badge badge-secondary">Unavailable</span>
-    {{/if}}
-</p>
+<div class="cp-kafka-card-summary">
+    <div class="cp-kafka-card-metric">
+        <span class="cp-kafka-card-label">Topology</span>
+        <strong>{{badge}}</strong>
+        <span>sub-topologies</span>
+    </div>
+    <div class="cp-kafka-card-metric">
+        <span class="cp-kafka-card-label">Runtime</span>
+        {{#if body.runtimeState.available}}
+            <span class="badge {{body.runtimeState.statusBadgeClass}}">{{body.runtimeState.status}}</span>
+        {{else}}
+            <span class="badge badge-secondary">Unavailable</span>
+        {{/if}}
+    </div>
+</div>

--- a/control-panel-kafka/src/main/resources/views/kafka-streams/detail.hbs
+++ b/control-panel-kafka/src/main/resources/views/kafka-streams/detail.hbs
@@ -6,7 +6,11 @@
                 Source: Micronaut <code>HealthEndpoint</code> visible details. Hidden or disabled Health details render as unavailable.
             </p>
         </div>
-        <span class="badge {{body.runtimeState.statusBadgeClass}}">{{body.runtimeState.status}}</span>
+        {{#if body.runtimeState.available}}
+            <span class="badge {{body.runtimeState.statusBadgeClass}}">{{body.runtimeState.status}}</span>
+        {{else}}
+            <span class="badge badge-secondary">Unavailable</span>
+        {{/if}}
     </div>
 
     {{#if body.runtimeState.available}}

--- a/control-panel-kafka/src/main/resources/views/kafka-streams/detail.hbs
+++ b/control-panel-kafka/src/main/resources/views/kafka-streams/detail.hbs
@@ -1,77 +1,132 @@
-<h5>Runtime state</h5>
-{{#if body.runtimeState.available}}
-    <p>
-        <strong>Status</strong>: <span class="badge badge-primary">{{body.runtimeState.status}}</span>
-        {{#if body.runtimeState.message}}
-            <span>{{body.runtimeState.message}}</span>
-        {{/if}}
-    </p>
-    {{#if body.runtimeState.hasThreads}}
-        <ul>
-        {{#each body.runtimeState.threads as |thread|}}
-            <li title="{{thread.name}}">
-                <strong>Thread</strong>:
-                <code>{{abbreviate thread.name 50}}</code> <span class="badge badge-primary">{{thread.state}}</span>
-                <ul>
-                    {{#if thread.adminClientId}}
-                        <li title="{{thread.adminClientId}}"><strong>Admin Client ID</strong>: <code>{{abbreviate thread.adminClientId 40}}</code></li>
-                    {{/if}}
-                    {{#if thread.consumerClientId}}
-                        <li title="{{thread.consumerClientId}}"><strong>Consumer Client ID</strong>: <code>{{abbreviate thread.consumerClientId 40}}</code></li>
-                    {{/if}}
-                    {{#if thread.restoreConsumerClientId}}
-                        <li title="{{thread.restoreConsumerClientId}}"><strong>Restore Consumer Client ID</strong>: <code>{{abbreviate thread.restoreConsumerClientId 40}}</code></li>
-                    {{/if}}
-                    {{#if thread.hasProducerClientIds}}
-                        <li>
-                            <strong>Producer Client IDs</strong>:
-                            <ul>
-                                {{#each thread.producerClientIds as |producerClientId|}}
-                                    <li title="{{producerClientId}}"><code>{{abbreviate producerClientId 30}}</code></li>
-                                {{/each}}
-                            </ul>
-                        </li>
-                    {{/if}}
-                    <li>
-                        <strong>Active tasks</strong>:
-                        {{#if thread.activeTasks.available}}
-                            <ul>
-                                {{#if thread.activeTasks.taskId}}
-                                    <li><strong>Task ID</strong>: <code>{{thread.activeTasks.taskId}}</code></li>
-                                {{/if}}
-                                <li><strong>Partition/topic</strong>: {{thread.activeTasks.partitionCount}}</li>
-                            </ul>
-                        {{else}}
-                            <span>No active task information reported.</span>
-                        {{/if}}
-                    </li>
-                    <li>
-                        <strong>Stand-by tasks</strong>:
-                        {{#if thread.standbyTasks.available}}
-                            <ul>
-                                {{#if thread.standbyTasks.taskId}}
-                                    <li><strong>Task ID</strong>: <code>{{thread.standbyTasks.taskId}}</code></li>
-                                {{/if}}
-                                <li><strong>Partition/topic</strong>: {{thread.standbyTasks.partitionCount}}</li>
-                            </ul>
-                        {{else}}
-                            <span>No standby task information reported.</span>
-                        {{/if}}
-                    </li>
-                </ul>
-            </li>
-        {{/each}}
-        </ul>
-    {{else}}
-        <p>No stream thread details are available for this Kafka Streams application.</p>
-    {{/if}}
-{{else}}
-    <p>{{body.runtimeState.message}}</p>
-{{/if}}
+<section class="cp-kafka-runtime {{body.runtimeState.sectionStateClass}}" aria-labelledby="kafka-streams-runtime-heading">
+    <div class="cp-kafka-section-header">
+        <div>
+            <h5 id="kafka-streams-runtime-heading" class="cp-kafka-section-title">Runtime state</h5>
+            <p class="cp-kafka-section-description">
+                Source: Micronaut <code>HealthEndpoint</code> visible details. Hidden or disabled Health details render as unavailable.
+            </p>
+        </div>
+        <span class="badge {{body.runtimeState.statusBadgeClass}}">{{body.runtimeState.status}}</span>
+    </div>
 
-<h5>Kafka Streams Topology</h5>
-<pre id="kafkaStreamsMermaidCode" style="display:none;">{{{ body.mermaid }}}</pre>
-<div id="kafkaStreamsDiagram" class="mermaid"></div>
+    {{#if body.runtimeState.available}}
+        {{#if body.runtimeState.message}}
+            <p class="cp-kafka-runtime-message">{{body.runtimeState.message}}</p>
+        {{/if}}
+
+        {{#if body.runtimeState.hasThreads}}
+            <div class="cp-data-table cp-kafka-runtime-table">
+                <div class="cp-data-table-container">
+                    <table class="table cp-data-table-table cp-kafka-threads-table">
+                        <thead>
+                            <tr>
+                                <th scope="col">Thread</th>
+                                <th scope="col">State</th>
+                                <th scope="col">Admin client</th>
+                                <th scope="col">Consumer client</th>
+                                <th scope="col">Restore consumer</th>
+                                <th scope="col">Producer clients</th>
+                                <th scope="col">Active tasks</th>
+                                <th scope="col">Standby tasks</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                        {{#each body.runtimeState.threads as |thread|}}
+                            <tr tabindex="0">
+                                <td data-label="Thread" title="{{thread.name}}">
+                                    <code class="cp-table-code">{{abbreviate thread.name 50}}</code>
+                                </td>
+                                <td data-label="State">
+                                    <span class="badge {{thread.stateBadgeClass}}">{{thread.state}}</span>
+                                </td>
+                                <td data-label="Admin client" title="{{thread.adminClientId}}">
+                                    {{#if thread.adminClientId}}
+                                        <code class="cp-table-code">{{abbreviate thread.adminClientId 40}}</code>
+                                    {{else}}
+                                        <span class="cp-kafka-muted">Not reported</span>
+                                    {{/if}}
+                                </td>
+                                <td data-label="Consumer client" title="{{thread.consumerClientId}}">
+                                    {{#if thread.consumerClientId}}
+                                        <code class="cp-table-code">{{abbreviate thread.consumerClientId 40}}</code>
+                                    {{else}}
+                                        <span class="cp-kafka-muted">Not reported</span>
+                                    {{/if}}
+                                </td>
+                                <td data-label="Restore consumer" title="{{thread.restoreConsumerClientId}}">
+                                    {{#if thread.restoreConsumerClientId}}
+                                        <code class="cp-table-code">{{abbreviate thread.restoreConsumerClientId 40}}</code>
+                                    {{else}}
+                                        <span class="cp-kafka-muted">Not reported</span>
+                                    {{/if}}
+                                </td>
+                                <td data-label="Producer clients">
+                                    {{#if thread.hasProducerClientIds}}
+                                        <ul class="cp-kafka-inline-list">
+                                            {{#each thread.producerClientIds as |producerClientId|}}
+                                                <li title="{{producerClientId}}"><code class="cp-table-code">{{abbreviate producerClientId 30}}</code></li>
+                                            {{/each}}
+                                        </ul>
+                                    {{else}}
+                                        <span class="cp-kafka-muted">None reported</span>
+                                    {{/if}}
+                                </td>
+                                <td data-label="Active tasks">
+                                    {{#if thread.activeTasks.available}}
+                                        <span class="cp-kafka-task-summary">
+                                            {{#if thread.activeTasks.taskId}}
+                                                <code class="cp-table-code">{{thread.activeTasks.taskId}}</code>
+                                            {{/if}}
+                                            <span>{{thread.activeTasks.partitionCount}} partition/topic entries</span>
+                                        </span>
+                                    {{else}}
+                                        <span class="cp-kafka-muted">None reported</span>
+                                    {{/if}}
+                                </td>
+                                <td data-label="Standby tasks">
+                                    {{#if thread.standbyTasks.available}}
+                                        <span class="cp-kafka-task-summary">
+                                            {{#if thread.standbyTasks.taskId}}
+                                                <code class="cp-table-code">{{thread.standbyTasks.taskId}}</code>
+                                            {{/if}}
+                                            <span>{{thread.standbyTasks.partitionCount}} partition/topic entries</span>
+                                        </span>
+                                    {{else}}
+                                        <span class="cp-kafka-muted">None reported</span>
+                                    {{/if}}
+                                </td>
+                            </tr>
+                        {{/each}}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        {{else}}
+            <div class="cp-kafka-runtime-empty">
+                <strong>No stream thread details reported.</strong>
+                <span>Health details are visible, but this Kafka Streams application did not report thread/task rows.</span>
+            </div>
+        {{/if}}
+    {{else}}
+        <div class="cp-kafka-runtime-empty">
+            <strong>Runtime state unavailable.</strong>
+            <span>{{body.runtimeState.message}}</span>
+        </div>
+    {{/if}}
+</section>
+
+<section class="cp-kafka-topology" aria-labelledby="kafka-streams-topology-heading">
+    <div class="cp-kafka-section-header">
+        <div>
+            <h5 id="kafka-streams-topology-heading" class="cp-kafka-section-title">Kafka Streams topology</h5>
+            <p class="cp-kafka-section-description">Configured topology remains the primary view for this stream.</p>
+        </div>
+    </div>
+    <pre id="kafkaStreamsMermaidCode" style="display:none;">{{{ body.mermaid }}}</pre>
+    <div id="kafkaStreamsDiagram" class="mermaid cp-kafka-diagram" aria-live="polite">
+        <span class="cp-kafka-muted">Rendering topology...</span>
+    </div>
+</section>
 
 <script>
   (function(){
@@ -96,7 +151,7 @@
       }
       if (window.mermaid) {
         container.innerText = code;
-        container.className = 'mermaid';
+        container.className = 'mermaid cp-kafka-diagram';
         try { window.mermaid.init(undefined, container); } catch(e) {}
         return true;
       }

--- a/control-panel-kafka/src/test/java/io/micronaut/controlpanel/panels/kafka/KafkaStreamsControlPanelTest.java
+++ b/control-panel-kafka/src/test/java/io/micronaut/controlpanel/panels/kafka/KafkaStreamsControlPanelTest.java
@@ -35,6 +35,8 @@ import io.micronaut.management.health.indicator.HealthResult;
 import org.mockito.Mockito;
 import reactor.core.publisher.Mono;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.security.Principal;
 import java.util.List;
 import java.util.Map;
@@ -414,6 +416,43 @@ final class KafkaStreamsControlPanelTest {
     }
 
     @Test
+    void testRuntimeStateModelExposesTemplateStateClasses() {
+        KafkaStreamsRuntimeState down = KafkaStreamsRuntimeState.available("DOWN", null, List.of());
+        KafkaStreamsRuntimeState unavailable = KafkaStreamsRuntimeState.unavailable("Health details hidden");
+        KafkaStreamsRuntimeState.ThreadState rebalancing = new KafkaStreamsRuntimeState.ThreadState(
+                "orders-thread-1",
+                "REBALANCING",
+                null,
+                null,
+                null,
+                List.of(),
+                null,
+                null
+        );
+
+        Assertions.assertEquals("badge-destructive", down.statusBadgeClass());
+        Assertions.assertEquals("cp-kafka-runtime--error", down.sectionStateClass());
+        Assertions.assertTrue(down.errorState());
+        Assertions.assertEquals("badge-secondary", unavailable.statusBadgeClass());
+        Assertions.assertEquals("cp-kafka-runtime--unavailable", unavailable.sectionStateClass());
+        Assertions.assertEquals("cp-kafka-badge-warning", rebalancing.stateBadgeClass());
+    }
+
+    @Test
+    void testKafkaStreamsDetailTemplateUsesResponsiveRuntimeRows() throws IOException {
+        String template = resourceText("/views/kafka-streams/detail.hbs");
+
+        Assertions.assertTrue(template.contains("Source: Micronaut <code>HealthEndpoint</code> visible details"));
+        Assertions.assertTrue(template.contains("class=\"table cp-data-table-table cp-kafka-threads-table\""));
+        Assertions.assertTrue(template.contains("<tr tabindex=\"0\">"));
+        Assertions.assertTrue(template.contains("data-label=\"Thread\""));
+        Assertions.assertTrue(template.contains("data-label=\"Producer clients\""));
+        Assertions.assertTrue(template.contains("Runtime state unavailable."));
+        Assertions.assertTrue(template.contains("Rendering topology..."));
+        Assertions.assertFalse(template.contains("<ul>\n        {{#each body.runtimeState.threads"));
+    }
+
+    @Test
     void testHyphenLabelBreaks() {
         Topology topology = new Topology();
         topology.addSource("KSTREAM-SOURCE-0", "a-b");
@@ -458,5 +497,12 @@ final class KafkaStreamsControlPanelTest {
         properties.setProperty(StreamsConfig.CLIENT_ID_CONFIG, clientId);
         properties.setProperty(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
         return new ConfiguredStreamBuilder(properties);
+    }
+
+    private static String resourceText(String path) throws IOException {
+        try (var in = KafkaStreamsControlPanelTest.class.getResourceAsStream(path)) {
+            Assertions.assertNotNull(in, () -> "Missing resource " + path);
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
     }
 }

--- a/control-panel-kafka/src/test/java/io/micronaut/controlpanel/panels/kafka/KafkaStreamsControlPanelTest.java
+++ b/control-panel-kafka/src/test/java/io/micronaut/controlpanel/panels/kafka/KafkaStreamsControlPanelTest.java
@@ -418,6 +418,7 @@ final class KafkaStreamsControlPanelTest {
     @Test
     void testRuntimeStateModelExposesTemplateStateClasses() {
         KafkaStreamsRuntimeState down = KafkaStreamsRuntimeState.available("DOWN", null, List.of());
+        KafkaStreamsRuntimeState outOfService = KafkaStreamsRuntimeState.available("OUT_OF_SERVICE", null, List.of());
         KafkaStreamsRuntimeState unavailable = KafkaStreamsRuntimeState.unavailable("Health details hidden");
         KafkaStreamsRuntimeState.ThreadState rebalancing = new KafkaStreamsRuntimeState.ThreadState(
                 "orders-thread-1",
@@ -433,6 +434,9 @@ final class KafkaStreamsControlPanelTest {
         Assertions.assertEquals("badge-destructive", down.statusBadgeClass());
         Assertions.assertEquals("cp-kafka-runtime--error", down.sectionStateClass());
         Assertions.assertTrue(down.errorState());
+        Assertions.assertEquals("badge-destructive", outOfService.statusBadgeClass());
+        Assertions.assertEquals("cp-kafka-runtime--error", outOfService.sectionStateClass());
+        Assertions.assertTrue(outOfService.errorState());
         Assertions.assertEquals("badge-secondary", unavailable.statusBadgeClass());
         Assertions.assertEquals("cp-kafka-runtime--unavailable", unavailable.sectionStateClass());
         Assertions.assertEquals("cp-kafka-badge-warning", rebalancing.stateBadgeClass());
@@ -447,6 +451,7 @@ final class KafkaStreamsControlPanelTest {
         Assertions.assertTrue(template.contains("<tr tabindex=\"0\">"));
         Assertions.assertTrue(template.contains("data-label=\"Thread\""));
         Assertions.assertTrue(template.contains("data-label=\"Producer clients\""));
+        Assertions.assertTrue(template.contains("<span class=\"badge badge-secondary\">Unavailable</span>"));
         Assertions.assertTrue(template.contains("Runtime state unavailable."));
         Assertions.assertTrue(template.contains("Rendering topology..."));
         Assertions.assertFalse(template.contains("<ul>\n        {{#each body.runtimeState.threads"));

--- a/control-panel-kafka/src/test/java/io/micronaut/controlpanel/panels/kafka/KafkaStreamsControlPanelTest.java
+++ b/control-panel-kafka/src/test/java/io/micronaut/controlpanel/panels/kafka/KafkaStreamsControlPanelTest.java
@@ -417,29 +417,33 @@ final class KafkaStreamsControlPanelTest {
 
     @Test
     void testRuntimeStateModelExposesTemplateStateClasses() {
+        KafkaStreamsRuntimeState up = KafkaStreamsRuntimeState.available("UP", null, List.of());
         KafkaStreamsRuntimeState down = KafkaStreamsRuntimeState.available("DOWN", null, List.of());
         KafkaStreamsRuntimeState outOfService = KafkaStreamsRuntimeState.available("OUT_OF_SERVICE", null, List.of());
+        KafkaStreamsRuntimeState unknown = KafkaStreamsRuntimeState.available("UNKNOWN", null, List.of());
         KafkaStreamsRuntimeState unavailable = KafkaStreamsRuntimeState.unavailable("Health details hidden");
-        KafkaStreamsRuntimeState.ThreadState rebalancing = new KafkaStreamsRuntimeState.ThreadState(
-                "orders-thread-1",
-                "REBALANCING",
-                null,
-                null,
-                null,
-                List.of(),
-                null,
-                null
-        );
 
+        Assertions.assertEquals("cp-kafka-badge-success", up.statusBadgeClass());
+        Assertions.assertEquals("cp-kafka-runtime--available", up.sectionStateClass());
+        Assertions.assertFalse(up.errorState());
         Assertions.assertEquals("badge-destructive", down.statusBadgeClass());
         Assertions.assertEquals("cp-kafka-runtime--error", down.sectionStateClass());
         Assertions.assertTrue(down.errorState());
         Assertions.assertEquals("badge-destructive", outOfService.statusBadgeClass());
         Assertions.assertEquals("cp-kafka-runtime--error", outOfService.sectionStateClass());
         Assertions.assertTrue(outOfService.errorState());
+        Assertions.assertEquals("badge-secondary", unknown.statusBadgeClass());
+        Assertions.assertEquals("cp-kafka-runtime--available", unknown.sectionStateClass());
+        Assertions.assertFalse(unknown.errorState());
         Assertions.assertEquals("badge-secondary", unavailable.statusBadgeClass());
         Assertions.assertEquals("cp-kafka-runtime--unavailable", unavailable.sectionStateClass());
-        Assertions.assertEquals("cp-kafka-badge-warning", rebalancing.stateBadgeClass());
+        Assertions.assertFalse(unavailable.errorState());
+
+        Assertions.assertEquals("badge-secondary", threadState(null).stateBadgeClass());
+        Assertions.assertEquals("cp-kafka-badge-success", threadState("RUNNING").stateBadgeClass());
+        Assertions.assertEquals("badge-destructive", threadState("DEAD").stateBadgeClass());
+        Assertions.assertEquals("cp-kafka-badge-warning", threadState("REBALANCING").stateBadgeClass());
+        Assertions.assertEquals("badge-secondary", threadState("UNKNOWN").stateBadgeClass());
     }
 
     @Test
@@ -509,5 +513,18 @@ final class KafkaStreamsControlPanelTest {
             Assertions.assertNotNull(in, () -> "Missing resource " + path);
             return new String(in.readAllBytes(), StandardCharsets.UTF_8);
         }
+    }
+
+    private static KafkaStreamsRuntimeState.ThreadState threadState(String state) {
+        return new KafkaStreamsRuntimeState.ThreadState(
+                "orders-thread-1",
+                state,
+                null,
+                null,
+                null,
+                List.of(),
+                null,
+                null
+        );
     }
 }

--- a/control-panel-ui/src/main/resources/static/css/dashboard.css
+++ b/control-panel-ui/src/main/resources/static/css/dashboard.css
@@ -1730,6 +1730,144 @@ dl.row dt {
     padding: 2rem 1rem !important;
 }
 
+.cp-kafka-card-summary {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.75rem;
+}
+
+.cp-kafka-card-metric {
+    display: grid;
+    gap: 0.25rem;
+    min-width: 0;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 0.75rem;
+    background: var(--muted);
+}
+
+.cp-kafka-card-label,
+.cp-kafka-muted,
+.cp-kafka-section-description {
+    color: var(--muted-foreground);
+}
+
+.cp-kafka-card-label {
+    font-size: 0.75rem;
+    font-weight: 650;
+    text-transform: uppercase;
+}
+
+.cp-kafka-runtime,
+.cp-kafka-topology {
+    display: grid;
+    gap: 0.875rem;
+    min-width: 0;
+    margin-bottom: 1.25rem;
+}
+
+.cp-kafka-runtime {
+    border: 1px solid var(--border);
+    border-left-width: 0.25rem;
+    border-radius: var(--radius);
+    padding: 1rem;
+    background: var(--card);
+}
+
+.cp-kafka-runtime--available {
+    border-left-color: var(--success);
+}
+
+.cp-kafka-runtime--error {
+    border-left-color: var(--destructive);
+}
+
+.cp-kafka-runtime--unavailable {
+    border-left-color: var(--warning);
+}
+
+.cp-kafka-section-header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 0.75rem;
+}
+
+.cp-kafka-section-title {
+    margin: 0;
+    color: var(--foreground);
+    font-size: 0.95rem;
+    font-weight: 650;
+    line-height: 1.25;
+}
+
+.cp-kafka-section-description,
+.cp-kafka-runtime-message {
+    margin: 0.25rem 0 0;
+    font-size: 0.875rem;
+}
+
+.cp-kafka-runtime-empty {
+    display: grid;
+    gap: 0.25rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 1rem;
+    color: var(--muted-foreground);
+    background: var(--muted);
+}
+
+.cp-kafka-runtime-empty strong {
+    color: var(--foreground);
+}
+
+.cp-kafka-runtime-table .cp-data-table-container {
+    max-width: 100%;
+}
+
+.cp-kafka-threads-table td {
+    overflow-wrap: anywhere;
+}
+
+.cp-kafka-threads-table tr:focus {
+    outline: 2px solid var(--ring);
+    outline-offset: -2px;
+}
+
+.cp-kafka-inline-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.cp-kafka-task-summary {
+    display: grid;
+    gap: 0.25rem;
+}
+
+.cp-kafka-diagram {
+    min-height: 12rem;
+    overflow: auto;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 1rem;
+    background: var(--card);
+}
+
+.badge.cp-kafka-badge-success {
+    background: var(--success);
+    color: var(--success-foreground);
+}
+
+.badge.cp-kafka-badge-warning {
+    background: var(--warning);
+    color: var(--warning-foreground);
+}
+
 .cp-actions-menu {
     position: relative;
     display: inline-flex;
@@ -2998,5 +3136,65 @@ div.mermaid {
     .cp-detail-section-heading {
         align-items: stretch;
         flex-direction: column;
+    }
+
+    .cp-kafka-card-summary {
+        grid-template-columns: 1fr;
+    }
+
+    .cp-kafka-section-header {
+        align-items: stretch;
+        flex-direction: column;
+    }
+
+    .cp-kafka-runtime-table .cp-data-table-container {
+        border: 0;
+        overflow: visible;
+    }
+
+    .cp-kafka-threads-table,
+    .cp-kafka-threads-table thead,
+    .cp-kafka-threads-table tbody,
+    .cp-kafka-threads-table tr,
+    .cp-kafka-threads-table th,
+    .cp-kafka-threads-table td {
+        display: block;
+    }
+
+    .cp-kafka-threads-table thead {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        overflow: hidden;
+        clip: rect(0 0 0 0);
+        white-space: nowrap;
+    }
+
+    .cp-kafka-threads-table tr {
+        border: 1px solid var(--border);
+        border-radius: var(--radius);
+        margin-bottom: 0.75rem;
+        background: var(--card);
+    }
+
+    .cp-kafka-threads-table tr:last-child {
+        margin-bottom: 0;
+    }
+
+    .cp-kafka-threads-table td {
+        display: grid;
+        grid-template-columns: minmax(7rem, 38%) minmax(0, 1fr);
+        gap: 0.75rem;
+        border-bottom: 1px solid var(--border);
+    }
+
+    .cp-kafka-threads-table td::before {
+        content: attr(data-label);
+        color: var(--muted-foreground);
+        font-weight: 650;
+    }
+
+    .cp-kafka-threads-table td:last-child {
+        border-bottom: 0;
     }
 }


### PR DESCRIPTION
## Summary

- Refine the Kafka Streams runtime-state section into scannable, keyboard-readable thread rows with labelled mobile records.
- Clarify that runtime data comes only from Micronaut `HealthEndpoint` visible details, and make unavailable/error states visually distinct from healthy zero-data states.
- Preserve the existing Kafka Streams topology rendering and dashboard sub-topology badge behavior.
- Address code-review/Sonar feedback by extracting runtime badge constants and expanding template-helper branch coverage.

## Issue Linkage

Paperclip issue: DEV-496.
Follow-up to Paperclip issue DEV-371 and merged PR #548.

No linked GitHub issue exists for this Paperclip follow-up, so there is no GitHub closing keyword or issue-author reviewer to apply.

## Verification

- `./gradlew :micronaut-control-panel-kafka:test --tests io.micronaut.controlpanel.panels.kafka.KafkaStreamsControlPanelTest --rerun-tasks` (20 tests)
- `./gradlew :micronaut-control-panel-kafka:check` (20 tests plus module checkstyle/spotless)
- `./gradlew spotlessCheck`
- `git diff --check origin/2.0.x...HEAD`
- Earlier implementation-stage desktop/mobile Playwright visual checks.

## UI Evidence

![Kafka runtime desktop](https://raw.githubusercontent.com/micronaut-projects/micronaut-control-panel/c248ef914dc09b9488d05e1d57bfad79944e2a26/assets/pr-551/23976f4ed5a0/kafka-runtime-state-desktop.png)

Desktop view showing runtime rows, unavailable state, and topology section.

![Kafka runtime mobile](https://raw.githubusercontent.com/micronaut-projects/micronaut-control-panel/bb586a353ba8db8cba90037b7535996f8286b819/assets/pr-551/23976f4ed5a0/kafka-runtime-state-mobile.png)

Mobile view showing labelled runtime records and unavailable state.

## Release Metadata

- Label: `type: enhancement`
- Target branch: `2.0.x`
- Organization projects: `5.0.0-M3` and `5.0.0 Release`
- Ambiguity note: Control Panel targets `2.0.0`, while open Micronaut organization projects are platform-release boards; because this branch is already on Micronaut 5-era dependencies and PR #548 used this same target branch context, the best-fit project set remains the open 5.0.0 prerelease/GA boards.

---
###### ✨ This message was AI-generated using gpt-5
