### PR TITLE
Add tracing diagnostics control panel

### DIFF
--- a/control-panel-tracing/build.gradle.kts
+++ b/control-panel-tracing/build.gradle.kts
@@ -14,5 +14,5 @@ dependencies {
 }
 
 micronautBuild {
-    binaryCompatibility.enabledAfter("2.0.0")
+    binaryCompatibility.enabledAfter("2.0.1")
 }

--- a/control-panel-tracing/build.gradle.kts
+++ b/control-panel-tracing/build.gradle.kts
@@ -1,0 +1,18 @@
+plugins {
+    io.micronaut.build.internal.`control-panel-module`
+}
+
+dependencies {
+    api(projects.micronautControlPanelCore)
+
+    testImplementation(projects.micronautControlPanelUi)
+    testImplementation(mnViews.micronaut.views.handlebars)
+    testImplementation(mnTest.micronaut.test.junit5)
+    testImplementation(mnTest.mockito.junit.jupiter)
+    testRuntimeOnly(mnTest.junit.jupiter.engine)
+    testAnnotationProcessor(mn.micronaut.inject.java)
+}
+
+micronautBuild {
+    binaryCompatibility.enabledAfter("2.0.0")
+}

--- a/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/ClassPresence.java
+++ b/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/ClassPresence.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.tracing;
+
+/**
+ * Classpath detector indirection for deterministic diagnostics tests.
+ */
+interface ClassPresence {
+
+    boolean isPresent(String className);
+
+    static ClassPresence contextClassLoader() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        return className -> {
+            try {
+                Class.forName(className, false, classLoader);
+                return true;
+            } catch (ClassNotFoundException | LinkageError e) {
+                return false;
+            }
+        };
+    }
+}

--- a/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/ClassPresence.java
+++ b/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/ClassPresence.java
@@ -28,7 +28,7 @@ interface ClassPresence {
             try {
                 Class.forName(className, false, classLoader);
                 return true;
-            } catch (ClassNotFoundException | LinkageError e) {
+            } catch (ClassNotFoundException | LinkageError _) {
                 return false;
             }
         };

--- a/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingBody.java
+++ b/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingBody.java
@@ -48,7 +48,7 @@ public record TracingBody(
         String sampler,
         String propagators,
         String providerState,
-    int presentInstrumentationCount
+        int presentInstrumentationCount
 ) {
 
     /**

--- a/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingBody.java
+++ b/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingBody.java
@@ -22,6 +22,18 @@ import java.util.List;
 
 /**
  * Body rendered by the tracing diagnostics panel.
+ *
+ * @param providers detected tracing providers
+ * @param exporters exporter rows grouped by signal
+ * @param resourceAttributes OpenTelemetry resource attributes
+ * @param instrumentations instrumentation surface rows
+ * @param configuration recognized tracing configuration values
+ * @param diagnostics local deterministic diagnostics
+ * @param serviceName effective service name
+ * @param sampler configured sampler
+ * @param propagators configured propagators
+ * @param providerState provider summary for compact rendering
+ * @param presentInstrumentationCount number of present instrumentation rows
  */
 @ReflectiveAccess
 @Internal
@@ -36,17 +48,32 @@ public record TracingBody(
         String sampler,
         String propagators,
         String providerState,
-        int presentInstrumentationCount
+    int presentInstrumentationCount
 ) {
 
+    /**
+     * Whether tracing providers were detected.
+     *
+     * @return true when at least one tracing provider was detected
+     */
     public boolean hasProviders() {
         return !providers.isEmpty();
     }
 
+    /**
+     * Whether resource attributes are available.
+     *
+     * @return true when at least one resource attribute is available
+     */
     public boolean hasResourceAttributes() {
         return !resourceAttributes.isEmpty();
     }
 
+    /**
+     * Whether local diagnostics are available.
+     *
+     * @return true when at least one local diagnostic is available
+     */
     public boolean hasDiagnostics() {
         return !diagnostics.isEmpty();
     }

--- a/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingBody.java
+++ b/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingBody.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.tracing;
+
+import io.micronaut.core.annotation.ReflectiveAccess;
+import io.micronaut.core.annotation.Internal;
+
+import java.util.List;
+
+/**
+ * Body rendered by the tracing diagnostics panel.
+ */
+@ReflectiveAccess
+@Internal
+public record TracingBody(
+        List<TracingProviderInfo> providers,
+        List<TracingExporterInfo> exporters,
+        List<TracingKeyValue> resourceAttributes,
+        List<TracingInstrumentationInfo> instrumentations,
+        List<TracingKeyValue> configuration,
+        List<TracingDiagnostic> diagnostics,
+        String serviceName,
+        String sampler,
+        String propagators,
+        String providerState,
+        int presentInstrumentationCount
+) {
+
+    public boolean hasProviders() {
+        return !providers.isEmpty();
+    }
+
+    public boolean hasResourceAttributes() {
+        return !resourceAttributes.isEmpty();
+    }
+
+    public boolean hasDiagnostics() {
+        return !diagnostics.isEmpty();
+    }
+}

--- a/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingControlPanel.java
+++ b/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingControlPanel.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.tracing;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.controlpanel.core.AbstractControlPanel;
+import io.micronaut.controlpanel.core.ControlPanel;
+import io.micronaut.controlpanel.core.config.ControlPanelConfiguration;
+import io.micronaut.core.util.StringUtils;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+/**
+ * Control panel for local tracing diagnostics.
+ */
+@Singleton
+@Requires(property = TracingControlPanel.ENABLED_PROPERTY, notEquals = StringUtils.FALSE)
+public class TracingControlPanel extends AbstractControlPanel<TracingBody> {
+
+    public static final String NAME = "tracing";
+    public static final String ENABLED_PROPERTY = ControlPanelConfiguration.PREFIX + "." + NAME + ".enabled";
+    public static final ControlPanel.Category CATEGORY = new ControlPanel.Category("observability", "Observability", "fa-chart-line", 20);
+
+    private final TracingDiagnosticsService diagnosticsService;
+
+    public TracingControlPanel(TracingDiagnosticsService diagnosticsService,
+                               @Named(NAME) ControlPanelConfiguration configuration) {
+        super(NAME, configuration);
+        this.diagnosticsService = diagnosticsService;
+    }
+
+    @Override
+    public TracingBody getBody() {
+        return diagnosticsService.getBody();
+    }
+
+    @Override
+    public ControlPanel.Category getCategory() {
+        return CATEGORY;
+    }
+
+    @Override
+    public String getBadge() {
+        TracingBody body = getBody();
+        return body.hasProviders() ? body.providers().size() + " providers" : "not detected";
+    }
+
+    @Override
+    public String getDetailLinkName() {
+        return "Inspect tracing";
+    }
+}

--- a/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingControlPanel.java
+++ b/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingControlPanel.java
@@ -30,12 +30,29 @@ import jakarta.inject.Singleton;
 @Requires(property = TracingControlPanel.ENABLED_PROPERTY, notEquals = StringUtils.FALSE)
 public class TracingControlPanel extends AbstractControlPanel<TracingBody> {
 
+    /**
+     * The tracing control panel name.
+     */
     public static final String NAME = "tracing";
+
+    /**
+     * Property used to enable or disable the tracing panel.
+     */
     public static final String ENABLED_PROPERTY = ControlPanelConfiguration.PREFIX + "." + NAME + ".enabled";
+
+    /**
+     * Observability category used by the tracing panel.
+     */
     public static final ControlPanel.Category CATEGORY = new ControlPanel.Category("observability", "Observability", "fa-chart-line", 20);
 
     private final TracingDiagnosticsService diagnosticsService;
 
+    /**
+     * Creates the tracing control panel.
+     *
+     * @param diagnosticsService tracing diagnostics service
+     * @param configuration control panel configuration
+     */
     public TracingControlPanel(TracingDiagnosticsService diagnosticsService,
                                @Named(NAME) ControlPanelConfiguration configuration) {
         super(NAME, configuration);

--- a/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingDiagnostic.java
+++ b/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingDiagnostic.java
@@ -20,6 +20,9 @@ import io.micronaut.core.annotation.Internal;
 
 /**
  * Local deterministic tracing diagnostic.
+ *
+ * @param severity diagnostic severity
+ * @param message diagnostic message
  */
 @ReflectiveAccess
 @Internal

--- a/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingDiagnostic.java
+++ b/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingDiagnostic.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.tracing;
+
+import io.micronaut.core.annotation.ReflectiveAccess;
+import io.micronaut.core.annotation.Internal;
+
+/**
+ * Local deterministic tracing diagnostic.
+ */
+@ReflectiveAccess
+@Internal
+public record TracingDiagnostic(String severity, String message) {
+}

--- a/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingDiagnosticsService.java
+++ b/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingDiagnosticsService.java
@@ -170,6 +170,14 @@ public final class TracingDiagnosticsService {
     private final TracingRedactor redactor;
     private final ClassPresence classPresence;
 
+    /**
+     * Creates a tracing diagnostics service.
+     *
+     * @param environment Micronaut environment
+     * @param applicationConfiguration application configuration
+     * @param beanContext bean context
+     * @param redactor tracing redactor
+     */
     public TracingDiagnosticsService(Environment environment,
                                      ApplicationConfiguration applicationConfiguration,
                                      BeanContext beanContext,

--- a/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingDiagnosticsService.java
+++ b/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingDiagnosticsService.java
@@ -242,13 +242,16 @@ public final class TracingDiagnosticsService {
     }
 
     private TracingExporterInfo exporter(String signal, String exporterKey, String endpointKey) {
-        String exporter = property(exporterKey).orElse(NONE);
+        Optional<String> configuredExporter = property(exporterKey);
+        String exporter = configuredExporter.orElse(NONE);
         String endpoint = property(endpointKey)
                 .or(() -> property("otel.exporter.otlp.endpoint"))
                 .map(value -> redactor.redact(endpointKey, value))
                 .orElse(NOT_CONFIGURED);
-        String status = NONE.equalsIgnoreCase(exporter) ? "disabled" : "configured";
-        return new TracingExporterInfo(signal, exporter, endpoint, status);
+        String status = configuredExporter
+                .map(value -> NONE.equalsIgnoreCase(value) ? "disabled" : "configured")
+                .orElse("default disabled");
+        return new TracingExporterInfo(signal, exporter, endpoint, status, configuredExporter.isPresent());
     }
 
     private List<TracingInstrumentationInfo> instrumentations() {
@@ -313,7 +316,7 @@ public final class TracingDiagnosticsService {
             diagnostics.add(new TracingDiagnostic("warning", "Multiple tracing provider families were detected. Check for duplicate agent and application instrumentation."));
         }
         exporters.stream()
-                .filter(exporter -> NONE.equalsIgnoreCase(exporter.exporter()))
+                .filter(exporter -> exporter.configured() && NONE.equalsIgnoreCase(exporter.exporter()))
                 .forEach(exporter -> diagnostics.add(new TracingDiagnostic("info", exporter.signal() + " exporter is set to none.")));
         configuredExporterWithoutKnownDependency(exporters).ifPresent(diagnostics::add);
         kafkaTopicConflict().ifPresent(diagnostics::add);
@@ -325,7 +328,7 @@ public final class TracingDiagnosticsService {
     }
 
     private Optional<TracingDiagnostic> configuredExporterWithoutKnownDependency(List<TracingExporterInfo> exporters) {
-        boolean hasConfiguredExporter = exporters.stream().anyMatch(exporter -> !"none".equalsIgnoreCase(exporter.exporter()));
+        boolean hasConfiguredExporter = exporters.stream().anyMatch(exporter -> exporter.configured() && !"none".equalsIgnoreCase(exporter.exporter()));
         if (hasConfiguredExporter
                 && !classPresence.isPresent("io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter")
                 && !classPresence.isPresent("io.opentelemetry.exporter.zipkin.ZipkinSpanExporter")) {

--- a/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingDiagnosticsService.java
+++ b/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingDiagnosticsService.java
@@ -230,7 +230,7 @@ public final class TracingDiagnosticsService {
         List<TracingProviderInfo> providers = new ArrayList<>();
         for (ClassCheck provider : PROVIDERS) {
             if (classPresence.isPresent(provider.className()) || containsBean(provider.className())) {
-                providers.add(new TracingProviderInfo(provider.name(), "present", provider.detail()));
+                providers.add(new TracingProviderInfo(provider.name(), PRESENT, provider.detail()));
             }
         }
         return providers;

--- a/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingDiagnosticsService.java
+++ b/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingDiagnosticsService.java
@@ -38,9 +38,12 @@ public final class TracingDiagnosticsService {
 
     private static final String NOT_CONFIGURED = "not configured";
     private static final String NONE = "none";
+    private static final String PRESENT = "present";
+    private static final String WARNING = "warning";
+    private static final String RESOURCE_ATTRIBUTES_KEY = "otel.resource.attributes";
     private static final List<String> CONFIGURATION_KEYS = List.of(
             "otel.service.name",
-            "otel.resource.attributes",
+            RESOURCE_ATTRIBUTES_KEY,
             "otel.traces.exporter",
             "otel.metrics.exporter",
             "otel.logs.exporter",
@@ -207,7 +210,7 @@ public final class TracingDiagnosticsService {
         String serviceName = serviceName();
         String sampler = property("otel.traces.sampler").orElse(NOT_CONFIGURED);
         String propagators = property("otel.propagators").orElse(NOT_CONFIGURED);
-        int presentInstrumentationCount = (int) instrumentations.stream().filter(i -> "present".equals(i.status())).count();
+        int presentInstrumentationCount = (int) instrumentations.stream().filter(i -> PRESENT.equals(i.status())).count();
         return new TracingBody(
                 providers,
                 exporters,
@@ -262,7 +265,7 @@ public final class TracingDiagnosticsService {
 
     private TracingInstrumentationInfo instrumentation(InstrumentationCheck check) {
         if (anyClassOrBeanPresent(check.tracingClasses())) {
-            return new TracingInstrumentationInfo(check.name(), "present", check.presentDetail());
+            return new TracingInstrumentationInfo(check.name(), PRESENT, check.presentDetail());
         }
         if (anyClassPresent(check.baseClasses())) {
             return new TracingInstrumentationInfo(check.name(), "unknown", check.unknownDetail());
@@ -280,7 +283,7 @@ public final class TracingDiagnosticsService {
 
     private List<TracingKeyValue> resourceAttributes() {
         Map<String, String> attributes = new LinkedHashMap<>();
-        property("otel.resource.attributes").ifPresent(value -> {
+        property(RESOURCE_ATTRIBUTES_KEY).ifPresent(value -> {
             for (String entry : value.split(",")) {
                 String trimmed = entry.trim();
                 if (!trimmed.isEmpty()) {
@@ -313,7 +316,7 @@ public final class TracingDiagnosticsService {
                 .distinct()
                 .count();
         if (providerFamilies > 1) {
-            diagnostics.add(new TracingDiagnostic("warning", "Multiple tracing provider families were detected. Check for duplicate agent and application instrumentation."));
+            diagnostics.add(new TracingDiagnostic(WARNING, "Multiple tracing provider families were detected. Check for duplicate agent and application instrumentation."));
         }
         exporters.stream()
                 .filter(exporter -> exporter.configured() && NONE.equalsIgnoreCase(exporter.exporter()))
@@ -321,8 +324,8 @@ public final class TracingDiagnosticsService {
         configuredExporterWithoutKnownDependency(exporters).ifPresent(diagnostics::add);
         kafkaTopicConflict().ifPresent(diagnostics::add);
         property("otel.sdk.disabled")
-                .filter(value -> "true".equalsIgnoreCase(value))
-                .ifPresent(value -> diagnostics.add(new TracingDiagnostic("warning", "OpenTelemetry SDK is disabled by configuration.")));
+                .filter("true"::equalsIgnoreCase)
+                .ifPresent(value -> diagnostics.add(new TracingDiagnostic(WARNING, "OpenTelemetry SDK is disabled by configuration.")));
         diagnostics.sort(Comparator.comparing(TracingDiagnostic::severity).reversed().thenComparing(TracingDiagnostic::message));
         return diagnostics;
     }
@@ -332,7 +335,7 @@ public final class TracingDiagnosticsService {
         if (hasConfiguredExporter
                 && !classPresence.isPresent("io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter")
                 && !classPresence.isPresent("io.opentelemetry.exporter.zipkin.ZipkinSpanExporter")) {
-            return Optional.of(new TracingDiagnostic("warning", "An exporter is configured, but a known OpenTelemetry exporter implementation was not detected."));
+            return Optional.of(new TracingDiagnostic(WARNING, "An exporter is configured, but a known OpenTelemetry exporter implementation was not detected."));
         }
         return Optional.empty();
     }
@@ -341,7 +344,7 @@ public final class TracingDiagnosticsService {
         Optional<String> included = property("kafka.tracing.included-topics");
         Optional<String> excluded = property("kafka.tracing.excluded-topics");
         if (included.isPresent() && excluded.isPresent()) {
-            return Optional.of(new TracingDiagnostic("warning", "Kafka tracing has both include and exclude topic filters configured."));
+            return Optional.of(new TracingDiagnostic(WARNING, "Kafka tracing has both include and exclude topic filters configured."));
         }
         return Optional.empty();
     }
@@ -352,7 +355,7 @@ public final class TracingDiagnosticsService {
     }
 
     private String configurationValue(String key, String value) {
-        if (!"otel.resource.attributes".equals(key)) {
+        if (!RESOURCE_ATTRIBUTES_KEY.equals(key)) {
             return value;
         }
         List<String> redactedAttributes = new ArrayList<>();
@@ -375,7 +378,7 @@ public final class TracingDiagnosticsService {
 
     private String serviceName() {
         return property("otel.service.name")
-                .or(() -> applicationConfiguration.getName())
+                .or(applicationConfiguration::getName)
                 .orElse(NOT_CONFIGURED);
     }
 
@@ -387,7 +390,7 @@ public final class TracingDiagnosticsService {
         try {
             Class<?> type = Class.forName(className, false, Thread.currentThread().getContextClassLoader());
             return beanContext.containsBean(type);
-        } catch (ClassNotFoundException | LinkageError e) {
+        } catch (ClassNotFoundException | LinkageError _) {
             return false;
         }
     }

--- a/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingDiagnosticsService.java
+++ b/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingDiagnosticsService.java
@@ -1,0 +1,419 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.tracing;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.env.Environment;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.runtime.ApplicationConfiguration;
+import jakarta.inject.Singleton;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Builds read-only tracing diagnostics from local Micronaut state.
+ */
+@Singleton
+@Internal
+public final class TracingDiagnosticsService {
+
+    private static final String NOT_CONFIGURED = "not configured";
+    private static final String NONE = "none";
+    private static final List<String> CONFIGURATION_KEYS = List.of(
+            "otel.service.name",
+            "otel.resource.attributes",
+            "otel.traces.exporter",
+            "otel.metrics.exporter",
+            "otel.logs.exporter",
+            "otel.exporter.otlp.endpoint",
+            "otel.exporter.otlp.traces.endpoint",
+            "otel.exporter.otlp.metrics.endpoint",
+            "otel.exporter.otlp.logs.endpoint",
+            "otel.exporter.otlp.headers",
+            "otel.propagators",
+            "otel.traces.sampler",
+            "otel.traces.sampler.arg",
+            "otel.sdk.disabled",
+            "tracing.zipkin.enabled",
+            "tracing.jaeger.enabled",
+            "tracing.opentracing.enabled",
+            "kafka.tracing.enabled",
+            "kafka.tracing.producer.enabled",
+            "kafka.tracing.consumer.enabled",
+            "kafka.tracing.excluded-topics",
+            "kafka.tracing.included-topics",
+            "logger.levels.io.opentelemetry",
+            "logger.levels.io.micronaut.tracing"
+    );
+
+    private static final List<ClassCheck> PROVIDERS = List.of(
+            new ClassCheck("OpenTelemetry", "io.opentelemetry.api.OpenTelemetry", "OpenTelemetry API is on the classpath."),
+            new ClassCheck("OpenTelemetry SDK", "io.opentelemetry.sdk.OpenTelemetrySdk", "OpenTelemetry SDK is on the classpath."),
+            new ClassCheck("Brave/Zipkin", "brave.Tracing", "Brave tracing is on the classpath."),
+            new ClassCheck("OpenTracing/Jaeger", "io.opentracing.Tracer", "OpenTracing API is on the classpath."),
+            new ClassCheck("Jaeger", "io.jaegertracing.Configuration", "Jaeger client configuration is on the classpath.")
+    );
+
+    private static final List<InstrumentationCheck> INSTRUMENTATIONS = List.of(
+            new InstrumentationCheck(
+                    "HTTP client/server",
+                    List.of(
+                            "io.micronaut.tracing.opentelemetry.instrument.http.client.OpenTelemetryClientFilter",
+                            "io.micronaut.tracing.opentelemetry.instrument.http.server.OpenTelemetryServerFilter",
+                            "io.micronaut.tracing.brave.http.BraveTracingClientFilter",
+                            "io.micronaut.tracing.brave.http.BraveTracingServerFilter",
+                            "io.micronaut.tracing.opentracing.instrument.http.OpenTracingClientFilter",
+                            "io.micronaut.tracing.opentracing.instrument.http.OpenTracingServerFilter"
+                    ),
+                    List.of("io.micronaut.http.HttpRequest", "io.micronaut.http.client.HttpClient"),
+                    "Micronaut Tracing HTTP client/server filters were detected.",
+                    "HTTP classes are present, but no Micronaut Tracing HTTP integration was detected.",
+                    "Micronaut Tracing HTTP integration was not detected."
+            ),
+            new InstrumentationCheck(
+                    "gRPC",
+                    List.of(
+                            "io.micronaut.tracing.opentelemetry.instrument.grpc.GrpcClientTracingInterceptorFactory",
+                            "io.micronaut.tracing.opentelemetry.instrument.grpc.GrpcServerTracingInterceptorFactory"
+                    ),
+                    List.of("io.grpc.ManagedChannel"),
+                    "Micronaut Tracing gRPC interceptors were detected.",
+                    "gRPC classes are present, but no Micronaut Tracing gRPC integration was detected.",
+                    "Micronaut Tracing gRPC integration was not detected."
+            ),
+            new InstrumentationCheck(
+                    "JDBC",
+                    List.of(
+                            "io.micronaut.tracing.opentelemetry.instrument.jdbc.DataSourceBeanCreatedEventListener",
+                            "io.micronaut.tracing.opentelemetry.instrument.jdbc.JdbcTelemetryConfiguration"
+                    ),
+                    List.of("java.sql.Driver"),
+                    "Micronaut Tracing JDBC datasource instrumentation was detected.",
+                    "JDBC classes are present, but no Micronaut Tracing JDBC integration was detected.",
+                    "Micronaut Tracing JDBC integration was not detected."
+            ),
+            new InstrumentationCheck(
+                    "R2DBC",
+                    List.of(
+                            "io.micronaut.tracing.opentelemetry.instrument.r2dbc.R2dbcConnectionFactoryFactory",
+                            "io.micronaut.tracing.opentelemetry.instrument.r2dbc.R2dbcTelemetryConfiguration"
+                    ),
+                    List.of("io.r2dbc.spi.ConnectionFactory"),
+                    "Micronaut Tracing R2DBC connection factory instrumentation was detected.",
+                    "R2DBC classes are present, but no Micronaut Tracing R2DBC integration was detected.",
+                    "Micronaut Tracing R2DBC integration was not detected."
+            ),
+            new InstrumentationCheck(
+                    "Kafka",
+                    List.of(
+                            "io.micronaut.tracing.opentelemetry.instrument.kafka.KafkaTelemetryConsumerTracingInstrumentation",
+                            "io.micronaut.tracing.opentelemetry.instrument.kafka.KafkaTelemetryProducerTracingInstrumentation",
+                            "io.micronaut.tracing.opentelemetry.instrument.kafka.TracingConsumerInterceptor",
+                            "io.micronaut.tracing.opentelemetry.instrument.kafka.TracingProducerInterceptor"
+                    ),
+                    List.of("org.apache.kafka.clients.consumer.Consumer", "org.apache.kafka.clients.producer.Producer"),
+                    "Micronaut Tracing Kafka producer/consumer instrumentation was detected.",
+                    "Kafka client classes are present, but no Micronaut Tracing Kafka integration was detected.",
+                    "Micronaut Tracing Kafka integration was not detected."
+            ),
+            new InstrumentationCheck(
+                    "AWS SDK",
+                    List.of("io.micronaut.tracing.opentelemetry.xray.SdkClientBuilderListener"),
+                    List.of("software.amazon.awssdk.core.SdkClient"),
+                    "Micronaut Tracing AWS SDK listener was detected.",
+                    "AWS SDK classes are present, but no Micronaut Tracing AWS SDK integration was detected.",
+                    "Micronaut Tracing AWS SDK integration was not detected."
+            ),
+            new InstrumentationCheck(
+                    "Logback appender",
+                    List.of(
+                            "io.micronaut.tracing.opentelemetry.log.OpenTelemetryLogbackAppenderInstaller",
+                            "io.opentelemetry.instrumentation.logback.appender.v1_0.OpenTelemetryAppender"
+                    ),
+                    List.of("ch.qos.logback.classic.Logger"),
+                    "OpenTelemetry Logback appender integration was detected.",
+                    "Logback classes are present, but no OpenTelemetry Logback appender integration was detected.",
+                    "OpenTelemetry Logback appender integration was not detected."
+            ),
+            new InstrumentationCheck(
+                    "Logback MDC",
+                    List.of("io.opentelemetry.instrumentation.logback.mdc.v1_0.OpenTelemetryAppender"),
+                    List.of("org.slf4j.MDC"),
+                    "OpenTelemetry Logback MDC integration was detected.",
+                    "SLF4J MDC is present, but no OpenTelemetry Logback MDC integration was detected.",
+                    "OpenTelemetry Logback MDC integration was not detected."
+            )
+    );
+
+    private final Environment environment;
+    private final ApplicationConfiguration applicationConfiguration;
+    private final BeanContext beanContext;
+    private final TracingRedactor redactor;
+    private final ClassPresence classPresence;
+
+    public TracingDiagnosticsService(Environment environment,
+                                     ApplicationConfiguration applicationConfiguration,
+                                     BeanContext beanContext,
+                                     TracingRedactor redactor) {
+        this(environment, applicationConfiguration, beanContext, redactor, ClassPresence.contextClassLoader());
+    }
+
+    TracingDiagnosticsService(Environment environment,
+                              ApplicationConfiguration applicationConfiguration,
+                              BeanContext beanContext,
+                              TracingRedactor redactor,
+                              ClassPresence classPresence) {
+        this.environment = environment;
+        this.applicationConfiguration = applicationConfiguration;
+        this.beanContext = beanContext;
+        this.redactor = redactor;
+        this.classPresence = classPresence;
+    }
+
+    TracingBody getBody() {
+        List<TracingProviderInfo> providers = providers();
+        List<TracingExporterInfo> exporters = exporters();
+        List<TracingKeyValue> resourceAttributes = resourceAttributes();
+        List<TracingInstrumentationInfo> instrumentations = instrumentations();
+        List<TracingKeyValue> configuration = configuration();
+        List<TracingDiagnostic> diagnostics = diagnostics(providers, exporters);
+        String serviceName = serviceName();
+        String sampler = property("otel.traces.sampler").orElse(NOT_CONFIGURED);
+        String propagators = property("otel.propagators").orElse(NOT_CONFIGURED);
+        int presentInstrumentationCount = (int) instrumentations.stream().filter(i -> "present".equals(i.status())).count();
+        return new TracingBody(
+                providers,
+                exporters,
+                resourceAttributes,
+                instrumentations,
+                configuration,
+                diagnostics,
+                serviceName,
+                sampler,
+                propagators,
+                providers.isEmpty() ? "not detected" : providers.size() + " detected",
+                presentInstrumentationCount
+        );
+    }
+
+    private List<TracingProviderInfo> providers() {
+        List<TracingProviderInfo> providers = new ArrayList<>();
+        for (ClassCheck provider : PROVIDERS) {
+            if (classPresence.isPresent(provider.className()) || containsBean(provider.className())) {
+                providers.add(new TracingProviderInfo(provider.name(), "present", provider.detail()));
+            }
+        }
+        return providers;
+    }
+
+    private List<TracingExporterInfo> exporters() {
+        return List.of(
+                exporter("Traces", "otel.traces.exporter", "otel.exporter.otlp.traces.endpoint"),
+                exporter("Metrics", "otel.metrics.exporter", "otel.exporter.otlp.metrics.endpoint"),
+                exporter("Logs", "otel.logs.exporter", "otel.exporter.otlp.logs.endpoint")
+        );
+    }
+
+    private TracingExporterInfo exporter(String signal, String exporterKey, String endpointKey) {
+        String exporter = property(exporterKey).orElse(NONE);
+        String endpoint = property(endpointKey)
+                .or(() -> property("otel.exporter.otlp.endpoint"))
+                .map(value -> redactor.redact(endpointKey, value))
+                .orElse(NOT_CONFIGURED);
+        String status = NONE.equalsIgnoreCase(exporter) ? "disabled" : "configured";
+        return new TracingExporterInfo(signal, exporter, endpoint, status);
+    }
+
+    private List<TracingInstrumentationInfo> instrumentations() {
+        return INSTRUMENTATIONS.stream()
+                .map(this::instrumentation)
+                .toList();
+    }
+
+    private TracingInstrumentationInfo instrumentation(InstrumentationCheck check) {
+        if (anyClassOrBeanPresent(check.tracingClasses())) {
+            return new TracingInstrumentationInfo(check.name(), "present", check.presentDetail());
+        }
+        if (anyClassPresent(check.baseClasses())) {
+            return new TracingInstrumentationInfo(check.name(), "unknown", check.unknownDetail());
+        }
+        return new TracingInstrumentationInfo(check.name(), "absent", check.absentDetail());
+    }
+
+    private List<TracingKeyValue> configuration() {
+        List<TracingKeyValue> values = new ArrayList<>();
+        for (String key : CONFIGURATION_KEYS) {
+            property(key).ifPresent(value -> values.add(keyValue(key, configurationValue(key, value), "configuration")));
+        }
+        return values;
+    }
+
+    private List<TracingKeyValue> resourceAttributes() {
+        Map<String, String> attributes = new LinkedHashMap<>();
+        property("otel.resource.attributes").ifPresent(value -> {
+            for (String entry : value.split(",")) {
+                String trimmed = entry.trim();
+                if (!trimmed.isEmpty()) {
+                    int equals = trimmed.indexOf('=');
+                    if (equals > 0) {
+                        attributes.put(trimmed.substring(0, equals).trim(), trimmed.substring(equals + 1).trim());
+                    } else {
+                        attributes.put(trimmed, "");
+                    }
+                }
+            }
+        });
+        if (attributes.isEmpty() && !NOT_CONFIGURED.equals(serviceName())) {
+            attributes.put("service.name", serviceName());
+        }
+        return attributes.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .map(entry -> keyValue(entry.getKey(), entry.getValue(), "resource"))
+                .toList();
+    }
+
+    private List<TracingDiagnostic> diagnostics(List<TracingProviderInfo> providers, List<TracingExporterInfo> exporters) {
+        List<TracingDiagnostic> diagnostics = new ArrayList<>();
+        if (providers.isEmpty()) {
+            diagnostics.add(new TracingDiagnostic("info", "No tracing provider was detected on the application classpath."));
+        }
+        long providerFamilies = providers.stream()
+                .map(TracingProviderInfo::name)
+                .map(this::providerFamily)
+                .distinct()
+                .count();
+        if (providerFamilies > 1) {
+            diagnostics.add(new TracingDiagnostic("warning", "Multiple tracing provider families were detected. Check for duplicate agent and application instrumentation."));
+        }
+        exporters.stream()
+                .filter(exporter -> NONE.equalsIgnoreCase(exporter.exporter()))
+                .forEach(exporter -> diagnostics.add(new TracingDiagnostic("info", exporter.signal() + " exporter is set to none.")));
+        configuredExporterWithoutKnownDependency(exporters).ifPresent(diagnostics::add);
+        kafkaTopicConflict().ifPresent(diagnostics::add);
+        property("otel.sdk.disabled")
+                .filter(value -> "true".equalsIgnoreCase(value))
+                .ifPresent(value -> diagnostics.add(new TracingDiagnostic("warning", "OpenTelemetry SDK is disabled by configuration.")));
+        diagnostics.sort(Comparator.comparing(TracingDiagnostic::severity).reversed().thenComparing(TracingDiagnostic::message));
+        return diagnostics;
+    }
+
+    private Optional<TracingDiagnostic> configuredExporterWithoutKnownDependency(List<TracingExporterInfo> exporters) {
+        boolean hasConfiguredExporter = exporters.stream().anyMatch(exporter -> !"none".equalsIgnoreCase(exporter.exporter()));
+        if (hasConfiguredExporter
+                && !classPresence.isPresent("io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter")
+                && !classPresence.isPresent("io.opentelemetry.exporter.zipkin.ZipkinSpanExporter")) {
+            return Optional.of(new TracingDiagnostic("warning", "An exporter is configured, but a known OpenTelemetry exporter implementation was not detected."));
+        }
+        return Optional.empty();
+    }
+
+    private Optional<TracingDiagnostic> kafkaTopicConflict() {
+        Optional<String> included = property("kafka.tracing.included-topics");
+        Optional<String> excluded = property("kafka.tracing.excluded-topics");
+        if (included.isPresent() && excluded.isPresent()) {
+            return Optional.of(new TracingDiagnostic("warning", "Kafka tracing has both include and exclude topic filters configured."));
+        }
+        return Optional.empty();
+    }
+
+    private TracingKeyValue keyValue(String key, String value, String source) {
+        String redactedValue = redactor.redact(key, value);
+        return new TracingKeyValue(key, redactedValue, source, TracingRedactor.REDACTED.equals(redactedValue));
+    }
+
+    private String configurationValue(String key, String value) {
+        if (!"otel.resource.attributes".equals(key)) {
+            return value;
+        }
+        List<String> redactedAttributes = new ArrayList<>();
+        for (String entry : value.split(",")) {
+            String trimmed = entry.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            int equals = trimmed.indexOf('=');
+            if (equals > 0) {
+                String attributeKey = trimmed.substring(0, equals).trim();
+                String attributeValue = trimmed.substring(equals + 1).trim();
+                redactedAttributes.add(attributeKey + "=" + redactor.redact(attributeKey, attributeValue));
+            } else {
+                redactedAttributes.add(redactor.redact(trimmed, ""));
+            }
+        }
+        return String.join(",", redactedAttributes);
+    }
+
+    private String serviceName() {
+        return property("otel.service.name")
+                .or(() -> applicationConfiguration.getName())
+                .orElse(NOT_CONFIGURED);
+    }
+
+    private Optional<String> property(String key) {
+        return environment.getProperty(key, String.class).filter(value -> !value.isBlank());
+    }
+
+    private boolean containsBean(String className) {
+        try {
+            Class<?> type = Class.forName(className, false, Thread.currentThread().getContextClassLoader());
+            return beanContext.containsBean(type);
+        } catch (ClassNotFoundException | LinkageError e) {
+            return false;
+        }
+    }
+
+    private String providerFamily(String provider) {
+        String normalized = provider.toLowerCase(Locale.ROOT);
+        if (normalized.contains("opentelemetry")) {
+            return "opentelemetry";
+        }
+        if (normalized.contains("opentracing")) {
+            return "opentracing";
+        }
+        if (normalized.contains("brave") || normalized.contains("zipkin")) {
+            return "brave";
+        }
+        if (normalized.contains("jaeger")) {
+            return "jaeger";
+        }
+        return normalized;
+    }
+
+    private boolean anyClassOrBeanPresent(List<String> classNames) {
+        return classNames.stream().anyMatch(className -> classPresence.isPresent(className) || containsBean(className));
+    }
+
+    private boolean anyClassPresent(List<String> classNames) {
+        return classNames.stream().anyMatch(classPresence::isPresent);
+    }
+
+    private record ClassCheck(String name, String className, String detail) {
+    }
+
+    private record InstrumentationCheck(String name,
+                                        List<String> tracingClasses,
+                                        List<String> baseClasses,
+                                        String presentDetail,
+                                        String unknownDetail,
+                                        String absentDetail) {
+    }
+}

--- a/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingExporterInfo.java
+++ b/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingExporterInfo.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.tracing;
+
+import io.micronaut.core.annotation.ReflectiveAccess;
+import io.micronaut.core.annotation.Internal;
+
+/**
+ * Exporter diagnostic row.
+ */
+@ReflectiveAccess
+@Internal
+public record TracingExporterInfo(String signal, String exporter, String endpoint, String status) {
+}

--- a/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingExporterInfo.java
+++ b/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingExporterInfo.java
@@ -25,8 +25,9 @@ import io.micronaut.core.annotation.Internal;
  * @param exporter configured exporter value
  * @param endpoint configured endpoint value
  * @param status exporter status
+ * @param configured whether the exporter was explicitly configured
  */
 @ReflectiveAccess
 @Internal
-public record TracingExporterInfo(String signal, String exporter, String endpoint, String status) {
+public record TracingExporterInfo(String signal, String exporter, String endpoint, String status, boolean configured) {
 }

--- a/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingExporterInfo.java
+++ b/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingExporterInfo.java
@@ -20,6 +20,11 @@ import io.micronaut.core.annotation.Internal;
 
 /**
  * Exporter diagnostic row.
+ *
+ * @param signal OpenTelemetry signal name
+ * @param exporter configured exporter value
+ * @param endpoint configured endpoint value
+ * @param status exporter status
  */
 @ReflectiveAccess
 @Internal

--- a/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingInstrumentationInfo.java
+++ b/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingInstrumentationInfo.java
@@ -20,6 +20,10 @@ import io.micronaut.core.annotation.Internal;
 
 /**
  * Instrumentation classpath diagnostic row.
+ *
+ * @param surface instrumentation surface
+ * @param status instrumentation status
+ * @param detail instrumentation detail
  */
 @ReflectiveAccess
 @Internal

--- a/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingInstrumentationInfo.java
+++ b/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingInstrumentationInfo.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.tracing;
+
+import io.micronaut.core.annotation.ReflectiveAccess;
+import io.micronaut.core.annotation.Internal;
+
+/**
+ * Instrumentation classpath diagnostic row.
+ */
+@ReflectiveAccess
+@Internal
+public record TracingInstrumentationInfo(String surface, String status, String detail) {
+}

--- a/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingKeyValue.java
+++ b/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingKeyValue.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.tracing;
+
+import io.micronaut.core.annotation.ReflectiveAccess;
+import io.micronaut.core.annotation.Internal;
+
+/**
+ * Redacted configuration or resource attribute row.
+ */
+@ReflectiveAccess
+@Internal
+public record TracingKeyValue(String key, String value, String source, boolean redacted) {
+}

--- a/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingProviderInfo.java
+++ b/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingProviderInfo.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.tracing;
+
+import io.micronaut.core.annotation.ReflectiveAccess;
+import io.micronaut.core.annotation.Internal;
+
+/**
+ * Tracing provider diagnostic row.
+ */
+@ReflectiveAccess
+@Internal
+public record TracingProviderInfo(String name, String status, String detail) {
+}

--- a/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingProviderInfo.java
+++ b/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingProviderInfo.java
@@ -20,6 +20,10 @@ import io.micronaut.core.annotation.Internal;
 
 /**
  * Tracing provider diagnostic row.
+ *
+ * @param name provider name
+ * @param status provider status
+ * @param detail provider detail
  */
 @ReflectiveAccess
 @Internal

--- a/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingRedactor.java
+++ b/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingRedactor.java
@@ -19,8 +19,9 @@ import jakarta.inject.Singleton;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
-import java.util.Set;
 import java.util.StringJoiner;
 
 /**
@@ -30,19 +31,6 @@ import java.util.StringJoiner;
 final class TracingRedactor {
 
     static final String REDACTED = "[redacted]";
-
-    private static final Set<String> SENSITIVE_QUERY_KEYS = Set.of(
-            "access_token",
-            "api_key",
-            "apikey",
-            "authorization",
-            "client_secret",
-            "credential",
-            "key",
-            "password",
-            "secret",
-            "token"
-    );
 
     String redact(String key, String value) {
         if (value == null || value.isBlank()) {
@@ -97,13 +85,24 @@ final class TracingRedactor {
         for (String part : query.split("&")) {
             int equals = part.indexOf('=');
             String key = equals >= 0 ? part.substring(0, equals) : part;
-            if (SENSITIVE_QUERY_KEYS.contains(key.toLowerCase(Locale.ROOT))) {
+            if (isSensitiveQueryKey(key)) {
                 joiner.add(key + "=" + REDACTED);
             } else {
                 joiner.add(part);
             }
         }
         return joiner.toString();
+    }
+
+    private boolean isSensitiveQueryKey(String key) {
+        if (isSensitiveKey(key)) {
+            return true;
+        }
+        try {
+            return isSensitiveKey(URLDecoder.decode(key, StandardCharsets.UTF_8));
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
     }
 
     private static boolean looksLikeUrl(String value) {

--- a/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingRedactor.java
+++ b/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingRedactor.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.tracing;
+
+import jakarta.inject.Singleton;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Locale;
+import java.util.Set;
+import java.util.StringJoiner;
+
+/**
+ * Redacts tracing configuration before it is exposed to templates.
+ */
+@Singleton
+final class TracingRedactor {
+
+    static final String REDACTED = "[redacted]";
+
+    private static final Set<String> SENSITIVE_QUERY_KEYS = Set.of(
+            "access_token",
+            "api_key",
+            "apikey",
+            "authorization",
+            "client_secret",
+            "credential",
+            "key",
+            "password",
+            "secret",
+            "token"
+    );
+
+    String redact(String key, String value) {
+        if (value == null || value.isBlank()) {
+            return "";
+        }
+        if (isSensitiveKey(key)) {
+            return REDACTED;
+        }
+        if (looksLikeUrl(value)) {
+            return redactUrl(value);
+        }
+        return value;
+    }
+
+    boolean isSensitiveKey(String key) {
+        if (key == null) {
+            return false;
+        }
+        String normalized = key.toLowerCase(Locale.ROOT).replace('_', '-');
+        return normalized.contains("password")
+                || normalized.contains("credential")
+                || normalized.contains("certificate")
+                || normalized.contains("secret")
+                || normalized.contains("token")
+                || normalized.contains("api-key")
+                || normalized.contains("apikey")
+                || normalized.contains("authorization")
+                || normalized.contains("headers")
+                || normalized.contains("auth")
+                || normalized.contains("bearer")
+                || normalized.endsWith(".key")
+                || normalized.endsWith("-key")
+                || normalized.equals("key");
+    }
+
+    private String redactUrl(String value) {
+        try {
+            URI uri = new URI(value);
+            String userInfo = uri.getRawUserInfo() == null ? null : REDACTED;
+            String query = redactQuery(uri.getRawQuery());
+            return new URI(uri.getScheme(), userInfo, uri.getHost(), uri.getPort(), uri.getRawPath(), query, uri.getRawFragment()).toString();
+        } catch (URISyntaxException e) {
+            return value.replaceFirst("(?i)(://)[^/?#@]+@", "$1" + REDACTED + "@");
+        }
+    }
+
+    private String redactQuery(String query) {
+        if (query == null || query.isBlank()) {
+            return query;
+        }
+        StringJoiner joiner = new StringJoiner("&");
+        for (String part : query.split("&")) {
+            int equals = part.indexOf('=');
+            String key = equals >= 0 ? part.substring(0, equals) : part;
+            if (SENSITIVE_QUERY_KEYS.contains(key.toLowerCase(Locale.ROOT))) {
+                joiner.add(key + "=" + REDACTED);
+            } else {
+                joiner.add(part);
+            }
+        }
+        return joiner.toString();
+    }
+
+    private static boolean looksLikeUrl(String value) {
+        return value.regionMatches(true, 0, "http://", 0, 7)
+                || value.regionMatches(true, 0, "https://", 0, 8);
+    }
+}

--- a/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingRedactor.java
+++ b/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingRedactor.java
@@ -92,8 +92,11 @@ final class TracingRedactor {
         return redacted.substring(0, queryStart + 1) + redactQuery(query) + fragment;
     }
 
-    private String redactQuery(@Nullable String query) {
-        if (query == null || query.isBlank()) {
+    private @Nullable String redactQuery(@Nullable String query) {
+        if (query == null) {
+            return null;
+        }
+        if (query.isBlank()) {
             return query;
         }
         StringJoiner joiner = new StringJoiner("&");

--- a/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingRedactor.java
+++ b/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingRedactor.java
@@ -61,6 +61,9 @@ final class TracingRedactor {
                 || normalized.contains("headers")
                 || normalized.contains("auth")
                 || normalized.contains("bearer")
+                || normalized.contains("tenant")
+                || normalized.contains("account")
+                || normalized.contains("user")
                 || normalized.endsWith(".key")
                 || normalized.endsWith("-key")
                 || normalized.equals("key");

--- a/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingRedactor.java
+++ b/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingRedactor.java
@@ -76,8 +76,22 @@ final class TracingRedactor {
             String query = redactQuery(uri.getRawQuery());
             return new URI(uri.getScheme(), userInfo, uri.getHost(), uri.getPort(), uri.getRawPath(), query, uri.getRawFragment()).toString();
         } catch (URISyntaxException e) {
-            return value.replaceFirst("(?i)(://)[^/?#@]+@", "$1" + REDACTED + "@");
+            return redactMalformedUrl(value);
         }
+    }
+
+    private String redactMalformedUrl(String value) {
+        String redacted = value.replaceFirst("(?i)(://)[^/?#@]+@", "$1" + REDACTED + "@");
+        int queryStart = redacted.indexOf('?');
+        if (queryStart < 0) {
+            return redacted;
+        }
+        int fragmentStart = redacted.indexOf('#', queryStart);
+        String query = fragmentStart >= 0
+                ? redacted.substring(queryStart + 1, fragmentStart)
+                : redacted.substring(queryStart + 1);
+        String fragment = fragmentStart >= 0 ? redacted.substring(fragmentStart) : "";
+        return redacted.substring(0, queryStart + 1) + redactQuery(query) + fragment;
     }
 
     private String redactQuery(String query) {

--- a/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingRedactor.java
+++ b/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/TracingRedactor.java
@@ -16,6 +16,7 @@
 package io.micronaut.controlpanel.panels.tracing;
 
 import jakarta.inject.Singleton;
+import org.jspecify.annotations.Nullable;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -33,7 +34,7 @@ final class TracingRedactor {
     static final String REDACTED = "[redacted]";
 
     String redact(String key, String value) {
-        if (value == null || value.isBlank()) {
+        if (value.isBlank()) {
             return "";
         }
         if (isSensitiveKey(key)) {
@@ -46,9 +47,6 @@ final class TracingRedactor {
     }
 
     boolean isSensitiveKey(String key) {
-        if (key == null) {
-            return false;
-        }
         String normalized = key.toLowerCase(Locale.ROOT).replace('_', '-');
         return normalized.contains("password")
                 || normalized.contains("credential")
@@ -75,7 +73,7 @@ final class TracingRedactor {
             String userInfo = uri.getRawUserInfo() == null ? null : REDACTED;
             String query = redactQuery(uri.getRawQuery());
             return new URI(uri.getScheme(), userInfo, uri.getHost(), uri.getPort(), uri.getRawPath(), query, uri.getRawFragment()).toString();
-        } catch (URISyntaxException e) {
+        } catch (URISyntaxException _) {
             return redactMalformedUrl(value);
         }
     }
@@ -94,7 +92,7 @@ final class TracingRedactor {
         return redacted.substring(0, queryStart + 1) + redactQuery(query) + fragment;
     }
 
-    private String redactQuery(String query) {
+    private String redactQuery(@Nullable String query) {
         if (query == null || query.isBlank()) {
             return query;
         }
@@ -117,7 +115,7 @@ final class TracingRedactor {
         }
         try {
             return isSensitiveKey(URLDecoder.decode(key, StandardCharsets.UTF_8));
-        } catch (IllegalArgumentException e) {
+        } catch (IllegalArgumentException _) {
             return false;
         }
     }

--- a/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/package-info.java
+++ b/control-panel-tracing/src/main/java/io/micronaut/controlpanel/panels/tracing/package-info.java
@@ -13,20 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * Tracing Control Panel classes.
+ */
+@NullMarked
 package io.micronaut.controlpanel.panels.tracing;
 
-import io.micronaut.core.annotation.ReflectiveAccess;
-import io.micronaut.core.annotation.Internal;
-
-/**
- * Redacted configuration or resource attribute row.
- *
- * @param key row key
- * @param value row value
- * @param source row source
- * @param redacted whether the value was redacted
- */
-@ReflectiveAccess
-@Internal
-public record TracingKeyValue(String key, String value, String source, boolean redacted) {
-}
+import org.jspecify.annotations.NullMarked;

--- a/control-panel-tracing/src/main/resources/micronaut-control-panel/micronaut-control-panel.properties
+++ b/control-panel-tracing/src/main/resources/micronaut-control-panel/micronaut-control-panel.properties
@@ -1,0 +1,4 @@
+micronaut.control-panel.panels.tracing.enabled = true
+micronaut.control-panel.panels.tracing.title = Tracing Diagnostics
+micronaut.control-panel.panels.tracing.icon = fa-route
+micronaut.control-panel.panels.tracing.order = 30

--- a/control-panel-tracing/src/main/resources/views/tracing/body.hbs
+++ b/control-panel-tracing/src/main/resources/views/tracing/body.hbs
@@ -1,0 +1,34 @@
+{{#with controlPanel.body }}
+    <div class="cp-data-table-container cp-vertical-table">
+        <table class="table cp-data-table-table">
+            <tbody>
+            <tr>
+                <th scope="row">Provider state</th>
+                <td>
+                    <span class="badge badge-secondary">{{ providerState }}</span>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row">Service name</th>
+                <td><code>{{ serviceName }}</code></td>
+            </tr>
+            <tr>
+                <th scope="row">Sampler</th>
+                <td><code>{{ sampler }}</code></td>
+            </tr>
+            <tr>
+                <th scope="row">Propagators</th>
+                <td><code>{{ propagators }}</code></td>
+            </tr>
+            <tr>
+                <th scope="row">Instrumentation</th>
+                <td>{{ presentInstrumentationCount }} present of {{ instrumentations.size }} checked</td>
+            </tr>
+            <tr>
+                <th scope="row">Diagnostics</th>
+                <td>{{ diagnostics.size }} local findings</td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+{{/with}}

--- a/control-panel-tracing/src/main/resources/views/tracing/detail.hbs
+++ b/control-panel-tracing/src/main/resources/views/tracing/detail.hbs
@@ -1,0 +1,232 @@
+{{#with controlPanel.body }}
+    <div class="cp-dashboard-stack">
+        <div class="card card-light">
+            <div class="card-header">
+                <div class="cp-card-heading">
+                    <div class="cp-card-header-text">
+                        <h3 class="card-title">Tracing overview</h3>
+                        <div class="card-description">Read-only diagnostics from local Micronaut configuration, beans, and classpath state.</div>
+                    </div>
+                </div>
+            </div>
+            <div class="card-body">
+                <div class="cp-data-table-container cp-vertical-table">
+                    <table class="table cp-data-table-table">
+                        <tbody>
+                        <tr>
+                            <th scope="row">Providers</th>
+                            <td><span class="badge badge-secondary">{{ providerState }}</span></td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Service name</th>
+                            <td><code>{{ serviceName }}</code></td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Sampler</th>
+                            <td><code>{{ sampler }}</code></td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Propagators</th>
+                            <td><code>{{ propagators }}</code></td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Instrumentation</th>
+                            <td>{{ presentInstrumentationCount }} present of {{ instrumentations.size }} checked</td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+
+        <div class="card card-light">
+            <div class="card-header">
+                <h3 class="card-title">Providers</h3>
+            </div>
+            <div class="card-body">
+                {{#if hasProviders}}
+                    <div class="cp-data-table-container">
+                        <table class="table cp-data-table-table cp-data-table-fixed">
+                            <thead>
+                            <tr>
+                                <th scope="col">Provider</th>
+                                <th scope="col">Status</th>
+                                <th scope="col">Details</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            {{#each providers}}
+                                <tr>
+                                    <td><code>{{ name }}</code></td>
+                                    <td><span class="badge badge-secondary">{{ status }}</span></td>
+                                    <td>{{ detail }}</td>
+                                </tr>
+                            {{/each}}
+                            </tbody>
+                        </table>
+                    </div>
+                {{else}}
+                    <div class="cp-data-table-empty">No tracing provider was detected. Add Micronaut Tracing/OpenTelemetry dependencies to enable provider diagnostics.</div>
+                {{/if}}
+            </div>
+        </div>
+
+        <div class="card card-light">
+            <div class="card-header">
+                <h3 class="card-title">Exporters</h3>
+            </div>
+            <div class="card-body">
+                <div class="cp-data-table-container">
+                    <table class="table cp-data-table-table cp-data-table-fixed">
+                        <thead>
+                        <tr>
+                            <th scope="col">Signal</th>
+                            <th scope="col">Exporter</th>
+                            <th scope="col">Endpoint</th>
+                            <th scope="col">Status</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        {{#each exporters}}
+                            <tr>
+                                <td>{{ signal }}</td>
+                                <td><code>{{ exporter }}</code></td>
+                                <td><code>{{ endpoint }}</code></td>
+                                <td><span class="badge badge-secondary">{{ status }}</span></td>
+                            </tr>
+                        {{/each}}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+
+        <div class="card card-light">
+            <div class="card-header">
+                <h3 class="card-title">Resource attributes</h3>
+            </div>
+            <div class="card-body">
+                {{#if hasResourceAttributes}}
+                    <div class="cp-data-table-container">
+                        <table class="table cp-data-table-table cp-data-table-fixed">
+                            <thead>
+                            <tr>
+                                <th scope="col">Attribute</th>
+                                <th scope="col">Value</th>
+                                <th scope="col">Source</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            {{#each resourceAttributes}}
+                                <tr>
+                                    <td><code>{{ key }}</code></td>
+                                    <td>
+                                        <code>{{ value }}</code>
+                                        {{#if redacted}}<span class="badge badge-secondary">redacted</span>{{/if}}
+                                    </td>
+                                    <td>{{ source }}</td>
+                                </tr>
+                            {{/each}}
+                            </tbody>
+                        </table>
+                    </div>
+                {{else}}
+                    <div class="cp-data-table-empty">No OpenTelemetry resource attributes were configured.</div>
+                {{/if}}
+            </div>
+        </div>
+
+        <div class="card card-light">
+            <div class="card-header">
+                <h3 class="card-title">Instrumentation</h3>
+            </div>
+            <div class="card-body">
+                <div class="cp-data-table-container">
+                    <table class="table cp-data-table-table cp-data-table-fixed">
+                        <thead>
+                        <tr>
+                            <th scope="col">Surface</th>
+                            <th scope="col">Status</th>
+                            <th scope="col">Details</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        {{#each instrumentations}}
+                            <tr>
+                                <td>{{ surface }}</td>
+                                <td><span class="badge badge-secondary">{{ status }}</span></td>
+                                <td>{{ detail }}</td>
+                            </tr>
+                        {{/each}}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+
+        <div class="card card-light">
+            <div class="card-header">
+                <h3 class="card-title">Configuration</h3>
+            </div>
+            <div class="card-body">
+                {{#if configuration}}
+                    <div class="cp-data-table-container">
+                        <table class="table cp-data-table-table cp-data-table-fixed">
+                            <thead>
+                            <tr>
+                                <th scope="col">Key</th>
+                                <th scope="col">Value</th>
+                                <th scope="col">Source</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            {{#each configuration}}
+                                <tr>
+                                    <td><code>{{ key }}</code></td>
+                                    <td>
+                                        <code>{{ value }}</code>
+                                        {{#if redacted}}<span class="badge badge-secondary">redacted</span>{{/if}}
+                                    </td>
+                                    <td>{{ source }}</td>
+                                </tr>
+                            {{/each}}
+                            </tbody>
+                        </table>
+                    </div>
+                {{else}}
+                    <div class="cp-data-table-empty">No recognized tracing configuration keys were found.</div>
+                {{/if}}
+            </div>
+        </div>
+
+        <div class="card card-light">
+            <div class="card-header">
+                <h3 class="card-title">Diagnostics</h3>
+            </div>
+            <div class="card-body">
+                {{#if hasDiagnostics}}
+                    <div class="cp-data-table-container">
+                        <table class="table cp-data-table-table cp-data-table-fixed">
+                            <thead>
+                            <tr>
+                                <th scope="col">Severity</th>
+                                <th scope="col">Message</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            {{#each diagnostics}}
+                                <tr>
+                                    <td><span class="badge badge-secondary">{{ severity }}</span></td>
+                                    <td>{{ message }}</td>
+                                </tr>
+                            {{/each}}
+                            </tbody>
+                        </table>
+                    </div>
+                {{else}}
+                    <div class="cp-data-table-empty">No local tracing diagnostics were reported.</div>
+                {{/if}}
+            </div>
+        </div>
+    </div>
+{{/with}}

--- a/control-panel-tracing/src/test/java/io/micronaut/controlpanel/panels/tracing/TracingControlPanelTest.java
+++ b/control-panel-tracing/src/test/java/io/micronaut/controlpanel/panels/tracing/TracingControlPanelTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.tracing;
+
+import io.micronaut.context.ApplicationContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TracingControlPanelTest {
+
+    @Test
+    void contextCreatesTracingControlPanelWhenModuleIsPresent() {
+        try (ApplicationContext context = ApplicationContext.run(Map.of(
+                TracingControlPanel.ENABLED_PROPERTY, true,
+                "micronaut.application.name", "orders"
+        ))) {
+            TracingControlPanel panel = context.getBean(TracingControlPanel.class);
+
+            assertEquals("tracing", panel.getName());
+            assertEquals("/views/tracing/body", panel.getBodyView().file());
+            assertEquals("/views/tracing/detail", panel.getDetailedView().file());
+            assertEquals("Observability", panel.getCategory().name());
+            assertEquals("Inspect tracing", panel.getDetailLinkName());
+            assertTrue(panel.getBody().diagnostics().stream().anyMatch(diagnostic -> diagnostic.message().contains("No tracing provider")));
+        }
+    }
+}

--- a/control-panel-tracing/src/test/java/io/micronaut/controlpanel/panels/tracing/TracingDiagnosticsServiceTest.java
+++ b/control-panel-tracing/src/test/java/io/micronaut/controlpanel/panels/tracing/TracingDiagnosticsServiceTest.java
@@ -36,7 +36,7 @@ class TracingDiagnosticsServiceTest {
                 "otel.traces.exporter", "otlp",
                 "otel.metrics.exporter", "none",
                 "otel.logs.exporter", "none",
-                "otel.exporter.otlp.endpoint", "https://user:password@collector.example:4317/v1/traces?token=raw-token&region=us",
+                "otel.exporter.otlp.endpoint", "https://user:password@collector.example:4317/v1/traces?token=raw-token&api-key=raw-api-key&clientSecret=raw-client-secret&access%5Ftoken=raw-access-token&region=us",
                 "otel.exporter.otlp.headers", "Authorization=Bearer raw-header",
                 "otel.propagators", "tracecontext,baggage",
                 "otel.traces.sampler", "parentbased_always_on"
@@ -49,10 +49,13 @@ class TracingDiagnosticsServiceTest {
             assertTrue(body.providers().stream().anyMatch(provider -> provider.name().equals("OpenTelemetry")));
             assertTrue(body.exporters().stream().anyMatch(exporter -> exporter.signal().equals("Traces") && exporter.exporter().equals("otlp")));
 
-            String renderedValues = body.configuration().toString() + body.resourceAttributes();
+            String renderedValues = body.configuration().toString() + body.resourceAttributes() + body.exporters();
             assertFalse(renderedValues.contains("resource-secret"));
             assertFalse(renderedValues.contains("raw-header"));
             assertFalse(renderedValues.contains("raw-token"));
+            assertFalse(renderedValues.contains("raw-api-key"));
+            assertFalse(renderedValues.contains("raw-client-secret"));
+            assertFalse(renderedValues.contains("raw-access-token"));
             assertFalse(renderedValues.contains("user:password"));
             assertTrue(renderedValues.contains(TracingRedactor.REDACTED));
         }

--- a/control-panel-tracing/src/test/java/io/micronaut/controlpanel/panels/tracing/TracingDiagnosticsServiceTest.java
+++ b/control-panel-tracing/src/test/java/io/micronaut/controlpanel/panels/tracing/TracingDiagnosticsServiceTest.java
@@ -89,6 +89,17 @@ class TracingDiagnosticsServiceTest {
     }
 
     @Test
+    void doesNotReportExporterNoneDiagnosticForDefaultedExporterValues() {
+        try (ApplicationContext context = ApplicationContext.run(Map.of())) {
+            TracingBody body = service(context, "io.opentelemetry.api.OpenTelemetry").getBody();
+
+            assertTrue(body.exporters().stream().allMatch(exporter -> "none".equals(exporter.exporter())));
+            assertTrue(body.exporters().stream().allMatch(exporter -> "default disabled".equals(exporter.status())));
+            assertFalse(body.diagnostics().stream().anyMatch(diagnostic -> diagnostic.message().contains("exporter is set to none")));
+        }
+    }
+
+    @Test
     void reportsLegacyProviderAndMultipleProviderCompatibilityWarning() {
         try (ApplicationContext context = ApplicationContext.run(Map.of())) {
             TracingBody body = service(context, "io.opentelemetry.api.OpenTelemetry", "brave.Tracing").getBody();

--- a/control-panel-tracing/src/test/java/io/micronaut/controlpanel/panels/tracing/TracingDiagnosticsServiceTest.java
+++ b/control-panel-tracing/src/test/java/io/micronaut/controlpanel/panels/tracing/TracingDiagnosticsServiceTest.java
@@ -57,6 +57,7 @@ class TracingDiagnosticsServiceTest {
             assertFalse(renderedValues.contains("raw-client-secret"));
             assertFalse(renderedValues.contains("raw-access-token"));
             assertFalse(renderedValues.contains("user:password"));
+            assertFalse(renderedValues.contains("tenant-a"));
             assertTrue(renderedValues.contains(TracingRedactor.REDACTED));
         }
     }

--- a/control-panel-tracing/src/test/java/io/micronaut/controlpanel/panels/tracing/TracingDiagnosticsServiceTest.java
+++ b/control-panel-tracing/src/test/java/io/micronaut/controlpanel/panels/tracing/TracingDiagnosticsServiceTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.tracing;
+
+import io.micronaut.context.ApplicationContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TracingDiagnosticsServiceTest {
+
+    @Test
+    void reportsOpenTelemetryConfigurationAndRedactsSensitiveValues() {
+        try (ApplicationContext context = ApplicationContext.run(Map.of(
+                "micronaut.application.name", "orders",
+                "otel.service.name", "orders-api",
+                "otel.resource.attributes", "deployment.environment=dev,api.key=resource-secret,tenant.id=tenant-a",
+                "otel.traces.exporter", "otlp",
+                "otel.metrics.exporter", "none",
+                "otel.logs.exporter", "none",
+                "otel.exporter.otlp.endpoint", "https://user:password@collector.example:4317/v1/traces?token=raw-token&region=us",
+                "otel.exporter.otlp.headers", "Authorization=Bearer raw-header",
+                "otel.propagators", "tracecontext,baggage",
+                "otel.traces.sampler", "parentbased_always_on"
+        ))) {
+            TracingBody body = service(context, "io.opentelemetry.api.OpenTelemetry", "io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter").getBody();
+
+            assertEquals("orders-api", body.serviceName());
+            assertEquals("parentbased_always_on", body.sampler());
+            assertEquals("tracecontext,baggage", body.propagators());
+            assertTrue(body.providers().stream().anyMatch(provider -> provider.name().equals("OpenTelemetry")));
+            assertTrue(body.exporters().stream().anyMatch(exporter -> exporter.signal().equals("Traces") && exporter.exporter().equals("otlp")));
+
+            String renderedValues = body.configuration().toString() + body.resourceAttributes();
+            assertFalse(renderedValues.contains("resource-secret"));
+            assertFalse(renderedValues.contains("raw-header"));
+            assertFalse(renderedValues.contains("raw-token"));
+            assertFalse(renderedValues.contains("user:password"));
+            assertTrue(renderedValues.contains(TracingRedactor.REDACTED));
+        }
+    }
+
+    @Test
+    void reportsTracingAbsentWithoutFailing() {
+        try (ApplicationContext context = ApplicationContext.run(Map.of("micronaut.application.name", "orders"))) {
+            TracingBody body = service(context).getBody();
+
+            assertFalse(body.hasProviders());
+            assertEquals("orders", body.serviceName());
+            assertTrue(body.diagnostics().stream().anyMatch(diagnostic -> diagnostic.message().contains("No tracing provider")));
+        }
+    }
+
+    @Test
+    void reportsExporterNoneAsDeterministicDiagnostic() {
+        try (ApplicationContext context = ApplicationContext.run(Map.of(
+                "otel.traces.exporter", "none",
+                "otel.metrics.exporter", "none",
+                "otel.logs.exporter", "none"
+        ))) {
+            TracingBody body = service(context, "io.opentelemetry.api.OpenTelemetry").getBody();
+
+            assertTrue(body.diagnostics().stream().anyMatch(diagnostic -> diagnostic.message().equals("Traces exporter is set to none.")));
+            assertTrue(body.diagnostics().stream().anyMatch(diagnostic -> diagnostic.message().equals("Metrics exporter is set to none.")));
+            assertTrue(body.diagnostics().stream().anyMatch(diagnostic -> diagnostic.message().equals("Logs exporter is set to none.")));
+        }
+    }
+
+    @Test
+    void reportsLegacyProviderAndMultipleProviderCompatibilityWarning() {
+        try (ApplicationContext context = ApplicationContext.run(Map.of())) {
+            TracingBody body = service(context, "io.opentelemetry.api.OpenTelemetry", "brave.Tracing").getBody();
+
+            assertTrue(body.providers().stream().anyMatch(provider -> provider.name().equals("OpenTelemetry")));
+            assertTrue(body.providers().stream().anyMatch(provider -> provider.name().equals("Brave/Zipkin")));
+            assertTrue(body.diagnostics().stream().anyMatch(diagnostic -> diagnostic.message().contains("Multiple tracing provider families")));
+        }
+    }
+
+    @Test
+    void reportsKafkaIncludeExcludeConflict() {
+        try (ApplicationContext context = ApplicationContext.run(Map.of(
+                "kafka.tracing.included-topics", "orders",
+                "kafka.tracing.excluded-topics", "audit"
+        ))) {
+            TracingBody body = service(context, "io.opentelemetry.api.OpenTelemetry").getBody();
+
+            assertTrue(body.diagnostics().stream().anyMatch(diagnostic -> diagnostic.message().contains("Kafka tracing has both include and exclude")));
+        }
+    }
+
+    @Test
+    void doesNotReportGenericBaseLibrariesAsTracingInstrumentation() {
+        try (ApplicationContext context = ApplicationContext.run(Map.of())) {
+            TracingBody body = service(context,
+                    "io.micronaut.http.client.HttpClient",
+                    "io.grpc.ManagedChannel",
+                    "java.sql.Driver",
+                    "io.r2dbc.spi.ConnectionFactory",
+                    "org.apache.kafka.clients.producer.Producer",
+                    "software.amazon.awssdk.core.SdkClient",
+                    "ch.qos.logback.classic.Logger",
+                    "org.slf4j.MDC").getBody();
+
+            assertEquals(0, body.presentInstrumentationCount());
+            assertEquals("unknown", instrumentation(body, "HTTP client/server").status());
+            assertEquals("unknown", instrumentation(body, "gRPC").status());
+            assertEquals("unknown", instrumentation(body, "JDBC").status());
+            assertEquals("unknown", instrumentation(body, "R2DBC").status());
+            assertEquals("unknown", instrumentation(body, "Kafka").status());
+            assertEquals("unknown", instrumentation(body, "AWS SDK").status());
+            assertEquals("unknown", instrumentation(body, "Logback appender").status());
+            assertEquals("unknown", instrumentation(body, "Logback MDC").status());
+            assertTrue(body.instrumentations().stream().allMatch(instrumentation -> instrumentation.detail().contains("no ") || instrumentation.detail().contains("but no ")));
+        }
+    }
+
+    @Test
+    void reportsMicronautTracingInstrumentationWhenIntegrationEvidenceIsPresent() {
+        try (ApplicationContext context = ApplicationContext.run(Map.of())) {
+            TracingBody body = service(context,
+                    "io.micronaut.tracing.opentelemetry.instrument.http.client.OpenTelemetryClientFilter",
+                    "io.micronaut.tracing.opentelemetry.instrument.grpc.GrpcServerTracingInterceptorFactory",
+                    "io.micronaut.tracing.opentelemetry.instrument.jdbc.DataSourceBeanCreatedEventListener",
+                    "io.micronaut.tracing.opentelemetry.instrument.r2dbc.R2dbcConnectionFactoryFactory",
+                    "io.micronaut.tracing.opentelemetry.instrument.kafka.KafkaTelemetryProducerTracingInstrumentation",
+                    "io.micronaut.tracing.opentelemetry.xray.SdkClientBuilderListener",
+                    "io.micronaut.tracing.opentelemetry.log.OpenTelemetryLogbackAppenderInstaller",
+                    "io.opentelemetry.instrumentation.logback.mdc.v1_0.OpenTelemetryAppender").getBody();
+
+            assertEquals(8, body.presentInstrumentationCount());
+            assertTrue(body.instrumentations().stream().allMatch(instrumentation -> "present".equals(instrumentation.status())));
+        }
+    }
+
+    @Test
+    void reportsAbsentWhenNeitherBaseLibraryNorTracingIntegrationIsDetected() {
+        try (ApplicationContext context = ApplicationContext.run(Map.of())) {
+            TracingBody body = service(context).getBody();
+
+            assertEquals("absent", instrumentation(body, "Kafka").status());
+            assertEquals("absent", instrumentation(body, "R2DBC").status());
+            assertEquals("absent", instrumentation(body, "AWS SDK").status());
+        }
+    }
+
+    private static TracingDiagnosticsService service(ApplicationContext context, String... presentClasses) {
+        Set<String> classes = Set.of(presentClasses);
+        return new TracingDiagnosticsService(
+                context.getEnvironment(),
+                context.getBean(io.micronaut.runtime.ApplicationConfiguration.class),
+                context,
+                new TracingRedactor(),
+                classes::contains
+        );
+    }
+
+    private static TracingInstrumentationInfo instrumentation(TracingBody body, String surface) {
+        return body.instrumentations().stream()
+                .filter(instrumentation -> instrumentation.surface().equals(surface))
+                .findFirst()
+                .orElseThrow();
+    }
+}

--- a/control-panel-tracing/src/test/java/io/micronaut/controlpanel/panels/tracing/TracingRedactorTest.java
+++ b/control-panel-tracing/src/test/java/io/micronaut/controlpanel/panels/tracing/TracingRedactorTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.tracing;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TracingRedactorTest {
+
+    @Test
+    void redactsMalformedUrlQueryValues() {
+        String redacted = new TracingRedactor().redact(
+                "otel.exporter.otlp.endpoint",
+                "https://user:password@collector.example/v1/[traces?api-key=prod-secret&clientSecret=client-secret&region=us#frag"
+        );
+
+        assertFalse(redacted.contains("user:password"));
+        assertFalse(redacted.contains("prod-secret"));
+        assertFalse(redacted.contains("client-secret"));
+        assertTrue(redacted.contains("api-key=" + TracingRedactor.REDACTED));
+        assertTrue(redacted.contains("clientSecret=" + TracingRedactor.REDACTED));
+        assertTrue(redacted.contains("region=us"));
+    }
+}

--- a/control-panel-tracing/src/test/java/io/micronaut/controlpanel/panels/tracing/TracingTemplateTest.java
+++ b/control-panel-tracing/src/test/java/io/micronaut/controlpanel/panels/tracing/TracingTemplateTest.java
@@ -33,7 +33,7 @@ class TracingTemplateTest {
     void renderedDetailTemplateDoesNotExposeRawSecrets() throws IOException {
         try (ApplicationContext context = ApplicationContext.run(Map.of(
                 "otel.traces.exporter", "otlp",
-                "otel.exporter.otlp.endpoint", "https://user:password@collector.example:4317?token=raw-token",
+                "otel.exporter.otlp.endpoint", "https://user:password@collector.example:4317?api-key=prod-secret&clientSecret=client-secret&token=raw-token",
                 "otel.resource.attributes", "api.key=resource-secret"
         ))) {
             TracingBody body = new TracingDiagnosticsService(
@@ -49,6 +49,8 @@ class TracingTemplateTest {
 
             assertTrue(html.contains(TracingRedactor.REDACTED));
             assertFalse(html.contains("user:password"));
+            assertFalse(html.contains("prod-secret"));
+            assertFalse(html.contains("client-secret"));
             assertFalse(html.contains("raw-token"));
             assertFalse(html.contains("resource-secret"));
         }

--- a/control-panel-tracing/src/test/java/io/micronaut/controlpanel/panels/tracing/TracingTemplateTest.java
+++ b/control-panel-tracing/src/test/java/io/micronaut/controlpanel/panels/tracing/TracingTemplateTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.tracing;
+
+import com.github.jknack.handlebars.Handlebars;
+import com.github.jknack.handlebars.io.ClassPathTemplateLoader;
+import io.micronaut.context.ApplicationContext;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TracingTemplateTest {
+
+    @Test
+    void renderedDetailTemplateDoesNotExposeRawSecrets() throws IOException {
+        try (ApplicationContext context = ApplicationContext.run(Map.of(
+                "otel.traces.exporter", "otlp",
+                "otel.exporter.otlp.endpoint", "https://user:password@collector.example:4317?token=raw-token",
+                "otel.resource.attributes", "api.key=resource-secret"
+        ))) {
+            TracingBody body = new TracingDiagnosticsService(
+                    context.getEnvironment(),
+                    context.getBean(io.micronaut.runtime.ApplicationConfiguration.class),
+                    context,
+                    new TracingRedactor(),
+                    Set.of("io.opentelemetry.api.OpenTelemetry")::contains
+            ).getBody();
+            Handlebars handlebars = new Handlebars(new ClassPathTemplateLoader("/", ".hbs"));
+
+            String html = handlebars.compile("views/tracing/detail").apply(Map.of("controlPanel", Map.of("body", body)));
+
+            assertTrue(html.contains(TracingRedactor.REDACTED));
+            assertFalse(html.contains("user:password"));
+            assertFalse(html.contains("raw-token"));
+            assertFalse(html.contains("resource-secret"));
+        }
+    }
+}

--- a/control-panel-tracing/src/test/resources/logback-test.xml
+++ b/control-panel-tracing/src/test/resources/logback-test.xml
@@ -1,0 +1,1 @@
+<configuration />

--- a/doc-examples/example-java/build.gradle.kts
+++ b/doc-examples/example-java/build.gradle.kts
@@ -50,6 +50,9 @@ dependencies {
     implementation(libs.avro)
     implementation(libs.avro.serde)
 
+    // Tracing
+    implementation(projects.micronautControlPanelTracing)
+
     // OpenAPI + Swagger UI (views generated at compile-time)
     annotationProcessor(mnOpenapi.micronaut.openapi)
     testAnnotationProcessor(mnOpenapi.micronaut.openapi)

--- a/doc-examples/example-java/src/main/resources/application.yml
+++ b/doc-examples/example-java/src/main/resources/application.yml
@@ -36,6 +36,20 @@ info:
       purpose: Local development
       owner: Micronaut
 
+otel:
+  service:
+    name: control-panel-example
+  resource:
+    attributes: deployment.environment=dev,service.namespace=control-panel,api.key=example-secret
+  traces:
+    exporter: none
+    sampler: parentbased_always_on
+  metrics:
+    exporter: none
+  logs:
+    exporter: none
+  propagators: tracecontext,baggage
+
 ehcache:
   caches:
     my-ehcache:

--- a/doc-examples/example-java/src/test/java/example/ControlPanelRenderingTest.java
+++ b/doc-examples/example-java/src/test/java/example/ControlPanelRenderingTest.java
@@ -18,4 +18,14 @@ class ControlPanelRenderingTest {
         assertTrue(body.contains("my-local"));
         assertTrue(body.contains("files stored."));
     }
+
+    @Test
+    void rendersTracingDiagnostics(@Client("/") HttpClient client) {
+        var body = client.toBlocking().retrieve(HttpRequest.GET("/control-panel/tracing"));
+
+        assertTrue(body.contains("Tracing overview"));
+        assertTrue(body.contains("control-panel-example"));
+        assertTrue(body.contains("Traces exporter is set to none."));
+        assertTrue(body.contains("[redacted]"));
+    }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,6 +20,7 @@ include("control-panel-object-storage")
 include("control-panel-cache")
 include("control-panel-datasource")
 include("control-panel-hibernate")
+include("control-panel-tracing")
 include("control-panel-ui")
 include("control-panel-kafka")
 

--- a/src/main/docs/guide/controlPanels/tracing.adoc
+++ b/src/main/docs/guide/controlPanels/tracing.adoc
@@ -1,0 +1,62 @@
+You can add a read-only tracing diagnostics panel to a Micronaut application that uses Micronaut Tracing or OpenTelemetry:
+
+dependency:io.micronaut.controlpanel:micronaut-control-panel-tracing[scope=developmentOnly]
+
+The tracing panel is intended for development-time diagnostics. It inspects local Micronaut configuration, the bean context, and the application classpath. It does not create spans, mutate tracing configuration, send test telemetry, or call OTLP, Zipkin, Jaeger, or any other telemetry backend.
+
+The panel reports:
+
+* Detected tracing provider families, including OpenTelemetry, Brave/Zipkin, and OpenTracing/Jaeger classes when present.
+* Effective service name from `otel.service.name`, falling back to the Micronaut application name when available.
+* OpenTelemetry trace, metric, and log exporter settings, including OTLP endpoint overrides.
+* OpenTelemetry propagator and sampler configuration.
+* OpenTelemetry resource attributes.
+* Local classpath evidence for common instrumentation surfaces: HTTP, gRPC, JDBC, R2DBC, Kafka, AWS SDK, Logback, and MDC.
+* Deterministic local diagnostics such as exporters set to `none`, configured exporters without a known exporter implementation, multiple provider families, disabled SDK configuration, and conflicting Kafka tracing topic include/exclude filters.
+
+The panel deliberately does not verify collector reachability, inspect remote backend state, infer dependency trees from build files, display raw captured headers, or bypass Control Panel security. A value can be `not configured` even when a remote backend would apply its own default. Instrumentation rows are marked `present` only when a Micronaut Tracing or OpenTelemetry integration class is visible. If only the base library is visible, such as JDBC, Kafka, Logback, or SLF4J MDC without the tracing integration, the row is reported as `unknown` instead of `present`.
+
+Sensitive values are redacted before rendering. This includes keys that look like passwords, credentials, certificates, tokens, API keys, authorization headers, bearer values, URL userinfo, and sensitive URL query parameters. Resource attributes are redacted with the same rules because they can contain tenant, account, or deployment identifiers.
+
+For a deterministic local OpenTelemetry configuration, you can start with:
+
+[configuration]
+----
+micronaut:
+  application:
+    name: orders
+otel:
+  service:
+    name: orders-api
+  resource:
+    attributes: deployment.environment=dev,service.namespace=checkout
+  traces:
+    exporter: none
+    sampler: parentbased_always_on
+  metrics:
+    exporter: none
+  logs:
+    exporter: none
+  propagators: tracecontext,baggage
+----
+
+To exercise a local diagnostic, configure both Kafka tracing include and exclude filters:
+
+[configuration]
+----
+kafka:
+  tracing:
+    included-topics: orders
+    excluded-topics: internal.audit
+----
+
+To disable the panel while keeping the dependency on the classpath:
+
+[configuration]
+----
+micronaut:
+  control-panel:
+    panels:
+      tracing:
+        enabled: false
+----

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -10,6 +10,7 @@ controlPanels:
   datasource: Datasource
   hibernate: Hibernate
   kafka: Kafka
+  tracing: Tracing
 
 custom: Creating Custom Control Panels
 repository: Repository


### PR DESCRIPTION
## Summary

- Adds an optional `micronaut-control-panel-tracing` module with a read-only Tracing Diagnostics panel.
- Reports local provider, exporter, resource, sampler, propagator, instrumentation, configuration, and deterministic diagnostic state without backend calls or mutation.
- Adds guide content, example app wiring, rendered-template coverage, redaction coverage, and review-stage cleanup for checkstyle/Javadocs/nullness metadata.

## Verification

- `./gradlew :micronaut-control-panel-tracing:check`
- `./gradlew :micronaut-doc-examples:micronaut-example-java:test --tests example.ControlPanelRenderingTest`
- `./gradlew docs`
- `git diff --check`

## PR Assets

Desktop 1440x900:

![Desktop screenshot](https://raw.githubusercontent.com/micronaut-projects/micronaut-control-panel/587c083d3d6cfb5d3a8c49f5cb3cf9f42f5470cc/assets/pr-557/01418692a8a6/dev-475-tracing-desktop-1440x900.png)

Mobile 390x844:

![Mobile screenshot](https://raw.githubusercontent.com/micronaut-projects/micronaut-control-panel/59ad031e57c5073f06786932b27e8757ba53708f/assets/pr-557/01418692a8a6/dev-475-tracing-mobile-390x844.png)

## Issue Linkage

Paperclip issue: DEV-475. No linked GitHub issue was present in Paperclip, and live GitHub searches for DEV-475/tracing diagnostics found no matching issue, so no GitHub closing keyword or linked-issue-creator reviewer applies.

## Project Routing

QA selected the Micronaut organization project set `5.0.0-M3` and `5.0.0 Release`. Ambiguity preserved: maintainers may move this PR to `5.1.0 Release` or another release board if Control Panel `2.0.0` is consumed later than Platform `5.0.0`.

---
###### ✨ This message was AI-generated using gpt-5
