### PR TITLE
Add Servlet runtime control panel

### DIFF
--- a/control-panel-servlet/build.gradle.kts
+++ b/control-panel-servlet/build.gradle.kts
@@ -1,0 +1,20 @@
+plugins {
+    io.micronaut.build.internal.`control-panel-module`
+}
+
+dependencies {
+    api(projects.micronautControlPanelCore)
+
+    compileOnly(mnServlet.servlet.api)
+    compileOnly(mnServlet.micronaut.servlet.core)
+
+    testAnnotationProcessor(mn.micronaut.inject.java)
+    testImplementation(mnTest.micronaut.test.junit5)
+    testImplementation(mnTest.mockito.junit.jupiter)
+    testImplementation(mnServlet.servlet.api)
+    testRuntimeOnly(mnTest.junit.jupiter.engine)
+}
+
+micronautBuild {
+    binaryCompatibility.enabledAfter("2.0.0")
+}

--- a/control-panel-servlet/build.gradle.kts
+++ b/control-panel-servlet/build.gradle.kts
@@ -23,5 +23,5 @@ dependencies {
 }
 
 micronautBuild {
-    binaryCompatibility.enabledAfter("2.0.0")
+    binaryCompatibility.enabledAfter("2.0.1")
 }

--- a/control-panel-servlet/build.gradle.kts
+++ b/control-panel-servlet/build.gradle.kts
@@ -9,9 +9,16 @@ dependencies {
     compileOnly(mnServlet.micronaut.servlet.core)
 
     testAnnotationProcessor(mn.micronaut.inject.java)
+    testAnnotationProcessor(mnServlet.micronaut.servlet.processor)
     testImplementation(mnTest.micronaut.test.junit5)
     testImplementation(mnTest.mockito.junit.jupiter)
+    testImplementation(mn.micronaut.http.client)
+    testImplementation(mn.micronaut.management)
+    testImplementation(mnSerde.micronaut.serde.jackson)
+    testImplementation(mnServlet.micronaut.http.server.jetty)
+    testImplementation(mnServlet.micronaut.servlet.api)
     testImplementation(mnServlet.servlet.api)
+    testImplementation(projects.micronautControlPanelUi)
     testRuntimeOnly(mnTest.junit.jupiter.engine)
 }
 

--- a/control-panel-servlet/src/main/java/io/micronaut/controlpanel/panels/servlet/DiagnosticWarning.java
+++ b/control-panel-servlet/src/main/java/io/micronaut/controlpanel/panels/servlet/DiagnosticWarning.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.servlet;
+
+import io.micronaut.core.annotation.ReflectiveAccess;
+
+/**
+ * Diagnostic warning surfaced by the Servlet runtime panel.
+ *
+ * @param code stable warning code
+ * @param severity warning severity
+ * @param summary warning summary
+ */
+@ReflectiveAccess
+public record DiagnosticWarning(String code, String severity, String summary) {
+}

--- a/control-panel-servlet/src/main/java/io/micronaut/controlpanel/panels/servlet/FilterRegistrationInfo.java
+++ b/control-panel-servlet/src/main/java/io/micronaut/controlpanel/panels/servlet/FilterRegistrationInfo.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.servlet;
+
+import io.micronaut.core.annotation.ReflectiveAccess;
+
+import java.util.List;
+
+/**
+ * Servlet filter registration metadata.
+ *
+ * @param name filter registration name
+ * @param className filter implementation class name
+ * @param urlPatternMappings URL pattern mappings
+ * @param servletNameMappings servlet-name mappings
+ * @param initParameters redacted init-parameter summary
+ */
+@ReflectiveAccess
+public record FilterRegistrationInfo(
+    String name,
+    String className,
+    List<String> urlPatternMappings,
+    List<String> servletNameMappings,
+    InitParameterSummary initParameters
+) {
+}

--- a/control-panel-servlet/src/main/java/io/micronaut/controlpanel/panels/servlet/InitParameterSummary.java
+++ b/control-panel-servlet/src/main/java/io/micronaut/controlpanel/panels/servlet/InitParameterSummary.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.servlet;
+
+import io.micronaut.core.annotation.ReflectiveAccess;
+
+import java.util.List;
+
+/**
+ * Redacted init-parameter summary.
+ *
+ * @param count init-parameter count
+ * @param names init-parameter names
+ */
+@ReflectiveAccess
+public record InitParameterSummary(int count, List<String> names) {
+}

--- a/control-panel-servlet/src/main/java/io/micronaut/controlpanel/panels/servlet/RuntimeConfigInfo.java
+++ b/control-panel-servlet/src/main/java/io/micronaut/controlpanel/panels/servlet/RuntimeConfigInfo.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.servlet;
+
+import io.micronaut.core.annotation.ReflectiveAccess;
+
+/**
+ * Safe runtime configuration summary.
+ *
+ * @param label setting label
+ * @param value setting value
+ * @param source setting source
+ */
+@ReflectiveAccess
+public record RuntimeConfigInfo(String label, String value, String source) {
+}

--- a/control-panel-servlet/src/main/java/io/micronaut/controlpanel/panels/servlet/ServletContextInfo.java
+++ b/control-panel-servlet/src/main/java/io/micronaut/controlpanel/panels/servlet/ServletContextInfo.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.servlet;
+
+import io.micronaut.core.annotation.ReflectiveAccess;
+
+/**
+ * Servlet context metadata.
+ *
+ * @param contextPath servlet context path
+ * @param serverInfo servlet container server info
+ * @param servletApiVersion declared Servlet API version
+ * @param effectiveServletApiVersion effective Servlet API version
+ * @param virtualServerName virtual server name
+ */
+@ReflectiveAccess
+public record ServletContextInfo(
+    String contextPath,
+    String serverInfo,
+    String servletApiVersion,
+    String effectiveServletApiVersion,
+    String virtualServerName
+) {
+}

--- a/control-panel-servlet/src/main/java/io/micronaut/controlpanel/panels/servlet/ServletControlPanel.java
+++ b/control-panel-servlet/src/main/java/io/micronaut/controlpanel/panels/servlet/ServletControlPanel.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.servlet;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.controlpanel.core.AbstractControlPanel;
+import io.micronaut.controlpanel.core.config.ControlPanelConfiguration;
+import io.micronaut.core.util.StringUtils;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+import jakarta.servlet.ServletContext;
+
+/**
+ * Control panel that displays read-only Servlet runtime metadata.
+ *
+ * @author Sergio del Amo
+ * @since 2.0.0
+ */
+@Singleton
+@Requires(classes = ServletContext.class)
+@Requires(beans = ServletContext.class)
+@Requires(property = ServletControlPanel.ENABLED_PROPERTY, notEquals = StringUtils.FALSE)
+public class ServletControlPanel extends AbstractControlPanel<ServletRuntimeBody> {
+
+    public static final String NAME = "servlet-runtime";
+    /**
+     * Configuration property that enables the panel.
+     */
+    public static final String ENABLED_PROPERTY = ControlPanelConfiguration.PREFIX + "." + NAME + ".enabled";
+    /**
+     * Runtime category for Servlet diagnostics.
+     */
+    public static final Category CATEGORY = new Category("runtime", "Runtime", "fa-server");
+
+    private final ServletRuntimeService runtimeService;
+
+    /**
+     * Constructor.
+     *
+     * @param runtimeService servlet runtime service
+     * @param configuration panel configuration
+     */
+    public ServletControlPanel(ServletRuntimeService runtimeService,
+                                @Named(NAME) ControlPanelConfiguration configuration) {
+        super(NAME, configuration);
+        this.runtimeService = runtimeService;
+    }
+
+    @Override
+    public ServletRuntimeBody getBody() {
+        return runtimeService.getBody();
+    }
+
+    @Override
+    public String getBadge() {
+        return runtimeService.getBody().runtimeName();
+    }
+
+    @Override
+    public Category getCategory() {
+        return CATEGORY;
+    }
+}

--- a/control-panel-servlet/src/main/java/io/micronaut/controlpanel/panels/servlet/ServletControlPanel.java
+++ b/control-panel-servlet/src/main/java/io/micronaut/controlpanel/panels/servlet/ServletControlPanel.java
@@ -31,10 +31,12 @@ import jakarta.servlet.ServletContext;
  */
 @Singleton
 @Requires(classes = ServletContext.class)
-@Requires(beans = ServletContext.class)
 @Requires(property = ServletControlPanel.ENABLED_PROPERTY, notEquals = StringUtils.FALSE)
 public class ServletControlPanel extends AbstractControlPanel<ServletRuntimeBody> {
 
+    /**
+     * Stable panel name.
+     */
     public static final String NAME = "servlet-runtime";
     /**
      * Configuration property that enables the panel.

--- a/control-panel-servlet/src/main/java/io/micronaut/controlpanel/panels/servlet/ServletRegistrationInfo.java
+++ b/control-panel-servlet/src/main/java/io/micronaut/controlpanel/panels/servlet/ServletRegistrationInfo.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.servlet;
+
+import io.micronaut.core.annotation.ReflectiveAccess;
+
+import java.util.List;
+
+/**
+ * Servlet registration metadata.
+ *
+ * @param name servlet registration name
+ * @param className servlet implementation class name
+ * @param mappings URL mappings
+ * @param runAsRole run-as role, if available
+ * @param initParameters redacted init-parameter summary
+ */
+@ReflectiveAccess
+public record ServletRegistrationInfo(
+    String name,
+    String className,
+    List<String> mappings,
+    String runAsRole,
+    InitParameterSummary initParameters
+) {
+}

--- a/control-panel-servlet/src/main/java/io/micronaut/controlpanel/panels/servlet/ServletRuntimeBody.java
+++ b/control-panel-servlet/src/main/java/io/micronaut/controlpanel/panels/servlet/ServletRuntimeBody.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.servlet;
+
+import io.micronaut.core.annotation.ReflectiveAccess;
+
+import java.util.List;
+
+/**
+ * Body model for the Servlet runtime panel.
+ *
+ * @param available whether a servlet context could be inspected
+ * @param runtimeName detected servlet runtime
+ * @param runtimeMode embedded, WAR, or unknown mode
+ * @param context servlet context metadata
+ * @param servlets servlet registrations
+ * @param filters filter registrations
+ * @param config runtime configuration summaries
+ * @param warnings diagnostic warnings
+ */
+@ReflectiveAccess
+public record ServletRuntimeBody(
+    boolean available,
+    String runtimeName,
+    String runtimeMode,
+    ServletContextInfo context,
+    List<ServletRegistrationInfo> servlets,
+    List<FilterRegistrationInfo> filters,
+    List<RuntimeConfigInfo> config,
+    List<DiagnosticWarning> warnings
+) {
+}

--- a/control-panel-servlet/src/main/java/io/micronaut/controlpanel/panels/servlet/ServletRuntimeService.java
+++ b/control-panel-servlet/src/main/java/io/micronaut/controlpanel/panels/servlet/ServletRuntimeService.java
@@ -36,7 +36,6 @@ import java.util.Optional;
  */
 @Singleton
 @Requires(classes = ServletContext.class)
-@Requires(beans = ServletContext.class)
 public class ServletRuntimeService {
 
     private static final String UNKNOWN = "unknown";
@@ -55,6 +54,7 @@ public class ServletRuntimeService {
         "micronaut.server.jdk.thread-selection"
     );
 
+    @Nullable
     private final ServletContext servletContext;
     private final Environment environment;
     @Nullable
@@ -67,7 +67,7 @@ public class ServletRuntimeService {
      * @param environment application environment
      * @param embeddedServer embedded server, if available
      */
-    public ServletRuntimeService(ServletContext servletContext,
+    public ServletRuntimeService(@Nullable ServletContext servletContext,
                                   Environment environment,
                                   @Nullable EmbeddedServer embeddedServer) {
         this.servletContext = servletContext;
@@ -81,18 +81,36 @@ public class ServletRuntimeService {
      * @return servlet runtime body
      */
     public ServletRuntimeBody getBody() {
-        var servlets = servletRegistrations(servletContext);
-        var filters = filterRegistrations(servletContext);
+        ServletContext context = resolveServletContext();
+        if (context == null) {
+            return unavailableBody();
+        }
+        var servlets = servletRegistrations(context);
+        var filters = filterRegistrations(context);
         var warnings = warnings(servlets, filters);
         return new ServletRuntimeBody(
             true,
-            runtimeName(),
+            runtimeName(context),
             embeddedServer == null ? "external WAR or servlet container" : "embedded",
-            contextInfo(servletContext),
+            contextInfo(context),
             servlets,
             filters,
             runtimeConfig(),
             warnings
+        );
+    }
+
+    private ServletRuntimeBody unavailableBody() {
+        return new ServletRuntimeBody(
+            false,
+            runtimeName(null),
+            embeddedServer == null ? UNKNOWN : "embedded",
+            new ServletContextInfo(UNKNOWN, UNKNOWN, UNKNOWN, UNKNOWN, UNKNOWN),
+            List.of(),
+            List.of(),
+            runtimeConfig(),
+            List.of(new DiagnosticWarning("servlet-context-unavailable", "warning",
+                "No ServletContext is available from the Micronaut application context or detected embedded servlet server."))
         );
     }
 
@@ -164,7 +182,7 @@ public class ServletRuntimeService {
         long runtimes = availableRuntimes();
         if (runtimes > 1) {
             warnings.add(new DiagnosticWarning("multiple-runtimes", "warning",
-                "Multiple Micronaut Servlet runtimes appear to be on the classpath; the active runtime is " + runtimeName() + "."));
+                "Multiple Micronaut Servlet runtimes appear to be on the classpath; the active runtime is " + runtimeName(resolveServletContext()) + "."));
         }
         servlets.stream()
             .filter(servlet -> servlet.mappings().isEmpty())
@@ -179,7 +197,7 @@ public class ServletRuntimeService {
         return warnings;
     }
 
-    private String runtimeName() {
+    private String runtimeName(@Nullable ServletContext context) {
         if (embeddedServer != null) {
             String className = embeddedServer.getClass().getName().toLowerCase();
             if (className.contains("jetty")) {
@@ -195,7 +213,7 @@ public class ServletRuntimeService {
                 return "JDK HTTP server";
             }
         }
-        String serverInfo = safe(servletContext::getServerInfo);
+        String serverInfo = context == null ? null : safe(context::getServerInfo);
         if (serverInfo != null) {
             String lower = serverInfo.toLowerCase();
             if (lower.contains("jetty")) {
@@ -209,6 +227,48 @@ public class ServletRuntimeService {
             }
         }
         return UNKNOWN;
+    }
+
+    @Nullable
+    private ServletContext resolveServletContext() {
+        if (servletContext != null) {
+            return servletContext;
+        }
+        return embeddedServer == null ? null : servletContextFromEmbeddedServer(embeddedServer);
+    }
+
+    @Nullable
+    private ServletContext servletContextFromEmbeddedServer(EmbeddedServer server) {
+        Object nativeServer = invoke(server, "getServer");
+        return nativeServer == null ? null : findServletContext(nativeServer);
+    }
+
+    @Nullable
+    private ServletContext findServletContext(Object candidate) {
+        if (candidate instanceof ServletContext context) {
+            return context;
+        }
+        Object context = invoke(candidate, "getServletContext");
+        if (context instanceof ServletContext servletContext) {
+            return servletContext;
+        }
+        Object handler = invoke(candidate, "getHandler");
+        if (handler != null && handler != candidate) {
+            ServletContext servletContext = findServletContext(handler);
+            if (servletContext != null) {
+                return servletContext;
+            }
+        }
+        Object handlers = invoke(candidate, "getHandlers");
+        if (handlers instanceof Iterable<?> iterable) {
+            for (Object nested : iterable) {
+                ServletContext servletContext = findServletContext(nested);
+                if (servletContext != null) {
+                    return servletContext;
+                }
+            }
+        }
+        return null;
     }
 
     private long availableRuntimes() {
@@ -237,6 +297,15 @@ public class ServletRuntimeService {
         try {
             return supplier.get();
         } catch (RuntimeException e) {
+            return null;
+        }
+    }
+
+    @Nullable
+    private static Object invoke(Object target, String methodName) {
+        try {
+            return target.getClass().getMethod(methodName).invoke(target);
+        } catch (ReflectiveOperationException | RuntimeException e) {
             return null;
         }
     }

--- a/control-panel-servlet/src/main/java/io/micronaut/controlpanel/panels/servlet/ServletRuntimeService.java
+++ b/control-panel-servlet/src/main/java/io/micronaut/controlpanel/panels/servlet/ServletRuntimeService.java
@@ -39,6 +39,10 @@ import java.util.Optional;
 public class ServletRuntimeService {
 
     private static final String UNKNOWN = "unknown";
+    private static final String JETTY = "Jetty";
+    private static final String TOMCAT = "Tomcat";
+    private static final String UNDERTOW = "Undertow";
+    private static final String JDK_HTTP_SERVER = "JDK HTTP server";
     private static final List<String> SAFE_CONFIGURATION_KEYS = List.of(
         "micronaut.server.host",
         "micronaut.server.port",
@@ -199,32 +203,28 @@ public class ServletRuntimeService {
 
     private String runtimeName(@Nullable ServletContext context) {
         if (embeddedServer != null) {
-            String className = embeddedServer.getClass().getName().toLowerCase();
-            if (className.contains("jetty")) {
-                return "Jetty";
-            }
-            if (className.contains("tomcat")) {
-                return "Tomcat";
-            }
-            if (className.contains("undertow")) {
-                return "Undertow";
-            }
-            if (className.contains("jdk")) {
-                return "JDK HTTP server";
-            }
+            return detectRuntimeName(embeddedServer.getClass().getName(), true);
         }
         String serverInfo = context == null ? null : safe(context::getServerInfo);
-        if (serverInfo != null) {
-            String lower = serverInfo.toLowerCase();
-            if (lower.contains("jetty")) {
-                return "Jetty";
-            }
-            if (lower.contains("tomcat")) {
-                return "Tomcat";
-            }
-            if (lower.contains("undertow")) {
-                return "Undertow";
-            }
+        return detectRuntimeName(serverInfo, false);
+    }
+
+    private static String detectRuntimeName(@Nullable String source, boolean includeJdk) {
+        if (source == null) {
+            return UNKNOWN;
+        }
+        String value = source.toLowerCase();
+        if (value.contains("jetty")) {
+            return JETTY;
+        }
+        if (value.contains("tomcat")) {
+            return TOMCAT;
+        }
+        if (value.contains("undertow")) {
+            return UNDERTOW;
+        }
+        if (includeJdk && value.contains("jdk")) {
+            return JDK_HTTP_SERVER;
         }
         return UNKNOWN;
     }

--- a/control-panel-servlet/src/main/java/io/micronaut/controlpanel/panels/servlet/ServletRuntimeService.java
+++ b/control-panel-servlet/src/main/java/io/micronaut/controlpanel/panels/servlet/ServletRuntimeService.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.servlet;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.env.Environment;
+import io.micronaut.core.reflect.ClassUtils;
+import io.micronaut.runtime.server.EmbeddedServer;
+import jakarta.inject.Singleton;
+import jakarta.servlet.ServletContext;
+import org.jspecify.annotations.Nullable;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Extracts read-only Servlet runtime metadata for the control panel.
+ */
+@Singleton
+@Requires(classes = ServletContext.class)
+@Requires(beans = ServletContext.class)
+public class ServletRuntimeService {
+
+    private static final String UNKNOWN = "unknown";
+    private static final List<String> SAFE_CONFIGURATION_KEYS = List.of(
+        "micronaut.server.host",
+        "micronaut.server.port",
+        "micronaut.server.context-path",
+        "micronaut.server.thread-selection",
+        "micronaut.server.jetty.access-logger.enabled",
+        "micronaut.server.jetty.access-logger.format",
+        "micronaut.server.tomcat.access-logger.enabled",
+        "micronaut.server.tomcat.access-logger.pattern",
+        "micronaut.server.tomcat.access-logger.directory",
+        "micronaut.server.undertow.access-logger.enabled",
+        "micronaut.server.undertow.access-logger.pattern",
+        "micronaut.server.jdk.thread-selection"
+    );
+
+    private final ServletContext servletContext;
+    private final Environment environment;
+    @Nullable
+    private final EmbeddedServer embeddedServer;
+
+    /**
+     * Constructor.
+     *
+     * @param servletContext servlet context
+     * @param environment application environment
+     * @param embeddedServer embedded server, if available
+     */
+    public ServletRuntimeService(ServletContext servletContext,
+                                  Environment environment,
+                                  @Nullable EmbeddedServer embeddedServer) {
+        this.servletContext = servletContext;
+        this.environment = environment;
+        this.embeddedServer = embeddedServer;
+    }
+
+    /**
+     * Builds the body model for rendering.
+     *
+     * @return servlet runtime body
+     */
+    public ServletRuntimeBody getBody() {
+        var servlets = servletRegistrations(servletContext);
+        var filters = filterRegistrations(servletContext);
+        var warnings = warnings(servlets, filters);
+        return new ServletRuntimeBody(
+            true,
+            runtimeName(),
+            embeddedServer == null ? "external WAR or servlet container" : "embedded",
+            contextInfo(servletContext),
+            servlets,
+            filters,
+            runtimeConfig(),
+            warnings
+        );
+    }
+
+    private ServletContextInfo contextInfo(ServletContext context) {
+        return new ServletContextInfo(
+            text(context.getContextPath(), "/"),
+            text(safe(context::getServerInfo), UNKNOWN),
+            context.getMajorVersion() + "." + context.getMinorVersion(),
+            context.getEffectiveMajorVersion() + "." + context.getEffectiveMinorVersion(),
+            text(safe(context::getVirtualServerName), UNKNOWN)
+        );
+    }
+
+    private List<ServletRegistrationInfo> servletRegistrations(ServletContext context) {
+        return context.getServletRegistrations()
+            .values()
+            .stream()
+            .map(registration -> new ServletRegistrationInfo(
+                text(registration.getName(), "(unnamed)"),
+                text(registration.getClassName(), UNKNOWN),
+                sorted(registration.getMappings()),
+                text(safe(registration::getRunAsRole), UNKNOWN),
+                initParameters(registration.getInitParameters())
+            ))
+            .sorted(Comparator.comparing(ServletRegistrationInfo::name))
+            .toList();
+    }
+
+    private List<FilterRegistrationInfo> filterRegistrations(ServletContext context) {
+        return context.getFilterRegistrations()
+            .values()
+            .stream()
+            .map(registration -> new FilterRegistrationInfo(
+                text(registration.getName(), "(unnamed)"),
+                text(registration.getClassName(), UNKNOWN),
+                sorted(registration.getUrlPatternMappings()),
+                sorted(registration.getServletNameMappings()),
+                initParameters(registration.getInitParameters())
+            ))
+            .sorted(Comparator.comparing(FilterRegistrationInfo::name))
+            .toList();
+    }
+
+    private InitParameterSummary initParameters(Map<String, String> initParameters) {
+        return new InitParameterSummary(initParameters.size(), initParameters.keySet().stream().sorted().toList());
+    }
+
+    private List<RuntimeConfigInfo> runtimeConfig() {
+        List<RuntimeConfigInfo> values = new ArrayList<>();
+        if (embeddedServer != null) {
+            values.add(new RuntimeConfigInfo("Active server", embeddedServer.getClass().getName(), "EmbeddedServer"));
+            URI uri = safe(embeddedServer::getURI);
+            if (uri != null) {
+                values.add(new RuntimeConfigInfo("Server URI", uri.toString(), "EmbeddedServer"));
+            }
+        }
+        for (String key : SAFE_CONFIGURATION_KEYS) {
+            Optional<String> value = environment.getProperty(key, String.class);
+            value.ifPresent(v -> values.add(new RuntimeConfigInfo(key, v, "configuration")));
+        }
+        if (values.isEmpty()) {
+            values.add(new RuntimeConfigInfo("Runtime configuration", "No selected Servlet runtime configuration properties are available.", "configuration"));
+        }
+        return values;
+    }
+
+    private List<DiagnosticWarning> warnings(List<ServletRegistrationInfo> servlets, List<FilterRegistrationInfo> filters) {
+        List<DiagnosticWarning> warnings = new ArrayList<>();
+        long runtimes = availableRuntimes();
+        if (runtimes > 1) {
+            warnings.add(new DiagnosticWarning("multiple-runtimes", "warning",
+                "Multiple Micronaut Servlet runtimes appear to be on the classpath; the active runtime is " + runtimeName() + "."));
+        }
+        servlets.stream()
+            .filter(servlet -> servlet.mappings().isEmpty())
+            .map(servlet -> new DiagnosticWarning("servlet-without-mapping", "info",
+                "Servlet '" + servlet.name() + "' is registered without URL mappings."))
+            .forEach(warnings::add);
+        filters.stream()
+            .filter(filter -> filter.urlPatternMappings().isEmpty() && filter.servletNameMappings().isEmpty())
+            .map(filter -> new DiagnosticWarning("filter-without-mapping", "info",
+                "Filter '" + filter.name() + "' is registered without URL pattern or servlet-name mappings."))
+            .forEach(warnings::add);
+        return warnings;
+    }
+
+    private String runtimeName() {
+        if (embeddedServer != null) {
+            String className = embeddedServer.getClass().getName().toLowerCase();
+            if (className.contains("jetty")) {
+                return "Jetty";
+            }
+            if (className.contains("tomcat")) {
+                return "Tomcat";
+            }
+            if (className.contains("undertow")) {
+                return "Undertow";
+            }
+            if (className.contains("jdk")) {
+                return "JDK HTTP server";
+            }
+        }
+        String serverInfo = safe(servletContext::getServerInfo);
+        if (serverInfo != null) {
+            String lower = serverInfo.toLowerCase();
+            if (lower.contains("jetty")) {
+                return "Jetty";
+            }
+            if (lower.contains("tomcat")) {
+                return "Tomcat";
+            }
+            if (lower.contains("undertow")) {
+                return "Undertow";
+            }
+        }
+        return UNKNOWN;
+    }
+
+    private long availableRuntimes() {
+        ClassLoader classLoader = getClass().getClassLoader();
+        return List.of(
+                "io.micronaut.servlet.jetty.JettyServer",
+                "io.micronaut.servlet.tomcat.TomcatServer",
+                "io.micronaut.servlet.undertow.UndertowServer",
+                "io.micronaut.servlet.jdk.JdkHttpServer"
+            )
+            .stream()
+            .filter(type -> ClassUtils.isPresent(type, classLoader))
+            .count();
+    }
+
+    private static List<String> sorted(Collection<String> values) {
+        return values.stream().sorted().toList();
+    }
+
+    private static String text(@Nullable String value, String fallback) {
+        return value == null || value.isBlank() ? fallback : value;
+    }
+
+    @Nullable
+    private static <T> T safe(SupplierWithException<T> supplier) {
+        try {
+            return supplier.get();
+        } catch (RuntimeException e) {
+            return null;
+        }
+    }
+
+    @FunctionalInterface
+    private interface SupplierWithException<T> {
+        T get();
+    }
+}

--- a/control-panel-servlet/src/main/java/io/micronaut/controlpanel/panels/servlet/package-info.java
+++ b/control-panel-servlet/src/main/java/io/micronaut/controlpanel/panels/servlet/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Servlet runtime diagnostics control panel.
+ */
+@NullMarked
+package io.micronaut.controlpanel.panels.servlet;
+
+import org.jspecify.annotations.NullMarked;

--- a/control-panel-servlet/src/main/resources/micronaut-control-panel/micronaut-control-panel.properties
+++ b/control-panel-servlet/src/main/resources/micronaut-control-panel/micronaut-control-panel.properties
@@ -1,0 +1,4 @@
+micronaut.control-panel.panels.servlet-runtime.title = Servlet Runtime
+micronaut.control-panel.panels.servlet-runtime.icon = fa-server
+micronaut.control-panel.panels.servlet-runtime.order = 25
+micronaut.control-panel.panels.servlet-runtime.enabled = true

--- a/control-panel-servlet/src/main/resources/views/servlet-runtime/body.hbs
+++ b/control-panel-servlet/src/main/resources/views/servlet-runtime/body.hbs
@@ -1,0 +1,28 @@
+{{#with controlPanel.body }}
+    <div class="cp-data-table-container cp-vertical-table">
+        <table class="table cp-data-table-table">
+            <tbody>
+            <tr>
+                <th scope="row">Runtime</th>
+                <td><span class="badge badge-secondary">{{runtimeName}}</span> {{runtimeMode}}</td>
+            </tr>
+            <tr>
+                <th scope="row">Context</th>
+                <td><code>{{context.contextPath}}</code> {{context.serverInfo}}</td>
+            </tr>
+            <tr>
+                <th scope="row">Servlet API</th>
+                <td>{{context.servletApiVersion}} effective {{context.effectiveServletApiVersion}}</td>
+            </tr>
+            <tr>
+                <th scope="row">Registrations</th>
+                <td>{{servlets.size}} servlets, {{filters.size}} filters</td>
+            </tr>
+            <tr>
+                <th scope="row">Warnings</th>
+                <td>{{warnings.size}}</td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+{{/with}}

--- a/control-panel-servlet/src/main/resources/views/servlet-runtime/detail.hbs
+++ b/control-panel-servlet/src/main/resources/views/servlet-runtime/detail.hbs
@@ -1,0 +1,177 @@
+{{#with controlPanel.body }}
+    <div class="cp-dashboard-stack">
+        <div class="row">
+            <div class="col-lg-4">
+                <div class="card">
+                    <div class="card-header">
+                        <h5 class="card-title">Runtime</h5>
+                    </div>
+                    <div class="card-body">
+                        <dl class="row">
+                            <dt class="col-sm-5">Runtime</dt>
+                            <dd class="col-sm-7"><span class="badge badge-primary">{{runtimeName}}</span></dd>
+                            <dt class="col-sm-5">Mode</dt>
+                            <dd class="col-sm-7">{{runtimeMode}}</dd>
+                            <dt class="col-sm-5">Server info</dt>
+                            <dd class="col-sm-7"><code>{{context.serverInfo}}</code></dd>
+                            <dt class="col-sm-5">Context path</dt>
+                            <dd class="col-sm-7"><code>{{context.contextPath}}</code></dd>
+                            <dt class="col-sm-5">Servlet API</dt>
+                            <dd class="col-sm-7">{{context.servletApiVersion}} effective {{context.effectiveServletApiVersion}}</dd>
+                            <dt class="col-sm-5">Virtual server</dt>
+                            <dd class="col-sm-7"><code>{{context.virtualServerName}}</code></dd>
+                        </dl>
+                    </div>
+                </div>
+            </div>
+            <div class="col-lg-8">
+                <div class="card">
+                    <div class="card-header">
+                        <h5 class="card-title">Runtime configuration</h5>
+                    </div>
+                    <div class="card-body">
+                        <div class="cp-data-table-container">
+                            <table class="table cp-data-table-table">
+                                <thead>
+                                <tr>
+                                    <th>Setting</th>
+                                    <th>Value</th>
+                                    <th>Source</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                {{#each config}}
+                                    <tr>
+                                        <td><code class="cp-table-code">{{label}}</code></td>
+                                        <td><code class="cp-table-code">{{value}}</code></td>
+                                        <td>{{source}}</td>
+                                    </tr>
+                                {{/each}}
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="card">
+            <div class="card-header">
+                <h5 class="card-title">Servlets</h5>
+            </div>
+            <div class="card-body">
+                {{#if servlets}}
+                    <div class="cp-data-table-container">
+                        <table class="table cp-data-table-table cp-data-table-fixed">
+                            <thead>
+                            <tr>
+                                <th>Name</th>
+                                <th>Class</th>
+                                <th>Mappings</th>
+                                <th>Run as</th>
+                                <th>Init parameters</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            {{#each servlets}}
+                                <tr>
+                                    <td><code class="cp-table-code">{{name}}</code></td>
+                                    <td><code class="cp-table-code">{{className}}</code></td>
+                                    <td>
+                                        {{#if mappings}}
+                                            {{#each mappings}}<code class="cp-table-code">{{this}}</code> {{/each}}
+                                        {{else}}
+                                            <span class="text-muted">No mappings</span>
+                                        {{/if}}
+                                    </td>
+                                    <td>{{runAsRole}}</td>
+                                    <td>
+                                        {{initParameters.count}} names
+                                        {{#if initParameters.names}}
+                                            {{#each initParameters.names}}<code class="cp-table-code">{{this}}</code> {{/each}}
+                                            <span class="badge badge-secondary">values redacted</span>
+                                        {{/if}}
+                                    </td>
+                                </tr>
+                            {{/each}}
+                            </tbody>
+                        </table>
+                    </div>
+                {{else}}
+                    <p>No servlet registrations are available from the ServletContext.</p>
+                {{/if}}
+            </div>
+        </div>
+
+        <div class="card">
+            <div class="card-header">
+                <h5 class="card-title">Filters</h5>
+            </div>
+            <div class="card-body">
+                {{#if filters}}
+                    <div class="cp-data-table-container">
+                        <table class="table cp-data-table-table cp-data-table-fixed">
+                            <thead>
+                            <tr>
+                                <th>Name</th>
+                                <th>Class</th>
+                                <th>URL patterns</th>
+                                <th>Servlet mappings</th>
+                                <th>Init parameters</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            {{#each filters}}
+                                <tr>
+                                    <td><code class="cp-table-code">{{name}}</code></td>
+                                    <td><code class="cp-table-code">{{className}}</code></td>
+                                    <td>
+                                        {{#if urlPatternMappings}}
+                                            {{#each urlPatternMappings}}<code class="cp-table-code">{{this}}</code> {{/each}}
+                                        {{else}}
+                                            <span class="text-muted">No URL patterns</span>
+                                        {{/if}}
+                                    </td>
+                                    <td>
+                                        {{#if servletNameMappings}}
+                                            {{#each servletNameMappings}}<code class="cp-table-code">{{this}}</code> {{/each}}
+                                        {{else}}
+                                            <span class="text-muted">No servlet mappings</span>
+                                        {{/if}}
+                                    </td>
+                                    <td>
+                                        {{initParameters.count}} names
+                                        {{#if initParameters.names}}
+                                            {{#each initParameters.names}}<code class="cp-table-code">{{this}}</code> {{/each}}
+                                            <span class="badge badge-secondary">values redacted</span>
+                                        {{/if}}
+                                    </td>
+                                </tr>
+                            {{/each}}
+                            </tbody>
+                        </table>
+                    </div>
+                {{else}}
+                    <p>No filter registrations are available from the ServletContext.</p>
+                {{/if}}
+            </div>
+        </div>
+
+        <div class="card">
+            <div class="card-header">
+                <h5 class="card-title">Warnings</h5>
+            </div>
+            <div class="card-body">
+                {{#if warnings}}
+                    <ul>
+                    {{#each warnings}}
+                        <li><span class="badge badge-secondary">{{severity}}</span> <code>{{code}}</code> {{summary}}</li>
+                    {{/each}}
+                    </ul>
+                {{else}}
+                    <p>No Servlet runtime warnings detected.</p>
+                {{/if}}
+            </div>
+        </div>
+    </div>
+{{/with}}

--- a/control-panel-servlet/src/main/resources/views/servlet-runtime/detail.hbs
+++ b/control-panel-servlet/src/main/resources/views/servlet-runtime/detail.hbs
@@ -1,5 +1,11 @@
 {{#with controlPanel.body }}
     <div class="cp-dashboard-stack">
+        {{#unless available}}
+            <div class="alert alert-warning" role="status">
+                Servlet runtime details are unavailable because no inspectable ServletContext was found.
+            </div>
+        {{/unless}}
+
         <div class="row">
             <div class="col-lg-4">
                 <div class="card">

--- a/control-panel-servlet/src/test/java/io/micronaut/controlpanel/panels/servlet/ServletControlPanelJettyIntegrationTest.java
+++ b/control-panel-servlet/src/test/java/io/micronaut/controlpanel/panels/servlet/ServletControlPanelJettyIntegrationTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.servlet;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.controlpanel.core.config.ControlPanelModuleConfiguration;
+import io.micronaut.controlpanel.core.security.ControlPanelSecurityConfiguration;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.runtime.server.EmbeddedServer;
+import io.micronaut.servlet.api.annotation.ServletFilterBean;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ServletControlPanelJettyIntegrationTest {
+
+    @Test
+    void rendersServletRuntimePanelFromJettyServletContext() {
+        EmbeddedServer server = ApplicationContext.run(EmbeddedServer.class, Map.of(
+            "micronaut.server.port", -1,
+            ControlPanelSecurityConfiguration.PROPERTY_ACCESS, "ANONYMOUS"
+        ));
+        try {
+            var client = server.getApplicationContext().createBean(HttpClient.class, server.getURL()).toBlocking();
+            assertTrue(server.getApplicationContext().containsBean(ServletControlPanel.class));
+
+            String html = client.retrieve(ControlPanelModuleConfiguration.DEFAULT_PATH + "/" + ServletControlPanel.NAME);
+
+            assertTrue(html.contains("Servlet Runtime"));
+            assertTrue(html.contains("Jetty"));
+            assertTrue(html.contains("Servlet API"));
+            assertTrue(html.contains("RenderedAuditFilter"));
+            assertTrue(html.contains("/api/*"));
+            assertTrue(html.contains("MicronautServlet"));
+        } finally {
+            server.stop();
+        }
+    }
+
+    @Factory
+    static final class FilterFactory {
+        @ServletFilterBean(
+            filterName = "RenderedAuditFilter",
+            urlPatterns = "/api/*",
+            servletNames = "MicronautServlet"
+        )
+        Filter renderedAuditFilter() {
+            return new RenderedAuditFilter();
+        }
+    }
+
+    private static final class RenderedAuditFilter implements Filter {
+        @Override
+        public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+            chain.doFilter(request, response);
+        }
+    }
+}

--- a/control-panel-servlet/src/test/java/io/micronaut/controlpanel/panels/servlet/ServletControlPanelTest.java
+++ b/control-panel-servlet/src/test/java/io/micronaut/controlpanel/panels/servlet/ServletControlPanelTest.java
@@ -26,8 +26,6 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRegistration;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
-import jakarta.servlet.annotation.WebFilter;
-import jakarta.servlet.annotation.WebInitParam;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -45,11 +43,17 @@ import static org.mockito.Mockito.when;
 
 class ServletControlPanelTest {
 
+    private static final String AUDIT_FILTER_NAME = "AuditFilter";
+    private static final String AUDIT_FILTER_URL_PATTERN = "/api/*";
+    private static final String AUDIT_FILTER_SERVLET_NAME = "MicronautServlet";
+
     @Test
-    void panelIsAbsentWithoutServletContext() {
+    void serviceShowsUnavailableStateWithoutServletContext() {
         try (ApplicationContext ctx = ApplicationContext.run()) {
-            assertFalse(ctx.containsBean(ServletRuntimeService.class));
-            assertFalse(ctx.containsBean(ServletControlPanel.class));
+            ServletRuntimeService service = new ServletRuntimeService(null, ctx.getEnvironment(), null);
+            ServletRuntimeBody body = service.getBody();
+            assertFalse(body.available());
+            assertTrue(body.warnings().stream().anyMatch(warning -> warning.code().equals("servlet-context-unavailable")));
         }
     }
 
@@ -82,10 +86,8 @@ class ServletControlPanelTest {
             assertEquals("/demo", body.context().contextPath());
             assertEquals("6.1", body.context().servletApiVersion());
             assertEquals(List.of("/"), body.servlets().get(0).mappings());
-            WebFilter annotation = AuditFilter.class.getAnnotation(WebFilter.class);
-
-            assertEquals(List.of(annotation.urlPatterns()[0]), body.filters().get(0).urlPatternMappings());
-            assertEquals(List.of(annotation.servletNames()[0]), body.filters().get(0).servletNameMappings());
+            assertEquals(List.of(AUDIT_FILTER_URL_PATTERN), body.filters().get(0).urlPatternMappings());
+            assertEquals(List.of(AUDIT_FILTER_SERVLET_NAME), body.filters().get(0).servletNameMappings());
             assertEquals(List.of("apiKey"), body.filters().get(0).initParameters().names());
             assertFalse(body.toString().contains("super-secret-value"));
             assertTrue(body.config().stream().anyMatch(config -> config.label().equals("micronaut.server.port") && config.value().equals("8081")));
@@ -126,21 +128,14 @@ class ServletControlPanelTest {
         when(servlet.getRunAsRole()).thenReturn(null);
         when(servlet.getInitParameters()).thenReturn(Map.of("startupMode", "super-secret-value"));
 
-        WebFilter annotation = AuditFilter.class.getAnnotation(WebFilter.class);
-        when(filter.getName()).thenReturn(annotation.filterName());
+        when(filter.getName()).thenReturn(AUDIT_FILTER_NAME);
         when(filter.getClassName()).thenReturn(AuditFilter.class.getName());
-        when(filter.getUrlPatternMappings()).thenReturn(List.of(annotation.urlPatterns()));
-        when(filter.getServletNameMappings()).thenReturn(List.of(annotation.servletNames()));
+        when(filter.getUrlPatternMappings()).thenReturn(List.of(AUDIT_FILTER_URL_PATTERN));
+        when(filter.getServletNameMappings()).thenReturn(List.of(AUDIT_FILTER_SERVLET_NAME));
         when(filter.getInitParameters()).thenReturn(Map.of("apiKey", "super-secret-value"));
         return context;
     }
 
-    @WebFilter(
-        filterName = "AuditFilter",
-        urlPatterns = "/api/*",
-        servletNames = "MicronautServlet",
-        initParams = @WebInitParam(name = "apiKey", value = "super-secret-value")
-    )
     private static final class AuditFilter implements Filter {
         @Override
         public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {

--- a/control-panel-servlet/src/test/java/io/micronaut/controlpanel/panels/servlet/ServletControlPanelTest.java
+++ b/control-panel-servlet/src/test/java/io/micronaut/controlpanel/panels/servlet/ServletControlPanelTest.java
@@ -18,6 +18,7 @@ package io.micronaut.controlpanel.panels.servlet;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.controlpanel.core.config.ControlPanelConfiguration;
 import io.micronaut.inject.qualifiers.Qualifiers;
+import io.micronaut.runtime.server.EmbeddedServer;
 import jakarta.servlet.FilterRegistration;
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
@@ -29,6 +30,7 @@ import jakarta.servlet.ServletResponse;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
@@ -38,6 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
@@ -95,6 +98,69 @@ class ServletControlPanelTest {
     }
 
     @Test
+    void detectsRuntimeFromServletContextServerInfo() {
+        try (ApplicationContext ctx = ApplicationContext.run()) {
+            assertEquals("Tomcat", new ServletRuntimeService(servletContext("Apache Tomcat/10.1.20"), ctx.getEnvironment(), null).getBody().runtimeName());
+            assertEquals("Undertow", new ServletRuntimeService(servletContext("Undertow/2.3.10"), ctx.getEnvironment(), null).getBody().runtimeName());
+            assertEquals("unknown", new ServletRuntimeService(servletContext("ExampleServer/1.0"), ctx.getEnvironment(), null).getBody().runtimeName());
+        }
+    }
+
+    @Test
+    void sortsRegistrationsAndWarnsWhenMappingsAreMissing() {
+        try (ApplicationContext ctx = ApplicationContext.run()) {
+            ServletContext context = mock(ServletContext.class);
+            ServletRegistration zServlet = servlet("ZServlet", List.of("/z"));
+            ServletRegistration aServlet = servlet("AServlet", List.of());
+            FilterRegistration zFilter = filter("ZFilter", List.of("/z/*"), List.of());
+            FilterRegistration aFilter = filter("AFilter", List.of(), List.of());
+
+            basicContext(context, "Jetty(12.0.0)");
+            doReturn(Map.of("ZServlet", zServlet, "AServlet", aServlet)).when(context).getServletRegistrations();
+            doReturn(Map.of("ZFilter", zFilter, "AFilter", aFilter)).when(context).getFilterRegistrations();
+
+            ServletRuntimeBody body = new ServletRuntimeService(context, ctx.getEnvironment(), null).getBody();
+
+            assertEquals(List.of("AServlet", "ZServlet"), body.servlets().stream().map(ServletRegistrationInfo::name).toList());
+            assertEquals(List.of("AFilter", "ZFilter"), body.filters().stream().map(FilterRegistrationInfo::name).toList());
+            assertTrue(body.warnings().stream().anyMatch(warning -> warning.code().equals("servlet-without-mapping")));
+            assertTrue(body.warnings().stream().anyMatch(warning -> warning.code().equals("filter-without-mapping")));
+        }
+    }
+
+    @Test
+    void usesSafeFallbacksForUnavailableServletContextMetadata() {
+        try (ApplicationContext ctx = ApplicationContext.run()) {
+            ServletContext context = servletContext("Jetty(12.0.0)");
+            when(context.getContextPath()).thenReturn(" ");
+            doThrow(IllegalStateException.class).when(context).getServerInfo();
+            doThrow(IllegalStateException.class).when(context).getVirtualServerName();
+
+            ServletRuntimeBody body = new ServletRuntimeService(context, ctx.getEnvironment(), null).getBody();
+
+            assertEquals("/", body.context().contextPath());
+            assertEquals("unknown", body.context().serverInfo());
+            assertEquals("unknown", body.context().virtualServerName());
+            assertEquals("unknown", body.runtimeName());
+        }
+    }
+
+    @Test
+    void includesEmbeddedServerRuntimeConfigurationWhenAvailable() {
+        try (ApplicationContext ctx = ApplicationContext.run()) {
+            EmbeddedServer server = mock(EmbeddedServer.class);
+            when(server.getURI()).thenReturn(URI.create("http://localhost:8080"));
+
+            ServletRuntimeBody body = new ServletRuntimeService(null, ctx.getEnvironment(), server).getBody();
+
+            assertFalse(body.available());
+            assertEquals("embedded", body.runtimeMode());
+            assertTrue(body.config().stream().anyMatch(config -> config.label().equals("Active server")));
+            assertTrue(body.config().stream().anyMatch(config -> config.label().equals("Server URI") && config.value().equals("http://localhost:8080")));
+        }
+    }
+
+    @Test
     void templateShowsMappingsAndRedactionLabel() throws IOException {
         try (var in = getClass().getResourceAsStream("/views/servlet-runtime/detail.hbs")) {
             assertNotNull(in);
@@ -108,32 +174,48 @@ class ServletControlPanelTest {
     }
 
     private static ServletContext servletContext() {
-        ServletContext context = mock(ServletContext.class);
-        ServletRegistration servlet = mock(ServletRegistration.class);
-        FilterRegistration filter = mock(FilterRegistration.class);
+        return servletContext("Jetty(12.0.0)");
+    }
 
+    private static ServletContext servletContext(String serverInfo) {
+        ServletContext context = mock(ServletContext.class);
+        ServletRegistration servlet = servlet("MicronautServlet", List.of("/"));
+        FilterRegistration filter = filter(AUDIT_FILTER_NAME, List.of(AUDIT_FILTER_URL_PATTERN), List.of(AUDIT_FILTER_SERVLET_NAME));
+
+        basicContext(context, serverInfo);
+        doReturn(Map.of("MicronautServlet", servlet)).when(context).getServletRegistrations();
+        doReturn(Map.of("AuditFilter", filter)).when(context).getFilterRegistrations();
+        return context;
+    }
+
+    private static void basicContext(ServletContext context, String serverInfo) {
         when(context.getContextPath()).thenReturn("/demo");
-        when(context.getServerInfo()).thenReturn("Jetty(12.0.0)");
+        when(context.getServerInfo()).thenReturn(serverInfo);
         when(context.getMajorVersion()).thenReturn(6);
         when(context.getMinorVersion()).thenReturn(1);
         when(context.getEffectiveMajorVersion()).thenReturn(6);
         when(context.getEffectiveMinorVersion()).thenReturn(1);
         when(context.getVirtualServerName()).thenReturn("default");
-        doReturn(Map.of("MicronautServlet", servlet)).when(context).getServletRegistrations();
-        doReturn(Map.of("AuditFilter", filter)).when(context).getFilterRegistrations();
+    }
 
-        when(servlet.getName()).thenReturn("MicronautServlet");
+    private static ServletRegistration servlet(String name, List<String> mappings) {
+        ServletRegistration servlet = mock(ServletRegistration.class);
+        when(servlet.getName()).thenReturn(name);
         when(servlet.getClassName()).thenReturn("io.micronaut.servlet.engine.DefaultMicronautServlet");
-        when(servlet.getMappings()).thenReturn(List.of("/"));
+        when(servlet.getMappings()).thenReturn(mappings);
         when(servlet.getRunAsRole()).thenReturn(null);
         when(servlet.getInitParameters()).thenReturn(Map.of("startupMode", "super-secret-value"));
+        return servlet;
+    }
 
-        when(filter.getName()).thenReturn(AUDIT_FILTER_NAME);
+    private static FilterRegistration filter(String name, List<String> urlPatternMappings, List<String> servletNameMappings) {
+        FilterRegistration filter = mock(FilterRegistration.class);
+        when(filter.getName()).thenReturn(name);
         when(filter.getClassName()).thenReturn(AuditFilter.class.getName());
-        when(filter.getUrlPatternMappings()).thenReturn(List.of(AUDIT_FILTER_URL_PATTERN));
-        when(filter.getServletNameMappings()).thenReturn(List.of(AUDIT_FILTER_SERVLET_NAME));
+        when(filter.getUrlPatternMappings()).thenReturn(urlPatternMappings);
+        when(filter.getServletNameMappings()).thenReturn(servletNameMappings);
         when(filter.getInitParameters()).thenReturn(Map.of("apiKey", "super-secret-value"));
-        return context;
+        return filter;
     }
 
     private static final class AuditFilter implements Filter {

--- a/control-panel-servlet/src/test/java/io/micronaut/controlpanel/panels/servlet/ServletControlPanelTest.java
+++ b/control-panel-servlet/src/test/java/io/micronaut/controlpanel/panels/servlet/ServletControlPanelTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.servlet;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.controlpanel.core.config.ControlPanelConfiguration;
+import io.micronaut.inject.qualifiers.Qualifiers;
+import jakarta.servlet.FilterRegistration;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRegistration;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.annotation.WebFilter;
+import jakarta.servlet.annotation.WebInitParam;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+class ServletControlPanelTest {
+
+    @Test
+    void panelIsAbsentWithoutServletContext() {
+        try (ApplicationContext ctx = ApplicationContext.run()) {
+            assertFalse(ctx.containsBean(ServletRuntimeService.class));
+            assertFalse(ctx.containsBean(ServletControlPanel.class));
+        }
+    }
+
+    @Test
+    void panelCanBeDisabled() {
+        try (ApplicationContext ctx = ApplicationContext.builder()
+            .properties(Map.of(ServletControlPanel.ENABLED_PROPERTY, false))
+            .singletons(servletContext())
+            .start()) {
+            ControlPanelConfiguration cfg = ctx.getBean(ControlPanelConfiguration.class, Qualifiers.byName(ServletControlPanel.NAME));
+            assertFalse(cfg.isEnabled());
+            assertTrue(ctx.containsBean(ServletRuntimeService.class));
+            assertFalse(ctx.containsBean(ServletControlPanel.class));
+        }
+    }
+
+    @Test
+    void readsWebFilterMappingsAndRedactsInitParameterValues() {
+        try (ApplicationContext ctx = ApplicationContext.builder()
+            .properties(Map.of("micronaut.server.port", 8081))
+            .singletons(servletContext())
+            .start()) {
+            ServletControlPanel panel = ctx.getBean(ServletControlPanel.class);
+
+            ServletRuntimeBody body = panel.getBody();
+
+            assertEquals("Servlet Runtime", panel.getTitle());
+            assertEquals("fa-server", panel.getIcon());
+            assertEquals("Jetty", body.runtimeName());
+            assertEquals("/demo", body.context().contextPath());
+            assertEquals("6.1", body.context().servletApiVersion());
+            assertEquals(List.of("/"), body.servlets().get(0).mappings());
+            WebFilter annotation = AuditFilter.class.getAnnotation(WebFilter.class);
+
+            assertEquals(List.of(annotation.urlPatterns()[0]), body.filters().get(0).urlPatternMappings());
+            assertEquals(List.of(annotation.servletNames()[0]), body.filters().get(0).servletNameMappings());
+            assertEquals(List.of("apiKey"), body.filters().get(0).initParameters().names());
+            assertFalse(body.toString().contains("super-secret-value"));
+            assertTrue(body.config().stream().anyMatch(config -> config.label().equals("micronaut.server.port") && config.value().equals("8081")));
+        }
+    }
+
+    @Test
+    void templateShowsMappingsAndRedactionLabel() throws IOException {
+        try (var in = getClass().getResourceAsStream("/views/servlet-runtime/detail.hbs")) {
+            assertNotNull(in);
+            var template = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+
+            assertTrue(template.contains("URL patterns"));
+            assertTrue(template.contains("Servlet mappings"));
+            assertTrue(template.contains("values redacted"));
+            assertFalse(template.contains("getInitParameter"));
+        }
+    }
+
+    private static ServletContext servletContext() {
+        ServletContext context = mock(ServletContext.class);
+        ServletRegistration servlet = mock(ServletRegistration.class);
+        FilterRegistration filter = mock(FilterRegistration.class);
+
+        when(context.getContextPath()).thenReturn("/demo");
+        when(context.getServerInfo()).thenReturn("Jetty(12.0.0)");
+        when(context.getMajorVersion()).thenReturn(6);
+        when(context.getMinorVersion()).thenReturn(1);
+        when(context.getEffectiveMajorVersion()).thenReturn(6);
+        when(context.getEffectiveMinorVersion()).thenReturn(1);
+        when(context.getVirtualServerName()).thenReturn("default");
+        doReturn(Map.of("MicronautServlet", servlet)).when(context).getServletRegistrations();
+        doReturn(Map.of("AuditFilter", filter)).when(context).getFilterRegistrations();
+
+        when(servlet.getName()).thenReturn("MicronautServlet");
+        when(servlet.getClassName()).thenReturn("io.micronaut.servlet.engine.DefaultMicronautServlet");
+        when(servlet.getMappings()).thenReturn(List.of("/"));
+        when(servlet.getRunAsRole()).thenReturn(null);
+        when(servlet.getInitParameters()).thenReturn(Map.of("startupMode", "super-secret-value"));
+
+        WebFilter annotation = AuditFilter.class.getAnnotation(WebFilter.class);
+        when(filter.getName()).thenReturn(annotation.filterName());
+        when(filter.getClassName()).thenReturn(AuditFilter.class.getName());
+        when(filter.getUrlPatternMappings()).thenReturn(List.of(annotation.urlPatterns()));
+        when(filter.getServletNameMappings()).thenReturn(List.of(annotation.servletNames()));
+        when(filter.getInitParameters()).thenReturn(Map.of("apiKey", "super-secret-value"));
+        return context;
+    }
+
+    @WebFilter(
+        filterName = "AuditFilter",
+        urlPatterns = "/api/*",
+        servletNames = "MicronautServlet",
+        initParams = @WebInitParam(name = "apiKey", value = "super-secret-value")
+    )
+    private static final class AuditFilter implements Filter {
+        @Override
+        public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+            chain.doFilter(request, response);
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ micronaut-testresources = "4.0.0"
 micronaut-gradle-plugin = "5.0.0-M1"
 micronaut-openapi = "7.0.0"
 micronaut-kafka = "6.0.0"
+micronaut-servlet = "6.0.0-RC1"
 kotlin-gradle-plugin = "2.3.21"
 micronaut-shared-settings = "8.0.0"
 playwright = "1.59.0"
@@ -45,6 +46,7 @@ handlebars-humanize = "4.3.1"
 
 [libraries]
 micronaut-openapi = { module = "io.micronaut.openapi:micronaut-openapi-bom", version.ref = "micronaut-openapi" }
+micronaut-servlet = { module = "io.micronaut.servlet:micronaut-servlet-bom", version.ref = "micronaut-servlet" }
 micronaut-core = { module = 'io.micronaut:micronaut-core-bom', version.ref = 'micronaut' }
 micronaut-security = { module = 'io.micronaut.security:micronaut-security', version.ref = 'micronaut-security' }
 micronaut-platform = { module = "io.micronaut.platform:micronaut-platform", version.ref = "micronaut-platform"}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,6 +20,7 @@ include("control-panel-object-storage")
 include("control-panel-cache")
 include("control-panel-datasource")
 include("control-panel-hibernate")
+include("control-panel-servlet")
 include("control-panel-ui")
 include("control-panel-kafka")
 
@@ -42,4 +43,5 @@ configure<MicronautBuildSettingsExtension> {
     importMicronautCatalog("micronaut-testresources")
     importMicronautCatalog("micronaut-openapi")
     importMicronautCatalog("micronaut-kafka")
+    importMicronautCatalog("micronaut-servlet")
 }

--- a/src/main/docs/guide/controlPanels/servlet.adoc
+++ b/src/main/docs/guide/controlPanels/servlet.adoc
@@ -1,0 +1,41 @@
+= Servlet Runtime Control Panel
+
+The Servlet Runtime Control Panel provides a read-only view of the Servlet container layer used by Micronaut Servlet-backed
+applications. It complements the HTTP Routes panel: routes still show Micronaut route handlers, while this panel shows
+the active Servlet runtime, `ServletContext` metadata, servlet registrations, filter registrations, and safe runtime
+configuration values exposed by the application.
+
+To add the Servlet Runtime control panel, add the following development-time dependency:
+
+dependency:io.micronaut.controlpanel:micronaut-control-panel-servlet[scope=developmentOnly]
+
+The panel appears only when the application has a `jakarta.servlet.ServletContext` bean. Applications that do not use a
+Servlet runtime can include the module without starting a panel or failing application startup.
+
+The panel is intended for local diagnostics with Servlet-backed runtimes such as Jetty, Tomcat, Undertow, the JDK HTTP
+server, or an external Servlet container. It shows:
+
+* detected runtime and embedded or external mode when available
+* context path, server info, Servlet API version, effective Servlet API version, and virtual server name
+* servlet registration names, classes, URL mappings, run-as role, and init-parameter names/counts
+* filter registration names, classes, URL pattern mappings, servlet-name mappings, and init-parameter names/counts
+* selected non-sensitive server and container configuration keys when present
+* warnings for multiple Servlet runtimes on the classpath or registrations without mappings
+
+Servlet and filter init-parameter values are redacted by default. The panel shows parameter names and counts only. It does
+not show request bodies, headers, cookies, principals, session data, live request traffic, user data, or route handler
+details.
+
+=== Configuration
+
+The Servlet Runtime control panel is automatically enabled when you include the module and a `ServletContext` is present.
+You can disable it by setting:
+
+[configuration]
+----
+micronaut:
+  control-panel:
+    panels:
+      servlet-runtime:
+        enabled: false
+----

--- a/src/main/docs/guide/controlPanels/servlet.adoc
+++ b/src/main/docs/guide/controlPanels/servlet.adoc
@@ -9,8 +9,10 @@ To add the Servlet Runtime control panel, add the following development-time dep
 
 dependency:io.micronaut.controlpanel:micronaut-control-panel-servlet[scope=developmentOnly]
 
-The panel appears only when the application has a `jakarta.servlet.ServletContext` bean. Applications that do not use a
-Servlet runtime can include the module without starting a panel or failing application startup.
+The panel appears when Servlet APIs are on the classpath and the module is enabled. For embedded Servlet runtimes such as
+Jetty, it can inspect the runtime `ServletContext` directly from the running embedded server even when the context is not
+published as a Micronaut bean. Applications that include the module without an inspectable `ServletContext` show an
+unavailable state rather than failing application startup.
 
 The panel is intended for local diagnostics with Servlet-backed runtimes such as Jetty, Tomcat, Undertow, the JDK HTTP
 server, or an external Servlet container. It shows:
@@ -28,7 +30,7 @@ details.
 
 === Configuration
 
-The Servlet Runtime control panel is automatically enabled when you include the module and a `ServletContext` is present.
+The Servlet Runtime control panel is automatically enabled when you include the module and Servlet APIs are present.
 You can disable it by setting:
 
 [configuration]

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -10,6 +10,7 @@ controlPanels:
   datasource: Datasource
   hibernate: Hibernate
   kafka: Kafka
+  servlet: Servlet Runtime
 
 custom: Creating Custom Control Panels
 repository: Repository


### PR DESCRIPTION
## Summary

- Adds an optional `micronaut-control-panel-servlet` module with a read-only Servlet Runtime panel.
- Shows detected runtime, `ServletContext` metadata, servlet/filter registrations, mappings, selected safe runtime config, and diagnostics warnings.
- Redacts servlet/filter init-parameter values by default and documents the panel scope, excluded sensitive data, and relationship to HTTP Routes.

## Paperclip / Issue Linkage

Paperclip issue: DEV-472. This is a manual Paperclip issue with no linked GitHub issue, so no GitHub closing keyword or GitHub issue reporter reviewer applies.

Required label: `type: enhancement`.

Organization project routing: QA originally selected `5.0.0-M3` and `5.0.0 Release` with an ambiguity note for the `2.0.x` Control Panel line. The live PR project association has since been retargeted to `5.1.0 Release` in `Backlog`; that live retarget is preserved.

## Verification

- `./gradlew :micronaut-control-panel-servlet:check`
- `./gradlew publishGuide`
- `./gradlew :micronaut-control-panel-servlet:dependencies --configuration runtimeClasspath`
- `git diff --check origin/2.0.x..HEAD && git diff --check`

## Screenshots

Desktop, `1440x900`:

![Desktop screenshot](https://raw.githubusercontent.com/micronaut-projects/micronaut-control-panel/f1f5f755c8ba6bed1595c039532a6913e70f28d8/assets/pr-555/5a8390275f11/servlet-runtime-desktop-1440x900.png)

Mobile, `390x844`:

![Mobile screenshot](https://raw.githubusercontent.com/micronaut-projects/micronaut-control-panel/f7386bdb8fa7bc04a69f9ecd8bc8a88c1d3b655a/assets/pr-555/5a8390275f11/servlet-runtime-mobile-390x844.png)

---
###### ✨ This message was AI-generated using gpt-5