### PR TITLE
Add JMX MBeans diagnostics control panel

### DIFF
--- a/control-panel-jmx/build.gradle.kts
+++ b/control-panel-jmx/build.gradle.kts
@@ -1,0 +1,17 @@
+plugins {
+    io.micronaut.build.internal.`control-panel-module`
+}
+
+dependencies {
+    api(projects.micronautControlPanelCore)
+
+    testImplementation(mn.micronaut.http.server.netty)
+    testImplementation(mn.micronaut.http.client)
+    testImplementation(mnTest.micronaut.test.junit5)
+    testRuntimeOnly(mnTest.junit.jupiter.engine)
+    testAnnotationProcessor(mn.micronaut.inject.java)
+}
+
+micronautBuild {
+    binaryCompatibility.enabledAfter("2.0.0")
+}

--- a/control-panel-jmx/build.gradle.kts
+++ b/control-panel-jmx/build.gradle.kts
@@ -13,5 +13,5 @@ dependencies {
 }
 
 micronautBuild {
-    binaryCompatibility.enabledAfter("2.0.0")
+    binaryCompatibility.enabledAfter("2.0.1")
 }

--- a/control-panel-jmx/src/main/java/io/micronaut/controlpanel/panels/jmx/JmxControlPanel.java
+++ b/control-panel-jmx/src/main/java/io/micronaut/controlpanel/panels/jmx/JmxControlPanel.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.jmx;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.controlpanel.core.AbstractControlPanel;
+import io.micronaut.controlpanel.core.ControlPanel;
+import io.micronaut.controlpanel.core.config.ControlPanelConfiguration;
+import io.micronaut.core.util.StringUtils;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+/**
+ * Read-only diagnostics panel for Micronaut endpoint MBeans registered through JMX.
+ */
+@Singleton
+@Requires(property = JmxControlPanel.ENABLED_PROPERTY, notEquals = StringUtils.FALSE)
+public class JmxControlPanel extends AbstractControlPanel<JmxDiagnostics> {
+
+    public static final String NAME = "jmx";
+    public static final String ENABLED_PROPERTY = ControlPanelConfiguration.PREFIX + "." + NAME + ".enabled";
+    public static final ControlPanel.Category CATEGORY = new ControlPanel.Category("diagnostics", "Diagnostics", "fas fa-stethoscope", 30);
+
+    private final JmxDiagnosticsService diagnosticsService;
+
+    public JmxControlPanel(JmxDiagnosticsService diagnosticsService, @Named(NAME) ControlPanelConfiguration configuration) {
+        super(NAME, configuration);
+        this.diagnosticsService = diagnosticsService;
+    }
+
+    @Override
+    public JmxDiagnostics getBody() {
+        return diagnosticsService.inspect();
+    }
+
+    @Override
+    public String getBadge() {
+        JmxDiagnostics body = getBody();
+        if (!body.serverAvailable()) {
+            return StringUtils.EMPTY_STRING;
+        }
+        return String.valueOf(body.endpointMBeanCount());
+    }
+
+    @Override
+    public ControlPanel.Category getCategory() {
+        return CATEGORY;
+    }
+
+    @Override
+    public String getDetailLinkName() {
+        return "Inspect MBeans";
+    }
+}

--- a/control-panel-jmx/src/main/java/io/micronaut/controlpanel/panels/jmx/JmxDiagnostics.java
+++ b/control-panel-jmx/src/main/java/io/micronaut/controlpanel/panels/jmx/JmxDiagnostics.java
@@ -17,6 +17,7 @@ package io.micronaut.controlpanel.panels.jmx;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.ReflectiveAccess;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 
@@ -49,10 +50,10 @@ public record JmxDiagnostics(boolean serverAvailable,
                              int domainCount,
                              int endpointMBeanCount,
                              int metadataFailureCount,
-                             JmxSettings settings,
-                             List<DomainSummary> domainSummaries,
-                             List<EndpointMBean> endpointMBeans,
-                             List<Warning> warnings,
+                             @Nullable JmxSettings settings,
+                             @Nullable List<DomainSummary> domainSummaries,
+                             @Nullable List<EndpointMBean> endpointMBeans,
+                             @Nullable List<Warning> warnings,
                              boolean hasDomainSummaries,
                              boolean hasEndpointMBeans,
                              boolean hasWarnings) {
@@ -86,11 +87,11 @@ public record JmxDiagnostics(boolean serverAvailable,
     @ReflectiveAccess
     public record JmxSettings(boolean configurationClassPresent,
                               boolean hasExplicitProperties,
-                              Setting agentId,
-                              Setting domain,
-                              Setting addToFactory,
-                              Setting ignoreAgentNotFound,
-                              Setting registerEndpoints,
+                              @Nullable Setting agentId,
+                              @Nullable Setting domain,
+                              @Nullable Setting addToFactory,
+                              @Nullable Setting ignoreAgentNotFound,
+                              @Nullable Setting registerEndpoints,
                               boolean registerEndpointsDisabled) {
 
         public JmxSettings {

--- a/control-panel-jmx/src/main/java/io/micronaut/controlpanel/panels/jmx/JmxDiagnostics.java
+++ b/control-panel-jmx/src/main/java/io/micronaut/controlpanel/panels/jmx/JmxDiagnostics.java
@@ -22,6 +22,22 @@ import java.util.List;
 
 /**
  * Read-only JMX diagnostics rendered by the JMX Control Panel.
+ *
+ * @param serverAvailable whether an MBean server bean is available
+ * @param serverClassName MBean server implementation class name
+ * @param defaultDomain server default domain
+ * @param endpointDomain Micronaut endpoint MBean domain
+ * @param totalMBeanCount total MBean count reported by the server
+ * @param domainCount number of readable domains
+ * @param endpointMBeanCount number of Micronaut endpoint MBeans
+ * @param metadataFailureCount number of endpoint MBeans with metadata warnings
+ * @param settings visible JMX settings
+ * @param domainSummaries MBean counts grouped by domain
+ * @param endpointMBeans Micronaut endpoint MBean metadata
+ * @param warnings panel-level warnings
+ * @param hasDomainSummaries whether domain summaries are available
+ * @param hasEndpointMBeans whether endpoint MBeans are available
+ * @param hasWarnings whether panel warnings are available
  */
 @Internal
 @ReflectiveAccess
@@ -57,6 +73,15 @@ public record JmxDiagnostics(boolean serverAvailable,
 
     /**
      * JMX configuration values visible to the panel.
+     *
+     * @param configurationClassPresent whether Micronaut JMX configuration is on the classpath
+     * @param hasExplicitProperties whether any JMX setting is explicitly configured
+     * @param agentId configured agent id setting
+     * @param domain configured domain setting
+     * @param addToFactory configured add-to-factory setting
+     * @param ignoreAgentNotFound configured ignore-agent-not-found setting
+     * @param registerEndpoints configured register-endpoints setting
+     * @param registerEndpointsDisabled whether endpoint registration is disabled
      */
     @ReflectiveAccess
     public record JmxSettings(boolean configurationClassPresent,
@@ -84,6 +109,11 @@ public record JmxDiagnostics(boolean serverAvailable,
 
     /**
      * One configuration setting.
+     *
+     * @param name property name
+     * @param value rendered property value
+     * @param source rendered value source
+     * @param configured whether the value was explicitly configured
      */
     @ReflectiveAccess
     public record Setting(String name, String value, String source, boolean configured) {
@@ -102,6 +132,9 @@ public record JmxDiagnostics(boolean serverAvailable,
 
     /**
      * Count of MBeans grouped by domain.
+     *
+     * @param domain JMX domain
+     * @param mBeanCount number of MBeans in the domain
      */
     @ReflectiveAccess
     public record DomainSummary(String domain, int mBeanCount) {
@@ -109,6 +142,23 @@ public record JmxDiagnostics(boolean serverAvailable,
 
     /**
      * One Micronaut endpoint MBean and the metadata that could be read safely.
+     *
+     * @param objectName redacted ObjectName
+     * @param endpointType endpoint type property
+     * @param registered whether the MBean is currently registered
+     * @param status rendered registration or metadata status
+     * @param warning row-level metadata warning
+     * @param operationCount number of operations
+     * @param infoImpactCount number of INFO operations
+     * @param actionImpactCount number of ACTION operations
+     * @param actionInfoImpactCount number of ACTION_INFO operations
+     * @param unknownImpactCount number of operations with unknown impact
+     * @param attributeCount number of attributes
+     * @param operations operation metadata
+     * @param attributes attribute metadata
+     * @param hasWarning whether the row has a warning
+     * @param hasOperations whether operations are available
+     * @param hasAttributes whether attributes are available
      */
     @ReflectiveAccess
     public record EndpointMBean(String objectName,
@@ -142,6 +192,13 @@ public record JmxDiagnostics(boolean serverAvailable,
 
     /**
      * JMX operation metadata. This does not include invocation support.
+     *
+     * @param name operation name
+     * @param returnType operation return type
+     * @param impact JMX operation impact
+     * @param parameterCount number of parameters
+     * @param parameters parameter metadata
+     * @param hasParameters whether parameters are available
      */
     @ReflectiveAccess
     public record Operation(String name,
@@ -160,6 +217,9 @@ public record JmxDiagnostics(boolean serverAvailable,
 
     /**
      * JMX operation parameter metadata.
+     *
+     * @param name parameter name
+     * @param type parameter type
      */
     @ReflectiveAccess
     public record Parameter(String name, String type) {
@@ -167,6 +227,11 @@ public record JmxDiagnostics(boolean serverAvailable,
 
     /**
      * JMX attribute metadata. Attribute values are intentionally not read.
+     *
+     * @param name attribute name
+     * @param type attribute type
+     * @param readable whether the attribute is readable
+     * @param writable whether the attribute is writable
      */
     @ReflectiveAccess
     public record Attribute(String name, String type, boolean readable, boolean writable) {
@@ -174,6 +239,9 @@ public record JmxDiagnostics(boolean serverAvailable,
 
     /**
      * Panel-level warning.
+     *
+     * @param level warning level
+     * @param message warning message
      */
     @ReflectiveAccess
     public record Warning(String level, String message) {

--- a/control-panel-jmx/src/main/java/io/micronaut/controlpanel/panels/jmx/JmxDiagnostics.java
+++ b/control-panel-jmx/src/main/java/io/micronaut/controlpanel/panels/jmx/JmxDiagnostics.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.jmx;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.ReflectiveAccess;
+
+import java.util.List;
+
+/**
+ * Read-only JMX diagnostics rendered by the JMX Control Panel.
+ */
+@Internal
+@ReflectiveAccess
+public record JmxDiagnostics(boolean serverAvailable,
+                             String serverClassName,
+                             String defaultDomain,
+                             String endpointDomain,
+                             int totalMBeanCount,
+                             int domainCount,
+                             int endpointMBeanCount,
+                             int metadataFailureCount,
+                             JmxSettings settings,
+                             List<DomainSummary> domainSummaries,
+                             List<EndpointMBean> endpointMBeans,
+                             List<Warning> warnings,
+                             boolean hasDomainSummaries,
+                             boolean hasEndpointMBeans,
+                             boolean hasWarnings) {
+
+    public JmxDiagnostics {
+        settings = settings == null ? JmxSettings.unavailable() : settings;
+        domainSummaries = domainSummaries == null ? List.of() : List.copyOf(domainSummaries);
+        endpointMBeans = endpointMBeans == null ? List.of() : List.copyOf(endpointMBeans);
+        warnings = warnings == null ? List.of() : List.copyOf(warnings);
+        hasDomainSummaries = !domainSummaries.isEmpty();
+        hasEndpointMBeans = !endpointMBeans.isEmpty();
+        hasWarnings = !warnings.isEmpty();
+    }
+
+    static JmxDiagnostics unavailable(JmxSettings settings, List<Warning> warnings) {
+        return new JmxDiagnostics(false, "Unavailable", "Unavailable", JmxDiagnosticsService.MICRONAUT_ENDPOINT_DOMAIN, 0, 0, 0, 0, settings, List.of(), List.of(), warnings, false, false, false);
+    }
+
+    /**
+     * JMX configuration values visible to the panel.
+     */
+    @ReflectiveAccess
+    public record JmxSettings(boolean configurationClassPresent,
+                              boolean hasExplicitProperties,
+                              Setting agentId,
+                              Setting domain,
+                              Setting addToFactory,
+                              Setting ignoreAgentNotFound,
+                              Setting registerEndpoints,
+                              boolean registerEndpointsDisabled) {
+
+        public JmxSettings {
+            agentId = agentId == null ? Setting.notConfigured("jmx.agent-id") : agentId;
+            domain = domain == null ? Setting.notConfigured("jmx.domain") : domain;
+            addToFactory = addToFactory == null ? Setting.defaulted("jmx.add-to-factory", "true") : addToFactory;
+            ignoreAgentNotFound = ignoreAgentNotFound == null ? Setting.defaulted("jmx.ignore-agent-not-found", "false") : ignoreAgentNotFound;
+            registerEndpoints = registerEndpoints == null ? Setting.defaulted("jmx.register-endpoints", "true") : registerEndpoints;
+            registerEndpointsDisabled = "false".equals(registerEndpoints.value());
+        }
+
+        static JmxSettings unavailable() {
+            return new JmxSettings(false, false, null, null, null, null, null, false);
+        }
+    }
+
+    /**
+     * One configuration setting.
+     */
+    @ReflectiveAccess
+    public record Setting(String name, String value, String source, boolean configured) {
+        static Setting configured(String name, String value) {
+            return new Setting(name, value, "configured", true);
+        }
+
+        static Setting defaulted(String name, String value) {
+            return new Setting(name, value, "default", false);
+        }
+
+        static Setting notConfigured(String name) {
+            return new Setting(name, "not configured", "not configured", false);
+        }
+    }
+
+    /**
+     * Count of MBeans grouped by domain.
+     */
+    @ReflectiveAccess
+    public record DomainSummary(String domain, int mBeanCount) {
+    }
+
+    /**
+     * One Micronaut endpoint MBean and the metadata that could be read safely.
+     */
+    @ReflectiveAccess
+    public record EndpointMBean(String objectName,
+                                String endpointType,
+                                boolean registered,
+                                String status,
+                                String warning,
+                                int operationCount,
+                                int infoImpactCount,
+                                int actionImpactCount,
+                                int actionInfoImpactCount,
+                                int unknownImpactCount,
+                                int attributeCount,
+                                List<Operation> operations,
+                                List<Attribute> attributes,
+                                boolean hasWarning,
+                                boolean hasOperations,
+                                boolean hasAttributes) {
+
+        public EndpointMBean {
+            operations = operations == null ? List.of() : List.copyOf(operations);
+            attributes = attributes == null ? List.of() : List.copyOf(attributes);
+            warning = warning == null ? "" : warning;
+            hasWarning = !warning.isBlank();
+            hasOperations = !operations.isEmpty();
+            hasAttributes = !attributes.isEmpty();
+            operationCount = operations.size();
+            attributeCount = attributes.size();
+        }
+    }
+
+    /**
+     * JMX operation metadata. This does not include invocation support.
+     */
+    @ReflectiveAccess
+    public record Operation(String name,
+                            String returnType,
+                            String impact,
+                            int parameterCount,
+                            List<Parameter> parameters,
+                            boolean hasParameters) {
+
+        public Operation {
+            parameters = parameters == null ? List.of() : List.copyOf(parameters);
+            hasParameters = !parameters.isEmpty();
+            parameterCount = parameters.size();
+        }
+    }
+
+    /**
+     * JMX operation parameter metadata.
+     */
+    @ReflectiveAccess
+    public record Parameter(String name, String type) {
+    }
+
+    /**
+     * JMX attribute metadata. Attribute values are intentionally not read.
+     */
+    @ReflectiveAccess
+    public record Attribute(String name, String type, boolean readable, boolean writable) {
+    }
+
+    /**
+     * Panel-level warning.
+     */
+    @ReflectiveAccess
+    public record Warning(String level, String message) {
+    }
+}

--- a/control-panel-jmx/src/main/java/io/micronaut/controlpanel/panels/jmx/JmxDiagnosticsService.java
+++ b/control-panel-jmx/src/main/java/io/micronaut/controlpanel/panels/jmx/JmxDiagnosticsService.java
@@ -18,6 +18,7 @@ package io.micronaut.controlpanel.panels.jmx;
 import io.micronaut.context.BeanContext;
 import io.micronaut.context.env.Environment;
 import jakarta.inject.Singleton;
+import org.jspecify.annotations.Nullable;
 
 import javax.management.MBeanAttributeInfo;
 import javax.management.MBeanInfo;
@@ -125,7 +126,7 @@ public class JmxDiagnosticsService {
         return new JmxDiagnostics.JmxSettings(classPresent, hasExplicitProperties, agentId, domain, addToFactory, ignoreAgentNotFound, registerEndpoints, false);
     }
 
-    private JmxDiagnostics.Setting configuredString(String property, String defaultValue) {
+    private JmxDiagnostics.Setting configuredString(String property, @Nullable String defaultValue) {
         return environment.getProperty(property, String.class)
             .map(value -> JmxDiagnostics.Setting.configured(property, redactSensitive(value)))
             .orElseGet(() -> defaultValue == null ? JmxDiagnostics.Setting.notConfigured(property) : JmxDiagnostics.Setting.defaulted(property, defaultValue));
@@ -148,7 +149,7 @@ public class JmxDiagnosticsService {
         }
     }
 
-    private static Set<ObjectName> queryNames(MBeanServer server, ObjectName pattern, List<JmxDiagnostics.Warning> warnings, String message) {
+    private static Set<ObjectName> queryNames(MBeanServer server, @Nullable ObjectName pattern, List<JmxDiagnostics.Warning> warnings, String message) {
         try {
             return server.queryNames(pattern, null);
         } catch (SecurityException e) {
@@ -296,11 +297,11 @@ public class JmxDiagnosticsService {
         return redactSensitive(objectName.getDomain()) + ":" + String.join(",", parts);
     }
 
-    private static String safeValue(String value) {
+    private static String safeValue(@Nullable String value) {
         return value == null || value.isBlank() ? "not available" : redactSensitive(value);
     }
 
-    private static String redactSensitive(String value) {
+    private static String redactSensitive(@Nullable String value) {
         if (value == null || value.isBlank()) {
             return "not available";
         }

--- a/control-panel-jmx/src/main/java/io/micronaut/controlpanel/panels/jmx/JmxDiagnosticsService.java
+++ b/control-panel-jmx/src/main/java/io/micronaut/controlpanel/panels/jmx/JmxDiagnosticsService.java
@@ -1,0 +1,316 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.jmx;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.env.Environment;
+import jakarta.inject.Singleton;
+
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanInfo;
+import javax.management.MBeanOperationInfo;
+import javax.management.MBeanParameterInfo;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.regex.Pattern;
+
+/**
+ * Collects read-only JMX metadata for the Control Panel.
+ */
+@Singleton
+public class JmxDiagnosticsService {
+
+    static final String MICRONAUT_ENDPOINT_DOMAIN = "io.micronaut.management.endpoint";
+
+    private static final Pattern SENSITIVE = Pattern.compile("(?i)(password|credential|certificate|secret|token|key|tenant|user|account)");
+    private static final String JMX_CONFIGURATION_CLASS = "io.micronaut.configuration.jmx.JmxConfiguration";
+
+    private final BeanContext beanContext;
+    private final Environment environment;
+
+    public JmxDiagnosticsService(BeanContext beanContext, Environment environment) {
+        this.beanContext = beanContext;
+        this.environment = environment;
+    }
+
+    /**
+     * Inspects JMX server metadata without invoking MBean operations or reading attribute values.
+     *
+     * @return diagnostics for rendering
+     */
+    public JmxDiagnostics inspect() {
+        JmxDiagnostics.JmxSettings settings = settings();
+        List<JmxDiagnostics.Warning> warnings = new ArrayList<>();
+        if (settings.registerEndpointsDisabled()) {
+            warnings.add(new JmxDiagnostics.Warning("warning", "jmx.register-endpoints is false, so Micronaut endpoint MBeans are not expected to be registered."));
+        }
+
+        MBeanServer server = beanContext.findBean(MBeanServer.class).orElse(null);
+        if (server == null) {
+            warnings.add(new JmxDiagnostics.Warning("warning", "No MBeanServer bean is available. Add micronaut-jmx or provide an MBeanServer bean to inspect JMX endpoint registrations."));
+            return JmxDiagnostics.unavailable(settings, warnings);
+        }
+
+        String serverClassName = server.getClass().getName();
+        String defaultDomain = safeValue(server.getDefaultDomain());
+        int totalMBeanCount = server.getMBeanCount();
+        Set<ObjectName> allNames = queryNames(server, null, warnings, "Could not query all MBean domains.");
+        List<JmxDiagnostics.DomainSummary> domainSummaries = domainSummaries(allNames);
+
+        Set<ObjectName> endpointNames = queryNames(server, endpointPattern(), warnings, "Could not query Micronaut endpoint MBeans.");
+        List<JmxDiagnostics.EndpointMBean> endpointMBeans = endpointMBeans(server, endpointNames);
+        long metadataFailures = endpointMBeans.stream().filter(JmxDiagnostics.EndpointMBean::hasWarning).count();
+
+        if (endpointMBeans.isEmpty() && !settings.registerEndpointsDisabled()) {
+            warnings.add(new JmxDiagnostics.Warning("warning", "No Micronaut endpoint MBeans are registered under " + MICRONAUT_ENDPOINT_DOMAIN + ". Verify micronaut-jmx, micronaut-management, and endpoint exposure settings."));
+        }
+        if (metadataFailures > 0) {
+            warnings.add(new JmxDiagnostics.Warning("warning", metadataFailures + " Micronaut endpoint MBean metadata read failed. Rows with warnings remain visible."));
+        }
+
+        return new JmxDiagnostics(
+            true,
+            redactSensitive(serverClassName),
+            redactSensitive(defaultDomain),
+            MICRONAUT_ENDPOINT_DOMAIN,
+            totalMBeanCount,
+            domainSummaries.size(),
+            endpointMBeans.size(),
+            Math.toIntExact(metadataFailures),
+            settings,
+            domainSummaries,
+            endpointMBeans,
+            warnings,
+            false,
+            false,
+            false
+        );
+    }
+
+    private JmxDiagnostics.JmxSettings settings() {
+        boolean classPresent = isPresent(JMX_CONFIGURATION_CLASS);
+        boolean hasExplicitProperties = environment.containsProperty("jmx.agent-id")
+            || environment.containsProperty("jmx.domain")
+            || environment.containsProperty("jmx.add-to-factory")
+            || environment.containsProperty("jmx.ignore-agent-not-found")
+            || environment.containsProperty("jmx.register-endpoints");
+
+        JmxDiagnostics.Setting agentId = configuredString("jmx.agent-id", null);
+        JmxDiagnostics.Setting domain = configuredString("jmx.domain", null);
+        JmxDiagnostics.Setting addToFactory = configuredString("jmx.add-to-factory", "true");
+        JmxDiagnostics.Setting ignoreAgentNotFound = configuredString("jmx.ignore-agent-not-found", "false");
+        JmxDiagnostics.Setting registerEndpoints = configuredString("jmx.register-endpoints", "true");
+
+        return new JmxDiagnostics.JmxSettings(classPresent, hasExplicitProperties, agentId, domain, addToFactory, ignoreAgentNotFound, registerEndpoints, false);
+    }
+
+    private JmxDiagnostics.Setting configuredString(String property, String defaultValue) {
+        return environment.getProperty(property, String.class)
+            .map(value -> JmxDiagnostics.Setting.configured(property, redactSensitive(value)))
+            .orElseGet(() -> defaultValue == null ? JmxDiagnostics.Setting.notConfigured(property) : JmxDiagnostics.Setting.defaulted(property, defaultValue));
+    }
+
+    private static boolean isPresent(String className) {
+        try {
+            Class.forName(className, false, JmxDiagnosticsService.class.getClassLoader());
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
+    private static ObjectName endpointPattern() {
+        try {
+            return new ObjectName(MICRONAUT_ENDPOINT_DOMAIN + ":*");
+        } catch (Exception e) {
+            throw new IllegalStateException("Invalid Micronaut endpoint MBean pattern", e);
+        }
+    }
+
+    private static Set<ObjectName> queryNames(MBeanServer server, ObjectName pattern, List<JmxDiagnostics.Warning> warnings, String message) {
+        try {
+            return server.queryNames(pattern, null);
+        } catch (SecurityException e) {
+            warnings.add(new JmxDiagnostics.Warning("warning", message + " Metadata is hidden by the active security policy."));
+            return Set.of();
+        } catch (RuntimeException e) {
+            warnings.add(new JmxDiagnostics.Warning("warning", message + " " + sanitizedException(e) + "."));
+            return Set.of();
+        } catch (Exception e) {
+            warnings.add(new JmxDiagnostics.Warning("warning", message + " " + sanitizedException(e) + "."));
+            return Set.of();
+        }
+    }
+
+    private static List<JmxDiagnostics.DomainSummary> domainSummaries(Set<ObjectName> allNames) {
+        Map<String, Integer> counts = new TreeMap<>();
+        for (ObjectName objectName : allNames) {
+            counts.merge(redactSensitive(objectName.getDomain()), 1, Integer::sum);
+        }
+        return counts.entrySet()
+            .stream()
+            .map(entry -> new JmxDiagnostics.DomainSummary(entry.getKey(), entry.getValue()))
+            .toList();
+    }
+
+    private static List<JmxDiagnostics.EndpointMBean> endpointMBeans(MBeanServer server, Set<ObjectName> endpointNames) {
+        return endpointNames.stream()
+            .sorted(Comparator.comparing(ObjectName::getCanonicalName))
+            .map(objectName -> endpointMBean(server, objectName))
+            .toList();
+    }
+
+    private static JmxDiagnostics.EndpointMBean endpointMBean(MBeanServer server, ObjectName objectName) {
+        boolean registered = false;
+        String warning = "";
+        List<JmxDiagnostics.Operation> operations = List.of();
+        List<JmxDiagnostics.Attribute> attributes = List.of();
+        try {
+            registered = server.isRegistered(objectName);
+            MBeanInfo mBeanInfo = server.getMBeanInfo(objectName);
+            operations = operations(mBeanInfo);
+            attributes = attributes(mBeanInfo);
+        } catch (SecurityException e) {
+            warning = "Metadata hidden by the active security policy.";
+        } catch (RuntimeException e) {
+            warning = "Metadata unavailable: " + sanitizedException(e) + ".";
+        } catch (Exception e) {
+            warning = "Metadata unavailable: " + sanitizedException(e) + ".";
+        }
+
+        int infoImpactCount = impactCount(operations, "INFO");
+        int actionImpactCount = impactCount(operations, "ACTION");
+        int actionInfoImpactCount = impactCount(operations, "ACTION_INFO");
+        int unknownImpactCount = impactCount(operations, "UNKNOWN");
+        String status = warning.isBlank() ? "registered" : "metadata warning";
+
+        return new JmxDiagnostics.EndpointMBean(
+            displayName(objectName),
+            endpointType(objectName),
+            registered,
+            status,
+            warning,
+            operations.size(),
+            infoImpactCount,
+            actionImpactCount,
+            actionInfoImpactCount,
+            unknownImpactCount,
+            attributes.size(),
+            operations,
+            attributes,
+            false,
+            false,
+            false
+        );
+    }
+
+    private static List<JmxDiagnostics.Operation> operations(MBeanInfo mBeanInfo) {
+        MBeanOperationInfo[] operationInfos = mBeanInfo.getOperations();
+        List<JmxDiagnostics.Operation> operations = new ArrayList<>(operationInfos.length);
+        for (MBeanOperationInfo operationInfo : operationInfos) {
+            List<JmxDiagnostics.Parameter> parameters = parameters(operationInfo.getSignature());
+            operations.add(new JmxDiagnostics.Operation(
+                safeValue(operationInfo.getName()),
+                safeValue(operationInfo.getReturnType()),
+                impact(operationInfo.getImpact()),
+                parameters.size(),
+                parameters,
+                false
+            ));
+        }
+        operations.sort(Comparator.comparing(JmxDiagnostics.Operation::name)
+            .thenComparing(JmxDiagnostics.Operation::returnType)
+            .thenComparingInt(JmxDiagnostics.Operation::parameterCount));
+        return operations;
+    }
+
+    private static List<JmxDiagnostics.Parameter> parameters(MBeanParameterInfo[] parameterInfos) {
+        List<JmxDiagnostics.Parameter> parameters = new ArrayList<>(parameterInfos.length);
+        for (MBeanParameterInfo parameterInfo : parameterInfos) {
+            parameters.add(new JmxDiagnostics.Parameter(safeValue(parameterInfo.getName()), safeValue(parameterInfo.getType())));
+        }
+        return parameters;
+    }
+
+    private static List<JmxDiagnostics.Attribute> attributes(MBeanInfo mBeanInfo) {
+        MBeanAttributeInfo[] attributeInfos = mBeanInfo.getAttributes();
+        List<JmxDiagnostics.Attribute> attributes = new ArrayList<>(attributeInfos.length);
+        for (MBeanAttributeInfo attributeInfo : attributeInfos) {
+            attributes.add(new JmxDiagnostics.Attribute(
+                safeValue(attributeInfo.getName()),
+                safeValue(attributeInfo.getType()),
+                attributeInfo.isReadable(),
+                attributeInfo.isWritable()
+            ));
+        }
+        attributes.sort(Comparator.comparing(JmxDiagnostics.Attribute::name).thenComparing(JmxDiagnostics.Attribute::type));
+        return attributes;
+    }
+
+    private static int impactCount(List<JmxDiagnostics.Operation> operations, String impact) {
+        return (int) operations.stream().filter(operation -> impact.equals(operation.impact())).count();
+    }
+
+    private static String impact(int impact) {
+        return switch (impact) {
+            case MBeanOperationInfo.INFO -> "INFO";
+            case MBeanOperationInfo.ACTION -> "ACTION";
+            case MBeanOperationInfo.ACTION_INFO -> "ACTION_INFO";
+            default -> "UNKNOWN";
+        };
+    }
+
+    private static String endpointType(ObjectName objectName) {
+        return redactSensitive(objectName.getKeyProperty("type"));
+    }
+
+    private static String displayName(ObjectName objectName) {
+        Map<String, String> properties = new TreeMap<>(objectName.getKeyPropertyList());
+        List<String> parts = new ArrayList<>(properties.size());
+        for (Map.Entry<String, String> entry : properties.entrySet()) {
+            String key = entry.getKey();
+            String value = SENSITIVE.matcher(key).find() || SENSITIVE.matcher(entry.getValue()).find() ? "[redacted]" : entry.getValue();
+            parts.add(key + "=" + value);
+        }
+        return redactSensitive(objectName.getDomain()) + ":" + String.join(",", parts);
+    }
+
+    private static String safeValue(String value) {
+        return value == null || value.isBlank() ? "not available" : redactSensitive(value);
+    }
+
+    private static String redactSensitive(String value) {
+        if (value == null || value.isBlank()) {
+            return "not available";
+        }
+        return SENSITIVE.matcher(value).find() ? "[redacted]" : value;
+    }
+
+    private static String sanitizedException(Exception e) {
+        String simpleName = e.getClass().getSimpleName();
+        if (simpleName == null || simpleName.isBlank()) {
+            return "JMX exception";
+        }
+        return simpleName.replaceAll("[^A-Za-z0-9]", "").toLowerCase(Locale.ROOT);
+    }
+}

--- a/control-panel-jmx/src/main/java/io/micronaut/controlpanel/panels/jmx/JmxDiagnosticsService.java
+++ b/control-panel-jmx/src/main/java/io/micronaut/controlpanel/panels/jmx/JmxDiagnosticsService.java
@@ -44,6 +44,7 @@ public class JmxDiagnosticsService {
 
     private static final Pattern SENSITIVE = Pattern.compile("(?i)(password|credential|certificate|secret|token|key|tenant|user|account)");
     private static final String JMX_CONFIGURATION_CLASS = "io.micronaut.configuration.jmx.JmxConfiguration";
+    private static final String WARNING_LEVEL = "warning";
 
     private final BeanContext beanContext;
     private final Environment environment;
@@ -62,12 +63,12 @@ public class JmxDiagnosticsService {
         JmxDiagnostics.JmxSettings settings = settings();
         List<JmxDiagnostics.Warning> warnings = new ArrayList<>();
         if (settings.registerEndpointsDisabled()) {
-            warnings.add(new JmxDiagnostics.Warning("warning", "jmx.register-endpoints is false, so Micronaut endpoint MBeans are not expected to be registered."));
+            warnings.add(new JmxDiagnostics.Warning(WARNING_LEVEL, "jmx.register-endpoints is false, so Micronaut endpoint MBeans are not expected to be registered."));
         }
 
         MBeanServer server = beanContext.findBean(MBeanServer.class).orElse(null);
         if (server == null) {
-            warnings.add(new JmxDiagnostics.Warning("warning", "No MBeanServer bean is available. Add micronaut-jmx or provide an MBeanServer bean to inspect JMX endpoint registrations."));
+            warnings.add(new JmxDiagnostics.Warning(WARNING_LEVEL, "No MBeanServer bean is available. Add micronaut-jmx or provide an MBeanServer bean to inspect JMX endpoint registrations."));
             return JmxDiagnostics.unavailable(settings, warnings);
         }
 
@@ -82,10 +83,10 @@ public class JmxDiagnosticsService {
         long metadataFailures = endpointMBeans.stream().filter(JmxDiagnostics.EndpointMBean::hasWarning).count();
 
         if (endpointMBeans.isEmpty() && !settings.registerEndpointsDisabled()) {
-            warnings.add(new JmxDiagnostics.Warning("warning", "No Micronaut endpoint MBeans are registered under " + MICRONAUT_ENDPOINT_DOMAIN + ". Verify micronaut-jmx, micronaut-management, and endpoint exposure settings."));
+            warnings.add(new JmxDiagnostics.Warning(WARNING_LEVEL, "No Micronaut endpoint MBeans are registered under " + MICRONAUT_ENDPOINT_DOMAIN + ". Verify micronaut-jmx, micronaut-management, and endpoint exposure settings."));
         }
         if (metadataFailures > 0) {
-            warnings.add(new JmxDiagnostics.Warning("warning", metadataFailures + " Micronaut endpoint MBean metadata read failed. Rows with warnings remain visible."));
+            warnings.add(new JmxDiagnostics.Warning(WARNING_LEVEL, metadataFailures + " Micronaut endpoint MBean metadata read failed. Rows with warnings remain visible."));
         }
 
         return new JmxDiagnostics(
@@ -151,13 +152,13 @@ public class JmxDiagnosticsService {
         try {
             return server.queryNames(pattern, null);
         } catch (SecurityException e) {
-            warnings.add(new JmxDiagnostics.Warning("warning", message + " Metadata is hidden by the active security policy."));
+            warnings.add(new JmxDiagnostics.Warning(WARNING_LEVEL, message + " Metadata is hidden by the active security policy."));
             return Set.of();
         } catch (RuntimeException e) {
-            warnings.add(new JmxDiagnostics.Warning("warning", message + " " + sanitizedException(e) + "."));
+            warnings.add(new JmxDiagnostics.Warning(WARNING_LEVEL, message + " " + sanitizedException(e) + "."));
             return Set.of();
         } catch (Exception e) {
-            warnings.add(new JmxDiagnostics.Warning("warning", message + " " + sanitizedException(e) + "."));
+            warnings.add(new JmxDiagnostics.Warning(WARNING_LEVEL, message + " " + sanitizedException(e) + "."));
             return Set.of();
         }
     }

--- a/control-panel-jmx/src/main/java/io/micronaut/controlpanel/panels/jmx/package-info.java
+++ b/control-panel-jmx/src/main/java/io/micronaut/controlpanel/panels/jmx/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * JMX diagnostics Control Panel classes.
+ */
+@Configuration
+@Requires(property = JmxControlPanel.ENABLED_PROPERTY, notEquals = StringUtils.FALSE)
+@Requires(condition = ControlPanelEnabledCondition.class)
+package io.micronaut.controlpanel.panels.jmx;
+
+import io.micronaut.context.annotation.Configuration;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.controlpanel.core.config.ControlPanelEnabledCondition;
+import io.micronaut.core.util.StringUtils;

--- a/control-panel-jmx/src/main/resources/micronaut-control-panel/micronaut-control-panel.properties
+++ b/control-panel-jmx/src/main/resources/micronaut-control-panel/micronaut-control-panel.properties
@@ -1,0 +1,4 @@
+micronaut.control-panel.panels.jmx.enabled = true
+micronaut.control-panel.panels.jmx.title = JMX
+micronaut.control-panel.panels.jmx.icon = fa-network-wired
+micronaut.control-panel.panels.jmx.order = 30

--- a/control-panel-jmx/src/main/resources/views/jmx/body.hbs
+++ b/control-panel-jmx/src/main/resources/views/jmx/body.hbs
@@ -1,0 +1,39 @@
+{{#with body}}
+    {{#if serverAvailable}}
+        <p class="card-text">
+            <strong>{{endpointMBeanCount}}</strong> Micronaut endpoint MBeans under
+            <code>{{endpointDomain}}</code>
+            across <strong>{{domainCount}}</strong> JMX domains.
+        </p>
+        <p class="card-text">
+            <strong>Server</strong>:
+            <code>{{serverClassName}}</code>
+        </p>
+        <p class="card-text">
+            <strong>Default domain</strong>:
+            <code>{{defaultDomain}}</code>
+        </p>
+        <p class="card-text">
+            <strong>Endpoint registration</strong>:
+            {{#if settings.registerEndpointsDisabled}}
+                <span class="badge badge-destructive">disabled</span>
+            {{else}}
+                <span class="badge badge-primary">enabled</span>
+            {{/if}}
+            <code>{{settings.registerEndpoints.name}}={{settings.registerEndpoints.value}}</code>
+        </p>
+    {{else}}
+        <p class="card-text">
+            <span class="badge badge-secondary">Unavailable</span>
+            No JMX server bean is available for inspection.
+        </p>
+    {{/if}}
+
+    {{#if hasWarnings}}
+        <p class="card-text">
+            {{#each warnings as |warning|}}
+                <span class="badge badge-secondary">{{warning.message}}</span>
+            {{/each}}
+        </p>
+    {{/if}}
+{{/with}}

--- a/control-panel-jmx/src/main/resources/views/jmx/detail.hbs
+++ b/control-panel-jmx/src/main/resources/views/jmx/detail.hbs
@@ -1,0 +1,328 @@
+{{#with controlPanel.body}}
+    <div class="cp-dashboard-stack">
+        <div class="card card-light">
+            <div class="card-header">
+                <div class="cp-card-heading">
+                    <div class="cp-card-header-text">
+                        <h3 class="card-title">JMX diagnostics</h3>
+                        <div class="card-description">Read-only MBean server metadata and Micronaut endpoint registrations.</div>
+                    </div>
+                </div>
+                <div class="card-tools">
+                    {{#if serverAvailable}}
+                        <span class="badge badge-primary">Server available</span>
+                    {{else}}
+                        <span class="badge badge-secondary">Server unavailable</span>
+                    {{/if}}
+                </div>
+            </div>
+            <div class="card-body">
+                {{#if hasWarnings}}
+                    <div class="cp-data-table-empty">
+                        {{#each warnings as |warning|}}
+                            <p>{{warning.message}}</p>
+                        {{/each}}
+                    </div>
+                {{/if}}
+
+                <div class="tabs" data-tabs>
+                    <div class="tabs-list" role="tablist" aria-label="JMX diagnostics">
+                        <button type="button" class="tabs-trigger active" id="tab-jmx-server" role="tab" aria-selected="true" aria-controls="panel-jmx-server" data-tabs-trigger="jmx-server">
+                            Server
+                        </button>
+                        <button type="button" class="tabs-trigger" id="tab-jmx-endpoints" role="tab" aria-selected="false" aria-controls="panel-jmx-endpoints" data-tabs-trigger="jmx-endpoints">
+                            Micronaut Endpoints
+                            <span class="badge badge-secondary">{{endpointMBeanCount}}</span>
+                        </button>
+                        <button type="button" class="tabs-trigger" id="tab-jmx-domains" role="tab" aria-selected="false" aria-controls="panel-jmx-domains" data-tabs-trigger="jmx-domains">
+                            All Domains
+                            <span class="badge badge-secondary">{{domainCount}}</span>
+                        </button>
+                        <button type="button" class="tabs-trigger" id="tab-jmx-details" role="tab" aria-selected="false" aria-controls="panel-jmx-details" data-tabs-trigger="jmx-details">
+                            Details
+                        </button>
+                    </div>
+
+                    <div class="tabs-panel" id="panel-jmx-server" role="tabpanel" aria-labelledby="tab-jmx-server" data-tabs-panel="jmx-server">
+                        <div class="cp-data-table-container cp-vertical-table">
+                            <table class="table cp-data-table-table">
+                                <tbody>
+                                <tr>
+                                    <th>Server bean</th>
+                                    <td>
+                                        {{#if serverAvailable}}
+                                            <span class="badge badge-primary">available</span>
+                                        {{else}}
+                                            <span class="badge badge-secondary">unavailable</span>
+                                        {{/if}}
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>Implementation class</th>
+                                    <td><code class="cp-table-code">{{serverClassName}}</code></td>
+                                </tr>
+                                <tr>
+                                    <th>Default domain</th>
+                                    <td><code class="cp-table-code">{{defaultDomain}}</code></td>
+                                </tr>
+                                <tr>
+                                    <th>Total MBeans</th>
+                                    <td>{{totalMBeanCount}}</td>
+                                </tr>
+                                <tr>
+                                    <th>Domains</th>
+                                    <td>{{domainCount}}</td>
+                                </tr>
+                                <tr>
+                                    <th>Micronaut endpoint MBeans</th>
+                                    <td>{{endpointMBeanCount}}</td>
+                                </tr>
+                                <tr>
+                                    <th>Micronaut JMX configuration class</th>
+                                    <td>
+                                        {{#if settings.configurationClassPresent}}
+                                            <span class="badge badge-primary">present</span>
+                                        {{else}}
+                                            <span class="badge badge-secondary">unavailable</span>
+                                        {{/if}}
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th><code>jmx.agent-id</code></th>
+                                    <td><code class="cp-table-code">{{settings.agentId.value}}</code> <span class="badge badge-secondary">{{settings.agentId.source}}</span></td>
+                                </tr>
+                                <tr>
+                                    <th><code>jmx.domain</code></th>
+                                    <td><code class="cp-table-code">{{settings.domain.value}}</code> <span class="badge badge-secondary">{{settings.domain.source}}</span></td>
+                                </tr>
+                                <tr>
+                                    <th><code>jmx.add-to-factory</code></th>
+                                    <td><code class="cp-table-code">{{settings.addToFactory.value}}</code> <span class="badge badge-secondary">{{settings.addToFactory.source}}</span></td>
+                                </tr>
+                                <tr>
+                                    <th><code>jmx.ignore-agent-not-found</code></th>
+                                    <td><code class="cp-table-code">{{settings.ignoreAgentNotFound.value}}</code> <span class="badge badge-secondary">{{settings.ignoreAgentNotFound.source}}</span></td>
+                                </tr>
+                                <tr>
+                                    <th><code>jmx.register-endpoints</code></th>
+                                    <td><code class="cp-table-code">{{settings.registerEndpoints.value}}</code> <span class="badge badge-secondary">{{settings.registerEndpoints.source}}</span></td>
+                                </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+
+                    <div class="tabs-panel" id="panel-jmx-endpoints" role="tabpanel" aria-labelledby="tab-jmx-endpoints" data-tabs-panel="jmx-endpoints" hidden>
+                        {{#if hasEndpointMBeans}}
+                            <div class="cp-data-table cp-data-table-paged" data-filter-table data-filter-table-page-size="10" data-filter-table-label="endpoint MBean" data-filter-table-label-plural="endpoint MBeans">
+                                <div class="cp-data-table-toolbar">
+                                    <div class="cp-data-table-summary" data-filter-table-summary>{{endpointMBeanCount}} endpoint MBeans</div>
+                                    <div class="cp-data-table-search">
+                                        <input type="text" class="form-control" data-filter-table-search placeholder="Search endpoint MBeans" aria-label="Search endpoint MBeans">
+                                    </div>
+                                </div>
+                                <div class="cp-data-table-container">
+                                    <table class="table cp-data-table-table cp-data-table-fixed">
+                                        <thead>
+                                        <tr>
+                                            <th>ObjectName</th>
+                                            <th>Endpoint type</th>
+                                            <th>Operations</th>
+                                            <th>Impacts</th>
+                                            <th>Status</th>
+                                        </tr>
+                                        </thead>
+                                        <tbody>
+                                        {{#each endpointMBeans as |mbean|}}
+                                            <tr data-filter-table-row>
+                                                <td><code class="cp-table-code">{{mbean.objectName}}</code></td>
+                                                <td><code class="cp-table-code">{{mbean.endpointType}}</code></td>
+                                                <td>{{mbean.operationCount}}</td>
+                                                <td>
+                                                    <span class="badge badge-secondary">INFO {{mbean.infoImpactCount}}</span>
+                                                    <span class="badge badge-secondary">ACTION {{mbean.actionImpactCount}}</span>
+                                                    <span class="badge badge-secondary">ACTION_INFO {{mbean.actionInfoImpactCount}}</span>
+                                                    <span class="badge badge-secondary">UNKNOWN {{mbean.unknownImpactCount}}</span>
+                                                </td>
+                                                <td>
+                                                    {{#if mbean.hasWarning}}
+                                                        <span class="badge badge-secondary">{{mbean.status}}</span>
+                                                        <span>{{mbean.warning}}</span>
+                                                    {{else}}
+                                                        <span class="badge badge-primary">{{mbean.status}}</span>
+                                                    {{/if}}
+                                                </td>
+                                            </tr>
+                                        {{/each}}
+                                        <tr data-filter-table-empty hidden>
+                                            <td class="cp-data-table-empty-cell" colspan="5">No endpoint MBeans found.</td>
+                                        </tr>
+                                        </tbody>
+                                    </table>
+                                </div>
+                                <div class="cp-data-table-footer">
+                                    <label class="cp-data-table-page-size">
+                                        Rows per page
+                                        <select class="form-control" data-filter-table-page-size-select aria-label="Endpoint MBeans per page">
+                                            <option value="5">5</option>
+                                            <option value="10" selected>10</option>
+                                            <option value="20">20</option>
+                                        </select>
+                                    </label>
+                                    <div class="cp-data-table-pagination">
+                                        <span class="cp-data-table-page" data-filter-table-page>Page 1 of 1</span>
+                                        <button type="button" class="btn btn-secondary btn-sm" data-filter-table-prev>Previous</button>
+                                        <button type="button" class="btn btn-secondary btn-sm" data-filter-table-next>Next</button>
+                                    </div>
+                                </div>
+                            </div>
+                        {{else}}
+                            <div class="cp-data-table-empty">No Micronaut endpoint MBeans are registered under <code>{{endpointDomain}}</code>.</div>
+                        {{/if}}
+                    </div>
+
+                    <div class="tabs-panel" id="panel-jmx-domains" role="tabpanel" aria-labelledby="tab-jmx-domains" data-tabs-panel="jmx-domains" hidden>
+                        {{#if hasDomainSummaries}}
+                            <div class="cp-data-table cp-data-table-paged" data-filter-table data-filter-table-page-size="12" data-filter-table-label="domain" data-filter-table-label-plural="domains">
+                                <div class="cp-data-table-toolbar">
+                                    <div class="cp-data-table-summary" data-filter-table-summary>{{domainCount}} domains</div>
+                                    <div class="cp-data-table-search">
+                                        <input type="text" class="form-control" data-filter-table-search placeholder="Search domains" aria-label="Search JMX domains">
+                                    </div>
+                                </div>
+                                <div class="cp-data-table-container">
+                                    <table class="table cp-data-table-table cp-data-table-fixed">
+                                        <thead>
+                                        <tr>
+                                            <th>Domain</th>
+                                            <th>MBeans</th>
+                                        </tr>
+                                        </thead>
+                                        <tbody>
+                                        {{#each domainSummaries as |domain|}}
+                                            <tr data-filter-table-row>
+                                                <td><code class="cp-table-code">{{domain.domain}}</code></td>
+                                                <td>{{domain.mBeanCount}}</td>
+                                            </tr>
+                                        {{/each}}
+                                        <tr data-filter-table-empty hidden>
+                                            <td class="cp-data-table-empty-cell" colspan="2">No domains found.</td>
+                                        </tr>
+                                        </tbody>
+                                    </table>
+                                </div>
+                                <div class="cp-data-table-footer">
+                                    <label class="cp-data-table-page-size">
+                                        Rows per page
+                                        <select class="form-control" data-filter-table-page-size-select aria-label="JMX domains per page">
+                                            <option value="8">8</option>
+                                            <option value="12" selected>12</option>
+                                            <option value="20">20</option>
+                                        </select>
+                                    </label>
+                                    <div class="cp-data-table-pagination">
+                                        <span class="cp-data-table-page" data-filter-table-page>Page 1 of 1</span>
+                                        <button type="button" class="btn btn-secondary btn-sm" data-filter-table-prev>Previous</button>
+                                        <button type="button" class="btn btn-secondary btn-sm" data-filter-table-next>Next</button>
+                                    </div>
+                                </div>
+                            </div>
+                        {{else}}
+                            <div class="cp-data-table-empty">No JMX domains could be read.</div>
+                        {{/if}}
+                    </div>
+
+                    <div class="tabs-panel" id="panel-jmx-details" role="tabpanel" aria-labelledby="tab-jmx-details" data-tabs-panel="jmx-details" hidden>
+                        {{#if hasEndpointMBeans}}
+                            <div class="cp-dashboard-stack">
+                                {{#each endpointMBeans as |mbean|}}
+                                    <div class="card card-light">
+                                        <div class="card-header">
+                                            <div class="cp-card-heading">
+                                                <div class="cp-card-header-text">
+                                                    <h3 class="card-title"><code class="cp-table-code">{{mbean.endpointType}}</code></h3>
+                                                    <div class="card-description"><code class="cp-table-code">{{mbean.objectName}}</code></div>
+                                                </div>
+                                            </div>
+                                            <div class="card-tools">
+                                                <span class="badge badge-secondary">{{mbean.operationCount}} operations</span>
+                                                <span class="badge badge-secondary">{{mbean.attributeCount}} attributes</span>
+                                            </div>
+                                        </div>
+                                        <div class="card-body">
+                                            {{#if mbean.hasWarning}}
+                                                <p>{{mbean.warning}}</p>
+                                            {{/if}}
+                                            {{#if mbean.hasOperations}}
+                                                <div class="cp-data-table-container">
+                                                    <table class="table cp-data-table-table cp-data-table-fixed">
+                                                        <thead>
+                                                        <tr>
+                                                            <th>Operation</th>
+                                                            <th>Return type</th>
+                                                            <th>Impact</th>
+                                                            <th>Signature</th>
+                                                        </tr>
+                                                        </thead>
+                                                        <tbody>
+                                                        {{#each mbean.operations as |operation|}}
+                                                            <tr>
+                                                                <td><code class="cp-table-code">{{operation.name}}</code></td>
+                                                                <td><code class="cp-table-code">{{operation.returnType}}</code></td>
+                                                                <td><span class="badge badge-secondary">{{operation.impact}}</span></td>
+                                                                <td>
+                                                                    {{#if operation.hasParameters}}
+                                                                        {{#each operation.parameters as |parameter|}}
+                                                                            <code class="cp-table-code">{{parameter.type}} {{parameter.name}}</code>
+                                                                        {{/each}}
+                                                                    {{else}}
+                                                                        <span class="badge badge-secondary">no parameters</span>
+                                                                    {{/if}}
+                                                                </td>
+                                                            </tr>
+                                                        {{/each}}
+                                                        </tbody>
+                                                    </table>
+                                                </div>
+                                            {{else}}
+                                                <p>No operation metadata is available for this MBean.</p>
+                                            {{/if}}
+
+                                            {{#if mbean.hasAttributes}}
+                                                <h4 class="cp-detail-section-title">Attributes</h4>
+                                                <div class="cp-data-table-container">
+                                                    <table class="table cp-data-table-table cp-data-table-fixed">
+                                                        <thead>
+                                                        <tr>
+                                                            <th>Attribute</th>
+                                                            <th>Type</th>
+                                                            <th>Readable</th>
+                                                            <th>Writable</th>
+                                                        </tr>
+                                                        </thead>
+                                                        <tbody>
+                                                        {{#each mbean.attributes as |attribute|}}
+                                                            <tr>
+                                                                <td><code class="cp-table-code">{{attribute.name}}</code></td>
+                                                                <td><code class="cp-table-code">{{attribute.type}}</code></td>
+                                                                <td>{{attribute.readable}}</td>
+                                                                <td>{{attribute.writable}}</td>
+                                                            </tr>
+                                                        {{/each}}
+                                                        </tbody>
+                                                    </table>
+                                                </div>
+                                            {{/if}}
+                                        </div>
+                                    </div>
+                                {{/each}}
+                            </div>
+                        {{else}}
+                            <div class="cp-data-table-empty">No Micronaut endpoint MBean metadata is available.</div>
+                        {{/if}}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+{{/with}}

--- a/control-panel-jmx/src/main/resources/views/jmx/detail.hbs
+++ b/control-panel-jmx/src/main/resources/views/jmx/detail.hbs
@@ -26,7 +26,7 @@
                 {{/if}}
 
                 <div class="tabs" data-tabs>
-                    <div class="tabs-list" role="tablist" aria-label="JMX diagnostics">
+                    <div class="tabs-list cp-jmx-tabs-list" role="tablist" aria-label="JMX diagnostics">
                         <button type="button" class="tabs-trigger active" id="tab-jmx-server" role="tab" aria-selected="true" aria-controls="panel-jmx-server" data-tabs-trigger="jmx-server">
                             Server
                         </button>
@@ -44,7 +44,7 @@
                     </div>
 
                     <div class="tabs-panel" id="panel-jmx-server" role="tabpanel" aria-labelledby="tab-jmx-server" data-tabs-panel="jmx-server">
-                        <div class="cp-data-table-container cp-vertical-table">
+                        <div class="cp-data-table-container cp-vertical-table cp-jmx-server-table">
                             <table class="table cp-data-table-table">
                                 <tbody>
                                 <tr>
@@ -89,23 +89,23 @@
                                 </tr>
                                 <tr>
                                     <th><code>jmx.agent-id</code></th>
-                                    <td><code class="cp-table-code">{{settings.agentId.value}}</code> <span class="badge badge-secondary">{{settings.agentId.source}}</span></td>
+                                    <td><span class="cp-jmx-setting-value"><code class="cp-table-code">{{settings.agentId.value}}</code> <span class="badge badge-secondary">{{settings.agentId.source}}</span></span></td>
                                 </tr>
                                 <tr>
                                     <th><code>jmx.domain</code></th>
-                                    <td><code class="cp-table-code">{{settings.domain.value}}</code> <span class="badge badge-secondary">{{settings.domain.source}}</span></td>
+                                    <td><span class="cp-jmx-setting-value"><code class="cp-table-code">{{settings.domain.value}}</code> <span class="badge badge-secondary">{{settings.domain.source}}</span></span></td>
                                 </tr>
                                 <tr>
                                     <th><code>jmx.add-to-factory</code></th>
-                                    <td><code class="cp-table-code">{{settings.addToFactory.value}}</code> <span class="badge badge-secondary">{{settings.addToFactory.source}}</span></td>
+                                    <td><span class="cp-jmx-setting-value"><code class="cp-table-code">{{settings.addToFactory.value}}</code> <span class="badge badge-secondary">{{settings.addToFactory.source}}</span></span></td>
                                 </tr>
                                 <tr>
                                     <th><code>jmx.ignore-agent-not-found</code></th>
-                                    <td><code class="cp-table-code">{{settings.ignoreAgentNotFound.value}}</code> <span class="badge badge-secondary">{{settings.ignoreAgentNotFound.source}}</span></td>
+                                    <td><span class="cp-jmx-setting-value"><code class="cp-table-code">{{settings.ignoreAgentNotFound.value}}</code> <span class="badge badge-secondary">{{settings.ignoreAgentNotFound.source}}</span></span></td>
                                 </tr>
                                 <tr>
                                     <th><code>jmx.register-endpoints</code></th>
-                                    <td><code class="cp-table-code">{{settings.registerEndpoints.value}}</code> <span class="badge badge-secondary">{{settings.registerEndpoints.source}}</span></td>
+                                    <td><span class="cp-jmx-setting-value"><code class="cp-table-code">{{settings.registerEndpoints.value}}</code> <span class="badge badge-secondary">{{settings.registerEndpoints.source}}</span></span></td>
                                 </tr>
                                 </tbody>
                             </table>

--- a/control-panel-jmx/src/test/java/io/micronaut/controlpanel/panels/jmx/JmxDiagnosticsServiceTest.java
+++ b/control-panel-jmx/src/test/java/io/micronaut/controlpanel/panels/jmx/JmxDiagnosticsServiceTest.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.jmx;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.controlpanel.core.config.ControlPanelConfiguration;
+import io.micronaut.inject.qualifiers.Qualifiers;
+import org.junit.jupiter.api.Test;
+
+import javax.management.Attribute;
+import javax.management.AttributeList;
+import javax.management.DynamicMBean;
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanInfo;
+import javax.management.MBeanOperationInfo;
+import javax.management.MBeanParameterInfo;
+import javax.management.MBeanServer;
+import javax.management.MBeanServerFactory;
+import javax.management.ObjectName;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JmxDiagnosticsServiceTest {
+
+    @Test
+    void inspectsMicronautEndpointMBeansWithoutInvokingOperationsOrReadingAttributes() throws Exception {
+        MBeanServer server = MBeanServerFactory.createMBeanServer("test-domain");
+        registerEndpoint(server, "HealthEndpoint", new EndpointMBean("status", MBeanOperationInfo.INFO));
+        registerEndpoint(server, "RefreshEndpoint", new EndpointMBean("refresh", MBeanOperationInfo.ACTION, "force", "boolean"));
+
+        try (ApplicationContext ctx = ApplicationContext.run()) {
+            ctx.registerSingleton(MBeanServer.class, server);
+
+            JmxDiagnostics diagnostics = ctx.getBean(JmxDiagnosticsService.class).inspect();
+
+            assertTrue(diagnostics.serverAvailable());
+            assertEquals(2, diagnostics.endpointMBeanCount());
+            assertTrue(diagnostics.hasDomainSummaries());
+            assertTrue(diagnostics.domainSummaries().stream().anyMatch(domain -> domain.domain().equals(JmxDiagnosticsService.MICRONAUT_ENDPOINT_DOMAIN) && domain.mBeanCount() == 2));
+            assertEquals("HealthEndpoint", diagnostics.endpointMBeans().get(0).endpointType());
+            assertEquals("INFO", diagnostics.endpointMBeans().get(0).operations().get(0).impact());
+            assertEquals(1, diagnostics.endpointMBeans().get(1).actionImpactCount());
+            assertEquals(1, diagnostics.endpointMBeans().get(1).operations().get(0).parameterCount());
+            assertEquals("boolean", diagnostics.endpointMBeans().get(1).operations().get(0).parameters().get(0).type());
+        }
+    }
+
+    @Test
+    void reportsRegisterEndpointsDisabledWithoutRequiringMicronautJmxConfigurationBean() throws Exception {
+        MBeanServer server = MBeanServerFactory.createMBeanServer("test-domain");
+
+        try (ApplicationContext ctx = ApplicationContext.run(Map.of("jmx.register-endpoints", false))) {
+            ctx.registerSingleton(MBeanServer.class, server);
+
+            JmxDiagnostics diagnostics = ctx.getBean(JmxDiagnosticsService.class).inspect();
+
+            assertTrue(diagnostics.serverAvailable());
+            assertFalse(diagnostics.settings().configurationClassPresent());
+            assertTrue(diagnostics.settings().hasExplicitProperties());
+            assertTrue(diagnostics.settings().registerEndpointsDisabled());
+            assertTrue(diagnostics.warnings().stream().anyMatch(warning -> warning.message().contains("jmx.register-endpoints is false")));
+        }
+    }
+
+    @Test
+    void reportsUnavailableServerInsteadOfFailingWhenNoMBeanServerBeanExists() {
+        try (ApplicationContext ctx = ApplicationContext.run()) {
+            JmxDiagnostics diagnostics = ctx.getBean(JmxDiagnosticsService.class).inspect();
+
+            assertFalse(diagnostics.serverAvailable());
+            assertTrue(diagnostics.warnings().stream().anyMatch(warning -> warning.message().contains("No MBeanServer bean")));
+        }
+    }
+
+    @Test
+    void keepsEndpointRowsVisibleWhenMetadataCannotBeRead() throws Exception {
+        MBeanServer server = MBeanServerFactory.createMBeanServer("test-domain");
+        ObjectName brokenName = new ObjectName(JmxDiagnosticsService.MICRONAUT_ENDPOINT_DOMAIN + ":type=BrokenEndpoint");
+        server.registerMBean(new EndpointMBean("broken", MBeanOperationInfo.INFO), brokenName);
+
+        try (ApplicationContext ctx = ApplicationContext.run()) {
+            ctx.registerSingleton(MBeanServer.class, failingMetadataServer(server, brokenName));
+
+            JmxDiagnostics diagnostics = ctx.getBean(JmxDiagnosticsService.class).inspect();
+
+            assertEquals(1, diagnostics.endpointMBeanCount());
+            assertEquals(1, diagnostics.metadataFailureCount());
+            assertTrue(diagnostics.endpointMBeans().get(0).hasWarning());
+            assertTrue(diagnostics.endpointMBeans().get(0).warning().contains("Metadata unavailable"));
+        }
+    }
+
+    @Test
+    void controlPanelIsConfiguredAndCanBeDisabled() {
+        try (ApplicationContext ctx = ApplicationContext.run(Map.of(JmxControlPanel.ENABLED_PROPERTY, false))) {
+            ControlPanelConfiguration cfg = ctx.getBean(ControlPanelConfiguration.class, Qualifiers.byName(JmxControlPanel.NAME));
+            assertFalse(cfg.isEnabled());
+            assertFalse(ctx.containsBean(JmxControlPanel.class));
+        }
+
+        try (ApplicationContext ctx = ApplicationContext.run()) {
+            ControlPanelConfiguration cfg = ctx.getBean(ControlPanelConfiguration.class, Qualifiers.byName(JmxControlPanel.NAME));
+            JmxControlPanel panel = ctx.getBean(JmxControlPanel.class);
+
+            assertEquals("JMX", cfg.getTitle());
+            assertEquals("fa-network-wired", panel.getIcon());
+            assertEquals("diagnostics", panel.getCategory().id());
+            assertNotNull(panel.getBody());
+        }
+    }
+
+    private static void registerEndpoint(MBeanServer server, String type, DynamicMBean mBean) throws Exception {
+        server.registerMBean(mBean, new ObjectName(JmxDiagnosticsService.MICRONAUT_ENDPOINT_DOMAIN + ":type=" + type));
+    }
+
+    private static MBeanServer failingMetadataServer(MBeanServer delegate, ObjectName brokenName) {
+        return (MBeanServer) Proxy.newProxyInstance(
+            JmxDiagnosticsServiceTest.class.getClassLoader(),
+            new Class<?>[] { MBeanServer.class },
+            (proxy, method, args) -> {
+                if ("getMBeanInfo".equals(method.getName()) && args != null && args.length == 1 && brokenName.equals(args[0])) {
+                    throw new IllegalStateException("secret token should not be rendered");
+                }
+                try {
+                    return method.invoke(delegate, args);
+                } catch (InvocationTargetException e) {
+                    throw e.getCause();
+                }
+            }
+        );
+    }
+
+    private static final class EndpointMBean implements DynamicMBean {
+
+        private final String operationName;
+        private final int impact;
+        private final String parameterName;
+        private final String parameterType;
+
+        EndpointMBean(String operationName, int impact) {
+            this(operationName, impact, null, null);
+        }
+
+        EndpointMBean(String operationName, int impact, String parameterName, String parameterType) {
+            this.operationName = operationName;
+            this.impact = impact;
+            this.parameterName = parameterName;
+            this.parameterType = parameterType;
+        }
+
+        @Override
+        public Object getAttribute(String attribute) {
+            throw new AssertionError("The JMX panel must not read attribute values");
+        }
+
+        @Override
+        public void setAttribute(Attribute attribute) {
+            throw new AssertionError("The JMX panel must not write attribute values");
+        }
+
+        @Override
+        public AttributeList getAttributes(String[] attributes) {
+            throw new AssertionError("The JMX panel must not read attribute values");
+        }
+
+        @Override
+        public AttributeList setAttributes(AttributeList attributes) {
+            throw new AssertionError("The JMX panel must not write attribute values");
+        }
+
+        @Override
+        public Object invoke(String actionName, Object[] params, String[] signature) {
+            throw new AssertionError("The JMX panel must not invoke operations");
+        }
+
+        @Override
+        public MBeanInfo getMBeanInfo() {
+            MBeanParameterInfo[] signature = parameterName == null ? new MBeanParameterInfo[0] : new MBeanParameterInfo[] {
+                new MBeanParameterInfo(parameterName, parameterType, "test parameter")
+            };
+            return new MBeanInfo(
+                getClass().getName(),
+                "test endpoint MBean",
+                new MBeanAttributeInfo[] {
+                    new MBeanAttributeInfo("State", String.class.getName(), "state metadata only", true, false, false)
+                },
+                null,
+                new MBeanOperationInfo[] {
+                    new MBeanOperationInfo(operationName, "test operation", signature, String.class.getName(), impact)
+                },
+                null
+            );
+        }
+    }
+
+}

--- a/control-panel-ui/src/main/resources/static/css/dashboard.css
+++ b/control-panel-ui/src/main/resources/static/css/dashboard.css
@@ -2463,6 +2463,14 @@ dl.row dt {
     overflow-wrap: anywhere;
 }
 
+.cp-jmx-setting-value {
+    display: inline-flex;
+    flex-wrap: wrap;
+    align-items: center;
+    min-width: 0;
+    gap: 0.35rem;
+}
+
 .cp-data-table-list {
     margin: 0;
     padding-left: 1.1rem;
@@ -4163,5 +4171,51 @@ body.cp-table-browser-resizing .cp-table-browser-splitter::before {
         content: attr(data-label);
         color: var(--muted-foreground);
         font-weight: 650;
+    }
+
+    .cp-jmx-tabs-list {
+        width: 100%;
+        flex-wrap: wrap;
+        overflow-x: visible;
+    }
+
+    .cp-jmx-tabs-list .tabs-trigger {
+        flex: 1 1 9rem;
+        white-space: normal;
+    }
+
+    .cp-jmx-server-table {
+        overflow: visible;
+    }
+
+    .cp-jmx-server-table .table,
+    .cp-jmx-server-table tbody,
+    .cp-jmx-server-table tr,
+    .cp-jmx-server-table th,
+    .cp-jmx-server-table td {
+        display: block;
+        width: 100%;
+    }
+
+    .cp-jmx-server-table tr + tr {
+        border-top: 1px solid var(--border);
+    }
+
+    .cp-jmx-server-table th,
+    .cp-jmx-server-table td {
+        border-bottom: 0;
+    }
+
+    .cp-jmx-server-table th {
+        padding-bottom: 0.25rem;
+        white-space: normal;
+    }
+
+    .cp-jmx-server-table td {
+        padding-top: 0;
+    }
+
+    .cp-jmx-setting-value {
+        display: flex;
     }
 }

--- a/doc-examples/example-java/build.gradle.kts
+++ b/doc-examples/example-java/build.gradle.kts
@@ -52,7 +52,7 @@ dependencies {
 
     // JMX
     implementation(projects.micronautControlPanelJmx)
-    implementation("io.micronaut.jmx:micronaut-jmx")
+    implementation(libs.micronaut.jmx)
 
     // OpenAPI + Swagger UI (views generated at compile-time)
     annotationProcessor(mnOpenapi.micronaut.openapi)

--- a/doc-examples/example-java/build.gradle.kts
+++ b/doc-examples/example-java/build.gradle.kts
@@ -50,6 +50,10 @@ dependencies {
     implementation(libs.avro)
     implementation(libs.avro.serde)
 
+    // JMX
+    implementation(projects.micronautControlPanelJmx)
+    implementation("io.micronaut.jmx:micronaut-jmx")
+
     // OpenAPI + Swagger UI (views generated at compile-time)
     annotationProcessor(mnOpenapi.micronaut.openapi)
     testAnnotationProcessor(mnOpenapi.micronaut.openapi)

--- a/doc-examples/example-java/src/test/java/example/ControlPanelRenderingTest.java
+++ b/doc-examples/example-java/src/test/java/example/ControlPanelRenderingTest.java
@@ -18,4 +18,12 @@ class ControlPanelRenderingTest {
         assertTrue(body.contains("my-local"));
         assertTrue(body.contains("files stored."));
     }
+
+    @Test
+    void rendersJmxCategory(@Client("/") HttpClient client) {
+        var body = client.toBlocking().retrieve(HttpRequest.GET("/control-panel/categories/diagnostics"));
+
+        assertTrue(body.contains("JMX"));
+        assertTrue(body.contains("Micronaut endpoint MBeans"));
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -58,6 +58,7 @@ micronaut-sql = { module = "io.micronaut.sql:micronaut-sql-bom", version.ref = "
 micronaut-data = { module = "io.micronaut.data:micronaut-data-bom", version.ref = "micronaut-data" }
 micronaut-testresources = { module = 'io.micronaut.testresources:micronaut-test-resources-bom', version.ref = "micronaut-testresources" }
 micronaut-kafka = { module = "io.micronaut.kafka:micronaut-kafka-bom", version.ref = "micronaut-kafka" }
+micronaut-jmx = { module = "io.micronaut.jmx:micronaut-jmx" }
 avro = { module = "org.apache.avro:avro", version.ref = "avro" }
 avro-serde = { module = "io.confluent:kafka-streams-avro-serde", version.ref = "avro-serde" }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,6 +22,7 @@ include("control-panel-datasource")
 include("control-panel-hibernate")
 include("control-panel-ui")
 include("control-panel-kafka")
+include("control-panel-jmx")
 
 include("doc-examples:example-java")
 

--- a/src/main/docs/guide/controlPanels/jmx.adoc
+++ b/src/main/docs/guide/controlPanels/jmx.adoc
@@ -1,0 +1,67 @@
+= JMX Control Panel
+
+The JMX Control Panel provides a read-only diagnostics view of the Micronaut endpoint MBeans registered in the application `MBeanServer`.
+It is intended for development and test environments where you want to confirm the JMX bridge before opening tools such as JConsole, Java Mission Control, Jolokia, or an external monitoring agent.
+
+To enable the panel, add the following module as a development-time dependency:
+
+dependency:io.micronaut.controlpanel:micronaut-control-panel-jmx[scope=developmentOnly]
+
+To register Micronaut management endpoints as JMX MBeans, add the Micronaut JMX and Management modules as well:
+
+dependency:io.micronaut.jmx:micronaut-jmx[scope=developmentOnly]
+dependency:io.micronaut:micronaut-management[scope=developmentOnly]
+
+The JMX panel does not register MBeans by itself.
+It only reads metadata from an existing `MBeanServer` bean.
+
+=== Configuration
+
+The JMX Control Panel is automatically enabled when you include the `micronaut-control-panel-jmx` module.
+You can disable it with:
+
+[configuration]
+----
+micronaut:
+  control-panel:
+    panels:
+      jmx:
+        enabled: false
+----
+
+The panel also displays the configured or default Micronaut JMX settings when they are visible through application configuration:
+
+[configuration]
+----
+jmx:
+  register-endpoints: true
+  domain: io.micronaut.management.endpoint
+----
+
+When `jmx.register-endpoints=false`, the panel remains visible but shows a warning because Micronaut endpoint MBeans are not expected to be registered.
+When no Micronaut endpoint MBeans are present, the panel shows a no-data state and keeps the server and domain diagnostics available.
+
+=== What the Panel Shows
+
+The panel reports:
+
+* whether an `MBeanServer` bean is available;
+* the selected server implementation and default domain;
+* configured values for `jmx.agent-id`, `jmx.domain`, `jmx.add-to-factory`, `jmx.ignore-agent-not-found`, and `jmx.register-endpoints`;
+* total MBean count and domain counts grouped by JMX domain;
+* Micronaut endpoint MBean `ObjectName` values under `io.micronaut.management.endpoint`;
+* operation names, return types, parameter signatures, and JMX operation impacts;
+* attribute metadata names, types, and readable/writable flags.
+
+The panel does not display arbitrary non-Micronaut MBean `ObjectName` values.
+Non-Micronaut domains are grouped by count only.
+
+=== Read-Only Boundary
+
+The JMX Control Panel is diagnostics-only.
+It does not invoke JMX operations, read attribute values, write attributes, or change JMX registration.
+Attribute rows contain metadata only, not runtime values.
+
+Because JMX metadata can reveal implementation details, keep Control Panel access restricted to trusted development or test environments.
+Do not expose the Control Panel publicly without authentication and authorization.
+The JMX panel complements external JMX clients; it is not a replacement for production monitoring, auditing, Jolokia security configuration, or JVM-level access controls.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -10,6 +10,7 @@ controlPanels:
   datasource: Datasource
   hibernate: Hibernate
   kafka: Kafka
+  jmx: JMX
 
 custom: Creating Custom Control Panels
 repository: Repository


### PR DESCRIPTION
## Summary

- Adds optional `micronaut-control-panel-jmx` with read-only JMX diagnostics for the selected `MBeanServer`, Micronaut endpoint MBeans, operation signatures, operation impacts, attribute metadata, domain counts, and no-data/warning states.
- Adds docs and example-app wiring for `micronaut-jmx` plus focused rendering coverage.
- Keeps the panel diagnostic only: no JMX operation invocation, no attribute value reads or writes, and no MBean registration changes.

## Issue Linkage

Paperclip: DEV-459. This Paperclip issue has no linked GitHub issue, so no GitHub closing keyword is applicable and no GitHub issue creator reviewer can be requested.

## Release Targeting

- Target branch: `2.0.x`.
- Label: `type: enhancement`.
- Selected Micronaut organization projects: `5.0.0-M3` and `5.0.0 Release`.
- Ambiguity note: the repository release target is Control Panel `2.0.0`, while the platform-consuming target appears to be the Micronaut `5.0.0` release train, so both selected project boards should remain linked.

## Screenshots

Desktop, `1440 x 900`:

![Desktop screenshot](https://raw.githubusercontent.com/micronaut-projects/micronaut-control-panel/69a1ec331922eff69b34fc374a75e1f5d8938a44/assets/pr-553/756e95b3082b/DEV-459-jmx-1440x900.png)

Mobile, `390 x 844`:

![Mobile screenshot](https://raw.githubusercontent.com/micronaut-projects/micronaut-control-panel/64797c1bb94ef01ecbc25a5d8e313275a75af2a2/assets/pr-553/756e95b3082b/DEV-459-jmx-390x844.png)

## Verification

- `git diff --check origin/2.0.x...HEAD`
- `./gradlew :micronaut-control-panel-jmx:test :micronaut-control-panel-bom:check spotlessCheck docs`
- `./gradlew :micronaut-doc-examples:micronaut-example-java:compileJava :micronaut-control-panel-bom:check :micronaut-control-panel-jmx:test spotlessCheck`
- `./gradlew :micronaut-doc-examples:micronaut-example-java:test --tests example.ControlPanelRenderingTest`
- `./gradlew :micronaut-control-panel-jmx:checkstyleMain :micronaut-control-panel-jmx:test spotlessCheck`

## Security Notes

Security review found no blocking issues. The panel exposes runtime JMX metadata to users who can access Control Panel, so it remains scoped to development/test use and relies on existing Control Panel access controls.

---
###### ✨ This message was AI-generated using gpt-5