### PR TITLE
Add validation diagnostics control panel

### DIFF
--- a/control-panel-datasource/src/main/java/io/micronaut/controlpanel/panels/datasource/OracleUcpConnectionPoolInspector.java
+++ b/control-panel-datasource/src/main/java/io/micronaut/controlpanel/panels/datasource/OracleUcpConnectionPoolInspector.java
@@ -23,6 +23,7 @@ import oracle.ucp.UniversalConnectionPoolStatistics;
 import oracle.ucp.jdbc.PoolDataSource;
 
 import javax.sql.DataSource;
+import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -117,6 +118,7 @@ final class OracleUcpConnectionPoolInspector implements ConnectionPoolInspector 
             PoolInfoSupport.group(
                 "Behavior",
                 option("Fast connection failover", safeBoolean(dataSource::getFastConnectionFailoverEnabled)),
+                option("Fail fast on chunk unavailable", optionalValue(dataSource, "getFailFastOnChunkUnavailable")),
                 option("Read-only instances", dataSource.isReadOnlyInstanceAllowed()),
                 option("Create in borrow thread", dataSource.isCreateConnectionInBorrowThread()),
                 option("Commit on return", dataSource.isCommitOnConnectionReturn()),
@@ -164,6 +166,14 @@ final class OracleUcpConnectionPoolInspector implements ConnectionPoolInspector 
                 durationMillis("Failed wait", statLong(stats, UniversalConnectionPoolStatistics::getCumulativeFailedConnectionWaitTime))
             )
         );
+    }
+
+    private static String optionalValue(PoolDataSource dataSource, String methodName) {
+        try {
+            return PoolInfoSupport.display(dataSource.getClass().getMethod(methodName).invoke(dataSource));
+        } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException | SecurityException _) {
+            return PoolInfoSupport.UNKNOWN;
+        }
     }
 
     private static String safeType(Supplier<Object> supplier) {

--- a/control-panel-validation/build.gradle.kts
+++ b/control-panel-validation/build.gradle.kts
@@ -20,5 +20,5 @@ dependencies {
 }
 
 micronautBuild {
-    binaryCompatibility.enabledAfter("2.0.0")
+    binaryCompatibility.enabledAfter("2.0.1")
 }

--- a/control-panel-validation/build.gradle.kts
+++ b/control-panel-validation/build.gradle.kts
@@ -1,0 +1,24 @@
+plugins {
+    io.micronaut.build.internal.`control-panel-module`
+}
+
+dependencies {
+    api(projects.micronautControlPanelCore)
+
+    compileOnly(platform(libs.micronaut.validation))
+    compileOnly("io.micronaut.validation:micronaut-validation")
+
+    testAnnotationProcessor(mn.micronaut.inject.java)
+    testAnnotationProcessor(platform(libs.micronaut.validation))
+    testAnnotationProcessor("io.micronaut.validation:micronaut-validation-processor")
+    testImplementation(mn.micronaut.http.server.netty)
+    testImplementation(mnSerde.micronaut.serde.jackson)
+    testImplementation(platform(libs.micronaut.validation))
+    testImplementation("io.micronaut.validation:micronaut-validation")
+    testImplementation(mnTest.micronaut.test.junit5)
+    testRuntimeOnly(mnTest.junit.jupiter.engine)
+}
+
+micronautBuild {
+    binaryCompatibility.enabledAfter("2.0.0")
+}

--- a/control-panel-validation/src/main/java/io/micronaut/controlpanel/panels/validation/ValidationAttributeSanitizer.java
+++ b/control-panel-validation/src/main/java/io/micronaut/controlpanel/panels/validation/ValidationAttributeSanitizer.java
@@ -72,39 +72,55 @@ final class ValidationAttributeSanitizer {
             return enumValue.name();
         }
         if (value instanceof CharSequence sequence) {
-            String s = sequence.toString();
-            if (mode == ValidationConfiguration.AttributeMode.SAFE && s.length() > MAX_STRING_LENGTH) {
-                return s.substring(0, MAX_STRING_LENGTH) + "... [truncated]";
-            }
-            return s;
+            return formatString(sequence, mode);
         }
         if (value.getClass().isArray()) {
-            int length = Array.getLength(value);
-            int limit = mode == ValidationConfiguration.AttributeMode.SAFE ? Math.min(length, MAX_ARRAY_ITEMS) : length;
-            List<String> parts = new ArrayList<>(limit);
-            for (int i = 0; i < limit; i++) {
-                parts.add(toDisplayValue(Array.get(value, i), mode));
-            }
-            String suffix = length > limit ? ", ... (" + length + " total)" : "";
-            return "[" + String.join(", ", parts) + suffix + "]";
+            return formatArray(value, mode);
         }
         if (value instanceof Iterable<?> iterable) {
-            List<String> parts = new ArrayList<>();
-            int count = 0;
-            for (Object item : iterable) {
-                if (mode == ValidationConfiguration.AttributeMode.SAFE && count >= MAX_ARRAY_ITEMS) {
-                    parts.add("...");
-                    break;
-                }
-                parts.add(toDisplayValue(item, mode));
-                count++;
-            }
-            return "[" + String.join(", ", parts) + "]";
+            return formatIterable(iterable, mode);
         }
         if (value instanceof Number || value instanceof Boolean) {
             return value.toString();
         }
         return mode == ValidationConfiguration.AttributeMode.SAFE ? value.getClass().getName() + " [redacted]" : value.toString();
+    }
+
+    private static String formatString(CharSequence sequence, ValidationConfiguration.AttributeMode mode) {
+        String s = sequence.toString();
+        if (mode == ValidationConfiguration.AttributeMode.SAFE && s.length() > MAX_STRING_LENGTH) {
+            return s.substring(0, MAX_STRING_LENGTH) + "... [truncated]";
+        }
+        return s;
+    }
+
+    private static String formatArray(Object value, ValidationConfiguration.AttributeMode mode) {
+        int length = Array.getLength(value);
+        int limit = displayLimit(length, mode);
+        List<String> parts = new ArrayList<>(limit);
+        for (int i = 0; i < limit; i++) {
+            parts.add(toDisplayValue(Array.get(value, i), mode));
+        }
+        String suffix = length > limit ? ", ... (" + length + " total)" : "";
+        return "[" + String.join(", ", parts) + suffix + "]";
+    }
+
+    private static String formatIterable(Iterable<?> iterable, ValidationConfiguration.AttributeMode mode) {
+        List<String> parts = new ArrayList<>();
+        int count = 0;
+        for (Object item : iterable) {
+            if (mode == ValidationConfiguration.AttributeMode.SAFE && count >= MAX_ARRAY_ITEMS) {
+                parts.add("...");
+                break;
+            }
+            parts.add(toDisplayValue(item, mode));
+            count++;
+        }
+        return "[" + String.join(", ", parts) + "]";
+    }
+
+    private static int displayLimit(int length, ValidationConfiguration.AttributeMode mode) {
+        return mode == ValidationConfiguration.AttributeMode.SAFE ? Math.min(length, MAX_ARRAY_ITEMS) : length;
     }
 
     private static boolean isStandardMember(String name) {

--- a/control-panel-validation/src/main/java/io/micronaut/controlpanel/panels/validation/ValidationAttributeSanitizer.java
+++ b/control-panel-validation/src/main/java/io/micronaut/controlpanel/panels/validation/ValidationAttributeSanitizer.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.validation;
+
+import io.micronaut.core.annotation.AnnotationClassValue;
+import jakarta.inject.Singleton;
+
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Converts annotation members into safe display strings.
+ *
+ * @since 2.0.0
+ */
+@Singleton
+final class ValidationAttributeSanitizer {
+
+    private static final int MAX_STRING_LENGTH = 120;
+    private static final int MAX_ARRAY_ITEMS = 8;
+    private static final List<String> SECRET_TOKENS = List.of("password", "secret", "token", "key", "credential");
+
+    List<ValidationDiagnostics.AttributeRow> sanitize(Map<CharSequence, Object> values, ValidationConfiguration.AttributeMode mode) {
+        if (mode == ValidationConfiguration.AttributeMode.NONE || values.isEmpty()) {
+            return List.of();
+        }
+        List<ValidationDiagnostics.AttributeRow> rows = new ArrayList<>();
+        values.entrySet().stream()
+            .filter(e -> !isStandardMember(e.getKey().toString()))
+            .sorted(Comparator.comparing(e -> e.getKey().toString()))
+            .forEach(e -> rows.add(sanitize(e.getKey().toString(), e.getValue(), mode)));
+        return List.copyOf(rows);
+    }
+
+    private static ValidationDiagnostics.AttributeRow sanitize(String name, Object value, ValidationConfiguration.AttributeMode mode) {
+        boolean redacted = mode == ValidationConfiguration.AttributeMode.SAFE && isSecretLike(name);
+        if (redacted) {
+            return new ValidationDiagnostics.AttributeRow(name, "[redacted]", true);
+        }
+        String display = toDisplayValue(value, mode);
+        return new ValidationDiagnostics.AttributeRow(name, display, mode == ValidationConfiguration.AttributeMode.SAFE && display.endsWith("[redacted]"));
+    }
+
+    private static String toDisplayValue(Object value, ValidationConfiguration.AttributeMode mode) {
+        if (value == null) {
+            return "null";
+        }
+        if (value instanceof Class<?> type) {
+            return type.getName();
+        }
+        if (value instanceof AnnotationClassValue<?> classValue) {
+            return classValue.getName();
+        }
+        if (value instanceof Enum<?> enumValue) {
+            return enumValue.name();
+        }
+        if (value instanceof CharSequence sequence) {
+            String s = sequence.toString();
+            if (mode == ValidationConfiguration.AttributeMode.SAFE && s.length() > MAX_STRING_LENGTH) {
+                return s.substring(0, MAX_STRING_LENGTH) + "... [truncated]";
+            }
+            return s;
+        }
+        if (value.getClass().isArray()) {
+            int length = Array.getLength(value);
+            int limit = mode == ValidationConfiguration.AttributeMode.SAFE ? Math.min(length, MAX_ARRAY_ITEMS) : length;
+            List<String> parts = new ArrayList<>(limit);
+            for (int i = 0; i < limit; i++) {
+                parts.add(toDisplayValue(Array.get(value, i), mode));
+            }
+            String suffix = length > limit ? ", ... (" + length + " total)" : "";
+            return "[" + String.join(", ", parts) + suffix + "]";
+        }
+        if (value instanceof Iterable<?> iterable) {
+            List<String> parts = new ArrayList<>();
+            int count = 0;
+            for (Object item : iterable) {
+                if (mode == ValidationConfiguration.AttributeMode.SAFE && count >= MAX_ARRAY_ITEMS) {
+                    parts.add("...");
+                    break;
+                }
+                parts.add(toDisplayValue(item, mode));
+                count++;
+            }
+            return "[" + String.join(", ", parts) + "]";
+        }
+        if (value instanceof Number || value instanceof Boolean) {
+            return value.toString();
+        }
+        return mode == ValidationConfiguration.AttributeMode.SAFE ? value.getClass().getName() + " [redacted]" : value.toString();
+    }
+
+    private static boolean isStandardMember(String name) {
+        return "message".equals(name) || "groups".equals(name) || "payload".equals(name);
+    }
+
+    private static boolean isSecretLike(String name) {
+        String normalized = name.toLowerCase(Locale.ROOT);
+        return SECRET_TOKENS.stream().anyMatch(normalized::contains);
+    }
+}

--- a/control-panel-validation/src/main/java/io/micronaut/controlpanel/panels/validation/ValidationConfiguration.java
+++ b/control-panel-validation/src/main/java/io/micronaut/controlpanel/panels/validation/ValidationConfiguration.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.validation;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.annotation.ReflectiveAccess;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Configuration for the validation diagnostics panel.
+ *
+ * @since 2.0.0
+ */
+@ConfigurationProperties(ValidationConfiguration.PREFIX)
+@ReflectiveAccess
+public class ValidationConfiguration {
+
+    public static final String PREFIX = "micronaut.control-panel.validation";
+
+    private List<String> includePackages = new ArrayList<>();
+    private List<String> excludePackages = new ArrayList<>();
+    private AttributeMode showConstraintAttributes = AttributeMode.SAFE;
+
+    /**
+     * Package prefixes included in diagnostics. Empty means application packages after framework defaults are excluded.
+     */
+    public List<String> getIncludePackages() {
+        return includePackages;
+    }
+
+    public void setIncludePackages(List<String> includePackages) {
+        this.includePackages = includePackages == null ? new ArrayList<>() : includePackages;
+    }
+
+    /**
+     * Package prefixes excluded from diagnostics.
+     */
+    public List<String> getExcludePackages() {
+        return excludePackages;
+    }
+
+    public void setExcludePackages(List<String> excludePackages) {
+        this.excludePackages = excludePackages == null ? new ArrayList<>() : excludePackages;
+    }
+
+    /**
+     * Controls how constraint annotation attributes are displayed.
+     */
+    public AttributeMode getShowConstraintAttributes() {
+        return showConstraintAttributes;
+    }
+
+    public void setShowConstraintAttributes(AttributeMode showConstraintAttributes) {
+        this.showConstraintAttributes = showConstraintAttributes == null ? AttributeMode.SAFE : showConstraintAttributes;
+    }
+
+    public enum AttributeMode {
+        NONE,
+        SAFE,
+        ALL
+    }
+}

--- a/control-panel-validation/src/main/java/io/micronaut/controlpanel/panels/validation/ValidationConfiguration.java
+++ b/control-panel-validation/src/main/java/io/micronaut/controlpanel/panels/validation/ValidationConfiguration.java
@@ -28,7 +28,7 @@ import java.util.List;
  */
 @ConfigurationProperties(ValidationConfiguration.PREFIX)
 @ReflectiveAccess
-public class ValidationConfiguration {
+public final class ValidationConfiguration {
 
     public static final String PREFIX = "micronaut.control-panel.validation";
 
@@ -38,40 +38,73 @@ public class ValidationConfiguration {
 
     /**
      * Package prefixes included in diagnostics. Empty means application packages after framework defaults are excluded.
+     *
+     * @return package prefixes included in diagnostics
      */
     public List<String> getIncludePackages() {
         return includePackages;
     }
 
+    /**
+     * Sets package prefixes included in diagnostics.
+     *
+     * @param includePackages package prefixes included in diagnostics
+     */
     public void setIncludePackages(List<String> includePackages) {
         this.includePackages = includePackages == null ? new ArrayList<>() : includePackages;
     }
 
     /**
      * Package prefixes excluded from diagnostics.
+     *
+     * @return package prefixes excluded from diagnostics
      */
     public List<String> getExcludePackages() {
         return excludePackages;
     }
 
+    /**
+     * Sets package prefixes excluded from diagnostics.
+     *
+     * @param excludePackages package prefixes excluded from diagnostics
+     */
     public void setExcludePackages(List<String> excludePackages) {
         this.excludePackages = excludePackages == null ? new ArrayList<>() : excludePackages;
     }
 
     /**
      * Controls how constraint annotation attributes are displayed.
+     *
+     * @return constraint annotation attribute display mode
      */
     public AttributeMode getShowConstraintAttributes() {
         return showConstraintAttributes;
     }
 
+    /**
+     * Sets how constraint annotation attributes are displayed.
+     *
+     * @param showConstraintAttributes constraint annotation attribute display mode
+     */
     public void setShowConstraintAttributes(AttributeMode showConstraintAttributes) {
         this.showConstraintAttributes = showConstraintAttributes == null ? AttributeMode.SAFE : showConstraintAttributes;
     }
 
+    /**
+     * Constraint annotation attribute display modes.
+     */
     public enum AttributeMode {
+        /**
+         * Hide constraint annotation attributes.
+         */
         NONE,
+        /**
+         * Display safe scalar attributes with redaction and truncation.
+         */
         SAFE,
+        /**
+         * Display all annotation attribute values from Micronaut metadata.
+         */
         ALL
     }
 }

--- a/control-panel-validation/src/main/java/io/micronaut/controlpanel/panels/validation/ValidationControlPanel.java
+++ b/control-panel-validation/src/main/java/io/micronaut/controlpanel/panels/validation/ValidationControlPanel.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.validation;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.controlpanel.core.AbstractControlPanel;
+import io.micronaut.controlpanel.core.config.ControlPanelConfiguration;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.runtime.context.scope.Refreshable;
+import io.micronaut.validation.validator.ValidatorConfiguration;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+import static io.micronaut.core.util.StringUtils.EMPTY_STRING;
+
+/**
+ * Control panel that displays Micronaut Validation compile-time metadata and provider wiring.
+ *
+ * @since 2.0.0
+ */
+@Singleton
+@Refreshable
+@Requires(classes = ValidatorConfiguration.class)
+@Requires(property = ValidationControlPanel.ENABLED_PROPERTY, notEquals = StringUtils.FALSE)
+public class ValidationControlPanel extends AbstractControlPanel<ValidationDiagnostics> {
+
+    public static final String NAME = "validation";
+    public static final String ENABLED_PROPERTY = ControlPanelConfiguration.PREFIX + "." + NAME + ".enabled";
+
+    private final ValidationDiagnosticsCollector collector;
+
+    public ValidationControlPanel(ValidationDiagnosticsCollector collector,
+                                  @Named(NAME) ControlPanelConfiguration configuration) {
+        super(NAME, configuration);
+        this.collector = collector;
+    }
+
+    @Override
+    public ValidationDiagnostics getBody() {
+        return collector.collect();
+    }
+
+    @Override
+    public String getBadge() {
+        int count = getBody().totalConstraints();
+        return count == 0 ? EMPTY_STRING : String.valueOf(count);
+    }
+}

--- a/control-panel-validation/src/main/java/io/micronaut/controlpanel/panels/validation/ValidationControlPanel.java
+++ b/control-panel-validation/src/main/java/io/micronaut/controlpanel/panels/validation/ValidationControlPanel.java
@@ -35,6 +35,7 @@ import static io.micronaut.core.util.StringUtils.EMPTY_STRING;
 @Refreshable
 @Requires(classes = ValidatorConfiguration.class)
 @Requires(property = ValidationControlPanel.ENABLED_PROPERTY, notEquals = StringUtils.FALSE)
+@SuppressWarnings("InjectMoreThanOneScopeAnnotationOnClass")
 public class ValidationControlPanel extends AbstractControlPanel<ValidationDiagnostics> {
 
     public static final String NAME = "validation";

--- a/control-panel-validation/src/main/java/io/micronaut/controlpanel/panels/validation/ValidationDiagnostics.java
+++ b/control-panel-validation/src/main/java/io/micronaut/controlpanel/panels/validation/ValidationDiagnostics.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.validation;
+
+import io.micronaut.core.annotation.ReflectiveAccess;
+
+import java.util.List;
+
+/**
+ * View model for validation diagnostics.
+ *
+ * @since 2.0.0
+ */
+@ReflectiveAccess
+public record ValidationDiagnostics(
+    boolean validationEnabled,
+    String status,
+    String statusDescription,
+    List<SummaryItem> summary,
+    List<ComponentRow> components,
+    List<ValidatedElementRow> routes,
+    List<ValidatedElementRow> methods,
+    List<ValidatedElementRow> configurationProperties,
+    List<ValidatedElementRow> classes,
+    List<StateMessage> messages,
+    int totalConstraints
+) {
+
+    public boolean hasRoutes() {
+        return !routes.isEmpty();
+    }
+
+    public boolean hasMethods() {
+        return !methods.isEmpty();
+    }
+
+    public boolean hasConfigurationProperties() {
+        return !configurationProperties.isEmpty();
+    }
+
+    public boolean hasClasses() {
+        return !classes.isEmpty();
+    }
+
+    public boolean hasComponents() {
+        return !components.isEmpty();
+    }
+
+    public boolean hasMessages() {
+        return !messages.isEmpty();
+    }
+
+    @ReflectiveAccess
+    public record SummaryItem(String label, String value, String source, String state) {
+    }
+
+    @ReflectiveAccess
+    public record ComponentRow(String kind, String beanType, String qualifier, String scope, String origin, String source) {
+    }
+
+    @ReflectiveAccess
+    public record ValidatedElementRow(String kind,
+                                      String name,
+                                      String source,
+                                      String packageName,
+                                      List<ConstraintRow> constraints,
+                                      boolean cascaded,
+                                      boolean validatedElement) {
+        public int constraintCount() {
+            return constraints.size();
+        }
+    }
+
+    @ReflectiveAccess
+    public record ConstraintRow(String name,
+                                String target,
+                                List<String> groups,
+                                boolean cascaded,
+                                List<AttributeRow> attributes,
+                                String source) {
+        public boolean hasGroups() {
+            return !groups.isEmpty();
+        }
+
+        public boolean hasAttributes() {
+            return !attributes.isEmpty();
+        }
+    }
+
+    @ReflectiveAccess
+    public record AttributeRow(String name, String value, boolean redacted) {
+    }
+
+    @ReflectiveAccess
+    public record StateMessage(String state, String title, String message) {
+    }
+}

--- a/control-panel-validation/src/main/java/io/micronaut/controlpanel/panels/validation/ValidationDiagnostics.java
+++ b/control-panel-validation/src/main/java/io/micronaut/controlpanel/panels/validation/ValidationDiagnostics.java
@@ -22,6 +22,18 @@ import java.util.List;
 /**
  * View model for validation diagnostics.
  *
+ * @param validationEnabled whether runtime validation is enabled
+ * @param status short validation status label
+ * @param statusDescription validation status description
+ * @param summary detected capability summary rows
+ * @param components validator component rows
+ * @param routes validated route rows
+ * @param methods validated method rows
+ * @param configurationProperties validated configuration property rows
+ * @param classes validated class rows
+ * @param messages state messages
+ * @param totalConstraints total number of collected constraint rows
+ *
  * @since 2.0.0
  */
 @ReflectiveAccess
@@ -63,14 +75,43 @@ public record ValidationDiagnostics(
         return !messages.isEmpty();
     }
 
+    /**
+     * Summary row.
+     *
+     * @param label capability label
+     * @param value capability value
+     * @param source metadata source
+     * @param state capability state
+     */
     @ReflectiveAccess
     public record SummaryItem(String label, String value, String source, String state) {
     }
 
+    /**
+     * Validator component row.
+     *
+     * @param kind validator kind
+     * @param beanType validator bean type
+     * @param qualifier bean qualifier
+     * @param scope bean scope
+     * @param origin bean origin
+     * @param source metadata source
+     */
     @ReflectiveAccess
     public record ComponentRow(String kind, String beanType, String qualifier, String scope, String origin, String source) {
     }
 
+    /**
+     * Validated element row.
+     *
+     * @param kind element kind
+     * @param name element name
+     * @param source metadata source
+     * @param packageName element package name
+     * @param constraints constraint rows
+     * @param cascaded whether the element is cascaded
+     * @param validatedElement whether Micronaut marks the element as validated
+     */
     @ReflectiveAccess
     public record ValidatedElementRow(String kind,
                                       String name,
@@ -84,6 +125,16 @@ public record ValidationDiagnostics(
         }
     }
 
+    /**
+     * Constraint row.
+     *
+     * @param name constraint name
+     * @param target constrained target
+     * @param groups validation groups
+     * @param cascaded whether the target is cascaded
+     * @param attributes safe constraint attributes
+     * @param source metadata source
+     */
     @ReflectiveAccess
     public record ConstraintRow(String name,
                                 String target,
@@ -100,10 +151,24 @@ public record ValidationDiagnostics(
         }
     }
 
+    /**
+     * Constraint annotation attribute row.
+     *
+     * @param name attribute name
+     * @param value display value
+     * @param redacted whether the value was redacted
+     */
     @ReflectiveAccess
     public record AttributeRow(String name, String value, boolean redacted) {
     }
 
+    /**
+     * State message row.
+     *
+     * @param state state label
+     * @param title message title
+     * @param message message body
+     */
     @ReflectiveAccess
     public record StateMessage(String state, String title, String message) {
     }

--- a/control-panel-validation/src/main/java/io/micronaut/controlpanel/panels/validation/ValidationDiagnosticsCollector.java
+++ b/control-panel-validation/src/main/java/io/micronaut/controlpanel/panels/validation/ValidationDiagnosticsCollector.java
@@ -33,7 +33,6 @@ import io.micronaut.validation.validator.constraints.ConstraintValidator;
 import io.micronaut.web.router.Router;
 import jakarta.inject.Singleton;
 import jakarta.validation.Valid;
-import jakarta.validation.Constraint;
 import jakarta.validation.Validator;
 import jakarta.validation.ValidatorFactory;
 
@@ -86,7 +85,7 @@ final class ValidationDiagnosticsCollector {
         List<ValidationDiagnostics.ValidatedElementRow> routes = collectRoutes(messages);
         List<ValidationDiagnostics.ValidatedElementRow> methods = collectMethods(messages);
         List<ValidationDiagnostics.ValidatedElementRow> configurationProperties = collectConfigurationProperties(messages);
-        List<ValidationDiagnostics.ValidatedElementRow> classes = collectClasses(routes, configurationProperties, messages);
+        List<ValidationDiagnostics.ValidatedElementRow> classes = collectClasses(configurationProperties, messages);
         int totalConstraints = countConstraints(routes) + countConstraints(methods) + countConstraints(configurationProperties) + countConstraints(classes);
         if (!validationEnabled) {
             messages.add(new ValidationDiagnostics.StateMessage("disabled", "Validation is disabled", "`micronaut.validator.enabled=false` disables runtime validation. Metadata remains visible for diagnostics."));
@@ -256,8 +255,7 @@ final class ValidationDiagnosticsCollector {
         }
     }
 
-    private List<ValidationDiagnostics.ValidatedElementRow> collectClasses(List<ValidationDiagnostics.ValidatedElementRow> routes,
-                                                                           List<ValidationDiagnostics.ValidatedElementRow> configurationProperties,
+    private List<ValidationDiagnostics.ValidatedElementRow> collectClasses(List<ValidationDiagnostics.ValidatedElementRow> configurationProperties,
                                                                            List<ValidationDiagnostics.StateMessage> messages) {
         try {
             Set<Class<?>> types = new LinkedHashSet<>();
@@ -279,7 +277,7 @@ final class ValidationDiagnosticsCollector {
                 .map(type -> inspectClass(type, "Class", "BeanIntrospection"))
                 .filter(Optional::isPresent)
                 .map(Optional::get)
-                .filter(row -> routes.stream().noneMatch(r -> r.name().contains(row.name())) || configurationProperties.stream().noneMatch(r -> r.name().equals(row.name())))
+                .filter(row -> configurationProperties.stream().noneMatch(configuration -> configuration.name().equals(row.name())))
                 .sorted(Comparator.comparing(ValidationDiagnostics.ValidatedElementRow::name))
                 .toList();
         } catch (RuntimeException e) {
@@ -319,7 +317,6 @@ final class ValidationDiagnosticsCollector {
 
     private List<ValidationDiagnostics.ConstraintRow> extractConstraints(AnnotationMetadata metadata, String target, String source) {
         List<ValidationDiagnostics.ConstraintRow> rows = new ArrayList<>();
-        Set<String> added = new LinkedHashSet<>();
         for (AnnotationValue<Annotation> value : metadata.getAnnotationValuesByStereotype(CONSTRAINT_STEREOTYPE)) {
             rows.add(new ValidationDiagnostics.ConstraintRow(
                 simpleName(value.getAnnotationName()),
@@ -329,38 +326,16 @@ final class ValidationDiagnosticsCollector {
                 attributeSanitizer.sanitize(value.getValues(), configuration.getShowConstraintAttributes()),
                 source
             ));
-            added.add(value.getAnnotationName());
-        }
-        for (String annotationName : metadata.getAnnotationNames()) {
-            if (added.contains(annotationName) || !isConstraintAnnotation(annotationName)) {
-                continue;
-            }
-            rows.add(new ValidationDiagnostics.ConstraintRow(
-                simpleName(annotationName),
-                target,
-                classNames(metadata.classValues(annotationName, "groups")),
-                hasCascade(metadata),
-                attributeSanitizer.sanitize(metadata.getValues(annotationName), configuration.getShowConstraintAttributes()),
-                source
-            ));
         }
         return rows;
-    }
-
-    private static boolean isConstraintAnnotation(String annotationName) {
-        try {
-            Class<?> type = Class.forName(annotationName);
-            return type.isAnnotationPresent(Constraint.class);
-        } catch (ClassNotFoundException e) {
-            return false;
-        }
     }
 
     private List<ValidationDiagnostics.ConstraintRow> extractTypeArgumentConstraints(Argument<?> argument, String target, String source) {
         List<ValidationDiagnostics.ConstraintRow> rows = new ArrayList<>();
         for (Argument<?> typeArgument : argument.getTypeParameters()) {
-            rows.addAll(extractConstraints(typeArgument.getAnnotationMetadata(), target + " type argument " + typeArgument.getName(), source));
-            rows.addAll(extractTypeArgumentConstraints(typeArgument, target, source));
+            String typeArgumentTarget = target + " type argument " + typeArgument.getName();
+            rows.addAll(extractConstraints(typeArgument.getAnnotationMetadata(), typeArgumentTarget, source));
+            rows.addAll(extractTypeArgumentConstraints(typeArgument, typeArgumentTarget, source));
         }
         return rows;
     }

--- a/control-panel-validation/src/main/java/io/micronaut/controlpanel/panels/validation/ValidationDiagnosticsCollector.java
+++ b/control-panel-validation/src/main/java/io/micronaut/controlpanel/panels/validation/ValidationDiagnosticsCollector.java
@@ -55,6 +55,9 @@ final class ValidationDiagnosticsCollector {
 
     private static final String CONSTRAINT_STEREOTYPE = "jakarta.validation.Constraint";
     private static final String VALIDATED_ELEMENT = "io.micronaut.validation.annotation.ValidatedElement";
+    private static final String STATE_AVAILABLE = "available";
+    private static final String STATE_CONFIGURED = "configured";
+    private static final String STATE_ERROR = "error";
 
     private final BeanContext beanContext;
     private final Environment environment;
@@ -113,14 +116,14 @@ final class ValidationDiagnosticsCollector {
 
     private List<ValidationDiagnostics.SummaryItem> collectSummary(boolean validationEnabled, List<ValidationDiagnostics.StateMessage> messages) {
         List<ValidationDiagnostics.SummaryItem> rows = new ArrayList<>();
-        rows.add(new ValidationDiagnostics.SummaryItem("Runtime validation", validationEnabled ? "Enabled" : "Disabled", "Environment", validationEnabled ? "configured" : "disabled"));
-        rows.add(new ValidationDiagnostics.SummaryItem("Attribute mode", configuration.getShowConstraintAttributes().name().toLowerCase(), ValidationConfiguration.PREFIX + ".show-constraint-attributes", "configured"));
-        rows.add(new ValidationDiagnostics.SummaryItem("Include packages", configuration.getIncludePackages().isEmpty() ? "Application packages" : String.join(", ", configuration.getIncludePackages()), ValidationConfiguration.PREFIX + ".include-packages", "configured"));
-        rows.add(new ValidationDiagnostics.SummaryItem("Exclude packages", configuration.getExcludePackages().isEmpty() ? "Framework defaults" : String.join(", ", configuration.getExcludePackages()), ValidationConfiguration.PREFIX + ".exclude-packages", "configured"));
+        rows.add(new ValidationDiagnostics.SummaryItem("Runtime validation", validationEnabled ? "Enabled" : "Disabled", "Environment", validationEnabled ? STATE_CONFIGURED : "disabled"));
+        rows.add(new ValidationDiagnostics.SummaryItem("Attribute mode", configuration.getShowConstraintAttributes().name().toLowerCase(), ValidationConfiguration.PREFIX + ".show-constraint-attributes", STATE_CONFIGURED));
+        rows.add(new ValidationDiagnostics.SummaryItem("Include packages", configuration.getIncludePackages().isEmpty() ? "Application packages" : String.join(", ", configuration.getIncludePackages()), ValidationConfiguration.PREFIX + ".include-packages", STATE_CONFIGURED));
+        rows.add(new ValidationDiagnostics.SummaryItem("Exclude packages", configuration.getExcludePackages().isEmpty() ? "Framework defaults" : String.join(", ", configuration.getExcludePackages()), ValidationConfiguration.PREFIX + ".exclude-packages", STATE_CONFIGURED));
         beanContext.findBean(ValidatorConfiguration.class).ifPresentOrElse(
             cfg -> {
-                rows.add(new ValidationDiagnostics.SummaryItem("Validator configuration", cfg.getClass().getName(), "ValidatorConfiguration bean", "available"));
-                rows.add(new ValidationDiagnostics.SummaryItem("Prepend property path", String.valueOf(cfg.isPrependPropertyPath()), "ValidatorConfiguration", "available"));
+                rows.add(new ValidationDiagnostics.SummaryItem("Validator configuration", cfg.getClass().getName(), "ValidatorConfiguration bean", STATE_AVAILABLE));
+                rows.add(new ValidationDiagnostics.SummaryItem("Prepend property path", String.valueOf(cfg.isPrependPropertyPath()), "ValidatorConfiguration", STATE_AVAILABLE));
             },
             () -> messages.add(new ValidationDiagnostics.StateMessage("partial", "Validator configuration bean unavailable", "Provider configuration could not be read, but compile-time validation metadata can still be shown."))
         );
@@ -138,7 +141,7 @@ final class ValidationDiagnosticsCollector {
                                  String label) {
         Optional<T> bean = beanContext.findBean(beanType);
         if (bean.isPresent()) {
-            rows.add(new ValidationDiagnostics.SummaryItem(label, bean.get().getClass().getName(), "BeanContext", "available"));
+            rows.add(new ValidationDiagnostics.SummaryItem(label, bean.get().getClass().getName(), "BeanContext", STATE_AVAILABLE));
         } else {
             rows.add(new ValidationDiagnostics.SummaryItem(label, "Not configured", "BeanContext", "unavailable"));
             messages.add(new ValidationDiagnostics.StateMessage("partial", label + " unavailable", "The bean is not configured or is hidden by the current provider. Provider-specific metadata is unavailable."));
@@ -186,7 +189,7 @@ final class ValidationDiagnosticsCollector {
                 .sorted(Comparator.comparing(ValidationDiagnostics.ValidatedElementRow::name))
                 .toList();
         } catch (RuntimeException e) {
-            messages.add(new ValidationDiagnostics.StateMessage("error", "Route metadata unavailable", e.getMessage()));
+            messages.add(new ValidationDiagnostics.StateMessage(STATE_ERROR, "Route metadata unavailable", e.getMessage()));
             return List.of();
         }
     }
@@ -207,7 +210,7 @@ final class ValidationDiagnosticsCollector {
                 .sorted(Comparator.comparing(ValidationDiagnostics.ValidatedElementRow::name))
                 .toList();
         } catch (RuntimeException e) {
-            messages.add(new ValidationDiagnostics.StateMessage("error", "Bean method metadata unavailable", e.getMessage()));
+            messages.add(new ValidationDiagnostics.StateMessage(STATE_ERROR, "Bean method metadata unavailable", e.getMessage()));
             return List.of();
         }
     }
@@ -250,7 +253,7 @@ final class ValidationDiagnosticsCollector {
                 .sorted(Comparator.comparing(ValidationDiagnostics.ValidatedElementRow::name))
                 .toList();
         } catch (RuntimeException e) {
-            messages.add(new ValidationDiagnostics.StateMessage("error", "Configuration property metadata unavailable", e.getMessage()));
+            messages.add(new ValidationDiagnostics.StateMessage(STATE_ERROR, "Configuration property metadata unavailable", e.getMessage()));
             return List.of();
         }
     }
@@ -273,15 +276,19 @@ final class ValidationDiagnosticsCollector {
                     types.add(definition.getBeanType());
                 }
             }
+            Set<String> configurationPropertyNames = new LinkedHashSet<>();
+            for (ValidationDiagnostics.ValidatedElementRow property : configurationProperties) {
+                configurationPropertyNames.add(property.name());
+            }
             return types.stream()
                 .map(type -> inspectClass(type, "Class", "BeanIntrospection"))
                 .filter(Optional::isPresent)
                 .map(Optional::get)
-                .filter(row -> configurationProperties.stream().noneMatch(configuration -> configuration.name().equals(row.name())))
+                .filter(row -> !configurationPropertyNames.contains(row.name()))
                 .sorted(Comparator.comparing(ValidationDiagnostics.ValidatedElementRow::name))
                 .toList();
         } catch (RuntimeException e) {
-            messages.add(new ValidationDiagnostics.StateMessage("error", "Class metadata unavailable", e.getMessage()));
+            messages.add(new ValidationDiagnostics.StateMessage(STATE_ERROR, "Class metadata unavailable", e.getMessage()));
             return List.of();
         }
     }
@@ -310,7 +317,7 @@ final class ValidationDiagnosticsCollector {
                 cascaded,
                 validatedElement
             ));
-        } catch (IntrospectionException e) {
+        } catch (IntrospectionException _) {
             return Optional.empty();
         }
     }

--- a/control-panel-validation/src/main/java/io/micronaut/controlpanel/panels/validation/ValidationDiagnosticsCollector.java
+++ b/control-panel-validation/src/main/java/io/micronaut/controlpanel/panels/validation/ValidationDiagnosticsCollector.java
@@ -1,0 +1,399 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.validation;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.env.Environment;
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.ReflectiveAccess;
+import io.micronaut.core.beans.BeanIntrospection;
+import io.micronaut.core.beans.exceptions.IntrospectionException;
+import io.micronaut.core.type.Argument;
+import io.micronaut.inject.BeanDefinition;
+import io.micronaut.inject.ExecutableMethod;
+import io.micronaut.inject.MethodReference;
+import io.micronaut.validation.validator.ExecutableMethodValidator;
+import io.micronaut.validation.validator.ReactiveValidator;
+import io.micronaut.validation.validator.ValidatorConfiguration;
+import io.micronaut.validation.validator.constraints.ConstraintValidator;
+import io.micronaut.web.router.Router;
+import jakarta.inject.Singleton;
+import jakarta.validation.Valid;
+import jakarta.validation.Constraint;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Collects read-only validation diagnostics from Micronaut compile-time metadata.
+ *
+ * @since 2.0.0
+ */
+@Singleton
+@ReflectiveAccess
+final class ValidationDiagnosticsCollector {
+
+    private static final String CONSTRAINT_STEREOTYPE = "jakarta.validation.Constraint";
+    private static final String VALIDATED_ELEMENT = "io.micronaut.validation.annotation.ValidatedElement";
+
+    private final BeanContext beanContext;
+    private final Environment environment;
+    private final Router router;
+    private final ValidationConfiguration configuration;
+    private final ValidationPackageFilter packageFilter;
+    private final ValidationAttributeSanitizer attributeSanitizer;
+
+    ValidationDiagnosticsCollector(BeanContext beanContext,
+                                   Environment environment,
+                                   Router router,
+                                   ValidationConfiguration configuration,
+                                   ValidationPackageFilter packageFilter,
+                                   ValidationAttributeSanitizer attributeSanitizer) {
+        this.beanContext = beanContext;
+        this.environment = environment;
+        this.router = router;
+        this.configuration = configuration;
+        this.packageFilter = packageFilter;
+        this.attributeSanitizer = attributeSanitizer;
+    }
+
+    ValidationDiagnostics collect() {
+        List<ValidationDiagnostics.StateMessage> messages = new ArrayList<>();
+        boolean validationEnabled = environment.getProperty("micronaut.validator.enabled", Boolean.class).orElse(true);
+        List<ValidationDiagnostics.SummaryItem> summary = collectSummary(validationEnabled, messages);
+        List<ValidationDiagnostics.ComponentRow> components = collectComponents(messages);
+        List<ValidationDiagnostics.ValidatedElementRow> routes = collectRoutes(messages);
+        List<ValidationDiagnostics.ValidatedElementRow> methods = collectMethods(messages);
+        List<ValidationDiagnostics.ValidatedElementRow> configurationProperties = collectConfigurationProperties(messages);
+        List<ValidationDiagnostics.ValidatedElementRow> classes = collectClasses(routes, configurationProperties, messages);
+        int totalConstraints = countConstraints(routes) + countConstraints(methods) + countConstraints(configurationProperties) + countConstraints(classes);
+        if (!validationEnabled) {
+            messages.add(new ValidationDiagnostics.StateMessage("disabled", "Validation is disabled", "`micronaut.validator.enabled=false` disables runtime validation. Metadata remains visible for diagnostics."));
+        } else if (totalConstraints == 0 && components.isEmpty()) {
+            messages.add(new ValidationDiagnostics.StateMessage("empty", "No validation metadata found", "Validation is configured, but no application routes, methods, classes, configuration properties, or custom validators matched the active package filters."));
+        }
+        String status = validationEnabled ? "Enabled" : "Disabled";
+        String description = validationEnabled
+            ? "Micronaut Validation classes are present. The panel is showing compile-time metadata and provider beans when available."
+            : "Micronaut Validation classes are present, but runtime validation is disabled by configuration.";
+        return new ValidationDiagnostics(
+            validationEnabled,
+            status,
+            description,
+            List.copyOf(summary),
+            List.copyOf(components),
+            List.copyOf(routes),
+            List.copyOf(methods),
+            List.copyOf(configurationProperties),
+            List.copyOf(classes),
+            List.copyOf(messages),
+            totalConstraints
+        );
+    }
+
+    private List<ValidationDiagnostics.SummaryItem> collectSummary(boolean validationEnabled, List<ValidationDiagnostics.StateMessage> messages) {
+        List<ValidationDiagnostics.SummaryItem> rows = new ArrayList<>();
+        rows.add(new ValidationDiagnostics.SummaryItem("Runtime validation", validationEnabled ? "Enabled" : "Disabled", "Environment", validationEnabled ? "configured" : "disabled"));
+        rows.add(new ValidationDiagnostics.SummaryItem("Attribute mode", configuration.getShowConstraintAttributes().name().toLowerCase(), ValidationConfiguration.PREFIX + ".show-constraint-attributes", "configured"));
+        rows.add(new ValidationDiagnostics.SummaryItem("Include packages", configuration.getIncludePackages().isEmpty() ? "Application packages" : String.join(", ", configuration.getIncludePackages()), ValidationConfiguration.PREFIX + ".include-packages", "configured"));
+        rows.add(new ValidationDiagnostics.SummaryItem("Exclude packages", configuration.getExcludePackages().isEmpty() ? "Framework defaults" : String.join(", ", configuration.getExcludePackages()), ValidationConfiguration.PREFIX + ".exclude-packages", "configured"));
+        beanContext.findBean(ValidatorConfiguration.class).ifPresentOrElse(
+            cfg -> {
+                rows.add(new ValidationDiagnostics.SummaryItem("Validator configuration", cfg.getClass().getName(), "ValidatorConfiguration bean", "available"));
+                rows.add(new ValidationDiagnostics.SummaryItem("Prepend property path", String.valueOf(cfg.isPrependPropertyPath()), "ValidatorConfiguration", "available"));
+            },
+            () -> messages.add(new ValidationDiagnostics.StateMessage("partial", "Validator configuration bean unavailable", "Provider configuration could not be read, but compile-time validation metadata can still be shown."))
+        );
+        addProvider(rows, messages, Validator.class, "Jakarta Validator");
+        addProvider(rows, messages, ValidatorFactory.class, "Jakarta ValidatorFactory");
+        addProvider(rows, messages, io.micronaut.validation.validator.Validator.class, "Micronaut Validator");
+        addProvider(rows, messages, ExecutableMethodValidator.class, "ExecutableMethodValidator");
+        addProvider(rows, messages, ReactiveValidator.class, "ReactiveValidator");
+        return rows;
+    }
+
+    private <T> void addProvider(List<ValidationDiagnostics.SummaryItem> rows,
+                                 List<ValidationDiagnostics.StateMessage> messages,
+                                 Class<T> beanType,
+                                 String label) {
+        Optional<T> bean = beanContext.findBean(beanType);
+        if (bean.isPresent()) {
+            rows.add(new ValidationDiagnostics.SummaryItem(label, bean.get().getClass().getName(), "BeanContext", "available"));
+        } else {
+            rows.add(new ValidationDiagnostics.SummaryItem(label, "Not configured", "BeanContext", "unavailable"));
+            messages.add(new ValidationDiagnostics.StateMessage("partial", label + " unavailable", "The bean is not configured or is hidden by the current provider. Provider-specific metadata is unavailable."));
+        }
+    }
+
+    private List<ValidationDiagnostics.ComponentRow> collectComponents(List<ValidationDiagnostics.StateMessage> messages) {
+        List<ValidationDiagnostics.ComponentRow> rows = new ArrayList<>();
+        addValidatorComponents(rows, ConstraintValidator.class, "Micronaut ConstraintValidator");
+        addValidatorComponents(rows, jakarta.validation.ConstraintValidator.class, "Jakarta ConstraintValidator");
+        if (rows.isEmpty()) {
+            messages.add(new ValidationDiagnostics.StateMessage("empty", "No custom validators detected", "No ConstraintValidator beans matched application package filters."));
+        }
+        return rows.stream()
+            .sorted(Comparator.comparing(ValidationDiagnostics.ComponentRow::beanType).thenComparing(ValidationDiagnostics.ComponentRow::kind))
+            .toList();
+    }
+
+    private void addValidatorComponents(List<ValidationDiagnostics.ComponentRow> rows, Class<?> validatorType, String kind) {
+        for (BeanDefinition<?> definition : beanContext.getBeanDefinitions(validatorType)) {
+            if (packageFilter.includes(definition.getBeanType(), configuration)) {
+                rows.add(new ValidationDiagnostics.ComponentRow(
+                    kind,
+                    definition.getBeanType().getName(),
+                    Optional.ofNullable(definition.getDeclaredQualifier()).map(Object::toString).orElse("default"),
+                    definition.getScopeName().orElse("unknown"),
+                    origin(definition.getBeanType()),
+                    "ConstraintValidator bean"
+                ));
+            }
+        }
+    }
+
+    private List<ValidationDiagnostics.ValidatedElementRow> collectRoutes(List<ValidationDiagnostics.StateMessage> messages) {
+        try {
+            return router.uriRoutes()
+                .filter(route -> packageFilter.includes(route.getTargetMethod().getDeclaringType(), configuration))
+                .map(route -> {
+                    MethodReference<?, ?> method = route.getTargetMethod();
+                    String name = route.getHttpMethodName() + " " + route.getUriMatchTemplate().toPathString() + " -> " + method.getDeclaringType().getName() + "." + method.getMethodName();
+                    return buildMethodRow("Route", name, method, "Router");
+                })
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .sorted(Comparator.comparing(ValidationDiagnostics.ValidatedElementRow::name))
+                .toList();
+        } catch (RuntimeException e) {
+            messages.add(new ValidationDiagnostics.StateMessage("error", "Route metadata unavailable", e.getMessage()));
+            return List.of();
+        }
+    }
+
+    private List<ValidationDiagnostics.ValidatedElementRow> collectMethods(List<ValidationDiagnostics.StateMessage> messages) {
+        try {
+            List<ValidationDiagnostics.ValidatedElementRow> rows = new ArrayList<>();
+            for (BeanDefinition<?> definition : beanContext.getAllBeanDefinitions()) {
+                if (!packageFilter.includes(definition.getBeanType(), configuration)) {
+                    continue;
+                }
+                for (ExecutableMethod<?, ?> method : definition.getExecutableMethods()) {
+                    buildMethodRow("Method", method.getDeclaringType().getName() + "." + method.getMethodName(), method, "ExecutableMethod")
+                        .ifPresent(rows::add);
+                }
+            }
+            return rows.stream()
+                .sorted(Comparator.comparing(ValidationDiagnostics.ValidatedElementRow::name))
+                .toList();
+        } catch (RuntimeException e) {
+            messages.add(new ValidationDiagnostics.StateMessage("error", "Bean method metadata unavailable", e.getMessage()));
+            return List.of();
+        }
+    }
+
+    private Optional<ValidationDiagnostics.ValidatedElementRow> buildMethodRow(String kind, String name, MethodReference<?, ?> method, String source) {
+        List<ValidationDiagnostics.ConstraintRow> constraints = new ArrayList<>();
+        constraints.addAll(extractConstraints(method.getAnnotationMetadata(), "method", source));
+        for (Argument<?> argument : method.getArguments()) {
+            constraints.addAll(extractConstraints(argument.getAnnotationMetadata(), "parameter " + argument.getName(), source));
+            constraints.addAll(extractTypeArgumentConstraints(argument, "parameter " + argument.getName(), source));
+        }
+        constraints.addAll(extractConstraints(method.getReturnType().getAnnotationMetadata(), "return value", source));
+        boolean cascaded = hasCascade(method.getAnnotationMetadata())
+            || hasCascade(method.getReturnType().getAnnotationMetadata())
+            || List.of(method.getArguments()).stream().anyMatch(arg -> hasCascade(arg.getAnnotationMetadata()));
+        boolean validatedElement = method.getAnnotationMetadata().hasStereotype(VALIDATED_ELEMENT);
+        if (constraints.isEmpty() && !cascaded && !validatedElement) {
+            return Optional.empty();
+        }
+        return Optional.of(new ValidationDiagnostics.ValidatedElementRow(
+            kind,
+            name,
+            source,
+            packageFilter.packageName(method.getDeclaringType()),
+            List.copyOf(constraints),
+            cascaded,
+            validatedElement
+        ));
+    }
+
+    private List<ValidationDiagnostics.ValidatedElementRow> collectConfigurationProperties(List<ValidationDiagnostics.StateMessage> messages) {
+        try {
+            List<ValidationDiagnostics.ValidatedElementRow> rows = new ArrayList<>();
+            for (BeanDefinition<?> definition : beanContext.getAllBeanDefinitions()) {
+                if (definition.isConfigurationProperties() && packageFilter.includes(definition.getBeanType(), configuration)) {
+                    inspectClass(definition.getBeanType(), "Configuration properties", "BeanDefinition/BeanIntrospection").ifPresent(rows::add);
+                }
+            }
+            return rows.stream()
+                .sorted(Comparator.comparing(ValidationDiagnostics.ValidatedElementRow::name))
+                .toList();
+        } catch (RuntimeException e) {
+            messages.add(new ValidationDiagnostics.StateMessage("error", "Configuration property metadata unavailable", e.getMessage()));
+            return List.of();
+        }
+    }
+
+    private List<ValidationDiagnostics.ValidatedElementRow> collectClasses(List<ValidationDiagnostics.ValidatedElementRow> routes,
+                                                                           List<ValidationDiagnostics.ValidatedElementRow> configurationProperties,
+                                                                           List<ValidationDiagnostics.StateMessage> messages) {
+        try {
+            Set<Class<?>> types = new LinkedHashSet<>();
+            router.uriRoutes()
+                .filter(route -> packageFilter.includes(route.getTargetMethod().getDeclaringType(), configuration))
+                .forEach(route -> {
+                    for (Argument<?> argument : route.getTargetMethod().getArguments()) {
+                        if (packageFilter.includes(argument.getType(), configuration)) {
+                            types.add(argument.getType());
+                        }
+                    }
+                });
+            for (BeanDefinition<?> definition : beanContext.getAllBeanDefinitions()) {
+                if (definition.isConfigurationProperties() && packageFilter.includes(definition.getBeanType(), configuration)) {
+                    types.add(definition.getBeanType());
+                }
+            }
+            return types.stream()
+                .map(type -> inspectClass(type, "Class", "BeanIntrospection"))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .filter(row -> routes.stream().noneMatch(r -> r.name().contains(row.name())) || configurationProperties.stream().noneMatch(r -> r.name().equals(row.name())))
+                .sorted(Comparator.comparing(ValidationDiagnostics.ValidatedElementRow::name))
+                .toList();
+        } catch (RuntimeException e) {
+            messages.add(new ValidationDiagnostics.StateMessage("error", "Class metadata unavailable", e.getMessage()));
+            return List.of();
+        }
+    }
+
+    private Optional<ValidationDiagnostics.ValidatedElementRow> inspectClass(Class<?> type, String kind, String source) {
+        try {
+            BeanIntrospection<?> introspection = BeanIntrospection.getIntrospection(type);
+            List<ValidationDiagnostics.ConstraintRow> constraints = new ArrayList<>();
+            constraints.addAll(extractConstraints(introspection.getAnnotationMetadata(), "class", source));
+            introspection.getBeanProperties().forEach(property -> {
+                constraints.addAll(extractConstraints(property.getAnnotationMetadata(), "property " + property.getName(), source));
+                constraints.addAll(extractTypeArgumentConstraints(property.asArgument(), "property " + property.getName(), source));
+            });
+            boolean cascaded = introspection.getBeanProperties().stream().anyMatch(p -> hasCascade(p.getAnnotationMetadata()))
+                || hasCascade(introspection.getAnnotationMetadata());
+            boolean validatedElement = introspection.getAnnotationMetadata().hasStereotype(VALIDATED_ELEMENT);
+            if (constraints.isEmpty() && !cascaded && !validatedElement) {
+                return Optional.empty();
+            }
+            return Optional.of(new ValidationDiagnostics.ValidatedElementRow(
+                kind,
+                type.getName(),
+                source,
+                packageFilter.packageName(type),
+                List.copyOf(constraints),
+                cascaded,
+                validatedElement
+            ));
+        } catch (IntrospectionException e) {
+            return Optional.empty();
+        }
+    }
+
+    private List<ValidationDiagnostics.ConstraintRow> extractConstraints(AnnotationMetadata metadata, String target, String source) {
+        List<ValidationDiagnostics.ConstraintRow> rows = new ArrayList<>();
+        Set<String> added = new LinkedHashSet<>();
+        for (AnnotationValue<Annotation> value : metadata.getAnnotationValuesByStereotype(CONSTRAINT_STEREOTYPE)) {
+            rows.add(new ValidationDiagnostics.ConstraintRow(
+                simpleName(value.getAnnotationName()),
+                target,
+                classNames(value.classValues("groups")),
+                hasCascade(metadata),
+                attributeSanitizer.sanitize(value.getValues(), configuration.getShowConstraintAttributes()),
+                source
+            ));
+            added.add(value.getAnnotationName());
+        }
+        for (String annotationName : metadata.getAnnotationNames()) {
+            if (added.contains(annotationName) || !isConstraintAnnotation(annotationName)) {
+                continue;
+            }
+            rows.add(new ValidationDiagnostics.ConstraintRow(
+                simpleName(annotationName),
+                target,
+                classNames(metadata.classValues(annotationName, "groups")),
+                hasCascade(metadata),
+                attributeSanitizer.sanitize(metadata.getValues(annotationName), configuration.getShowConstraintAttributes()),
+                source
+            ));
+        }
+        return rows;
+    }
+
+    private static boolean isConstraintAnnotation(String annotationName) {
+        try {
+            Class<?> type = Class.forName(annotationName);
+            return type.isAnnotationPresent(Constraint.class);
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
+    private List<ValidationDiagnostics.ConstraintRow> extractTypeArgumentConstraints(Argument<?> argument, String target, String source) {
+        List<ValidationDiagnostics.ConstraintRow> rows = new ArrayList<>();
+        for (Argument<?> typeArgument : argument.getTypeParameters()) {
+            rows.addAll(extractConstraints(typeArgument.getAnnotationMetadata(), target + " type argument " + typeArgument.getName(), source));
+            rows.addAll(extractTypeArgumentConstraints(typeArgument, target, source));
+        }
+        return rows;
+    }
+
+    private static boolean hasCascade(AnnotationMetadata metadata) {
+        return metadata.hasAnnotation(Valid.class) || metadata.hasStereotype(Valid.class);
+    }
+
+    private static List<String> classNames(Class<?>[] classes) {
+        List<String> names = new ArrayList<>(classes.length);
+        for (Class<?> type : classes) {
+            names.add(type.getName());
+        }
+        return List.copyOf(names);
+    }
+
+    private static String simpleName(String annotationName) {
+        int dot = annotationName.lastIndexOf('.');
+        return dot > -1 ? annotationName.substring(dot + 1) : annotationName;
+    }
+
+    private static String origin(Class<?> type) {
+        String name = type.getName();
+        if (name.startsWith("io.micronaut.")) {
+            return "micronaut";
+        }
+        if (name.startsWith("java.") || name.startsWith("jakarta.")) {
+            return "platform";
+        }
+        return "application";
+    }
+
+    private static int countConstraints(List<ValidationDiagnostics.ValidatedElementRow> rows) {
+        return rows.stream().mapToInt(ValidationDiagnostics.ValidatedElementRow::constraintCount).sum();
+    }
+}

--- a/control-panel-validation/src/main/java/io/micronaut/controlpanel/panels/validation/ValidationDiagnosticsCollector.java
+++ b/control-panel-validation/src/main/java/io/micronaut/controlpanel/panels/validation/ValidationDiagnosticsCollector.java
@@ -41,6 +41,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 
@@ -117,7 +118,7 @@ final class ValidationDiagnosticsCollector {
     private List<ValidationDiagnostics.SummaryItem> collectSummary(boolean validationEnabled, List<ValidationDiagnostics.StateMessage> messages) {
         List<ValidationDiagnostics.SummaryItem> rows = new ArrayList<>();
         rows.add(new ValidationDiagnostics.SummaryItem("Runtime validation", validationEnabled ? "Enabled" : "Disabled", "Environment", validationEnabled ? STATE_CONFIGURED : "disabled"));
-        rows.add(new ValidationDiagnostics.SummaryItem("Attribute mode", configuration.getShowConstraintAttributes().name().toLowerCase(), ValidationConfiguration.PREFIX + ".show-constraint-attributes", STATE_CONFIGURED));
+        rows.add(new ValidationDiagnostics.SummaryItem("Attribute mode", configuration.getShowConstraintAttributes().name().toLowerCase(Locale.ROOT), ValidationConfiguration.PREFIX + ".show-constraint-attributes", STATE_CONFIGURED));
         rows.add(new ValidationDiagnostics.SummaryItem("Include packages", configuration.getIncludePackages().isEmpty() ? "Application packages" : String.join(", ", configuration.getIncludePackages()), ValidationConfiguration.PREFIX + ".include-packages", STATE_CONFIGURED));
         rows.add(new ValidationDiagnostics.SummaryItem("Exclude packages", configuration.getExcludePackages().isEmpty() ? "Framework defaults" : String.join(", ", configuration.getExcludePackages()), ValidationConfiguration.PREFIX + ".exclude-packages", STATE_CONFIGURED));
         beanContext.findBean(ValidatorConfiguration.class).ifPresentOrElse(
@@ -189,7 +190,7 @@ final class ValidationDiagnosticsCollector {
                 .sorted(Comparator.comparing(ValidationDiagnostics.ValidatedElementRow::name))
                 .toList();
         } catch (RuntimeException e) {
-            messages.add(new ValidationDiagnostics.StateMessage(STATE_ERROR, "Route metadata unavailable", e.getMessage()));
+            messages.add(new ValidationDiagnostics.StateMessage(STATE_ERROR, "Route metadata unavailable", message(e)));
             return List.of();
         }
     }
@@ -210,7 +211,7 @@ final class ValidationDiagnosticsCollector {
                 .sorted(Comparator.comparing(ValidationDiagnostics.ValidatedElementRow::name))
                 .toList();
         } catch (RuntimeException e) {
-            messages.add(new ValidationDiagnostics.StateMessage(STATE_ERROR, "Bean method metadata unavailable", e.getMessage()));
+            messages.add(new ValidationDiagnostics.StateMessage(STATE_ERROR, "Bean method metadata unavailable", message(e)));
             return List.of();
         }
     }
@@ -253,7 +254,7 @@ final class ValidationDiagnosticsCollector {
                 .sorted(Comparator.comparing(ValidationDiagnostics.ValidatedElementRow::name))
                 .toList();
         } catch (RuntimeException e) {
-            messages.add(new ValidationDiagnostics.StateMessage(STATE_ERROR, "Configuration property metadata unavailable", e.getMessage()));
+            messages.add(new ValidationDiagnostics.StateMessage(STATE_ERROR, "Configuration property metadata unavailable", message(e)));
             return List.of();
         }
     }
@@ -288,7 +289,7 @@ final class ValidationDiagnosticsCollector {
                 .sorted(Comparator.comparing(ValidationDiagnostics.ValidatedElementRow::name))
                 .toList();
         } catch (RuntimeException e) {
-            messages.add(new ValidationDiagnostics.StateMessage(STATE_ERROR, "Class metadata unavailable", e.getMessage()));
+            messages.add(new ValidationDiagnostics.StateMessage(STATE_ERROR, "Class metadata unavailable", message(e)));
             return List.of();
         }
     }
@@ -377,5 +378,10 @@ final class ValidationDiagnosticsCollector {
 
     private static int countConstraints(List<ValidationDiagnostics.ValidatedElementRow> rows) {
         return rows.stream().mapToInt(ValidationDiagnostics.ValidatedElementRow::constraintCount).sum();
+    }
+
+    private static String message(RuntimeException e) {
+        String message = e.getMessage();
+        return message == null ? e.getClass().getSimpleName() : message;
     }
 }

--- a/control-panel-validation/src/main/java/io/micronaut/controlpanel/panels/validation/ValidationPackageFilter.java
+++ b/control-panel-validation/src/main/java/io/micronaut/controlpanel/panels/validation/ValidationPackageFilter.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.validation;
+
+import jakarta.inject.Singleton;
+
+import java.util.List;
+
+/**
+ * Applies package visibility rules for validation diagnostics.
+ *
+ * @since 2.0.0
+ */
+@Singleton
+final class ValidationPackageFilter {
+
+    private static final List<String> DEFAULT_EXCLUDES = List.of(
+        "java.",
+        "javax.",
+        "jakarta.",
+        "io.micronaut.",
+        "reactor.",
+        "org.reactivestreams."
+    );
+
+    boolean includes(Class<?> type, ValidationConfiguration configuration) {
+        if (type == null) {
+            return false;
+        }
+        Package pkg = type.getPackage();
+        String packageName = pkg == null ? "" : pkg.getName();
+        List<String> includePackages = configuration.getIncludePackages();
+        if (!includePackages.isEmpty()) {
+            return startsWithAny(packageName, includePackages) && !startsWithAny(packageName, configuration.getExcludePackages());
+        }
+        return !startsWithAny(packageName, DEFAULT_EXCLUDES) && !startsWithAny(packageName, configuration.getExcludePackages());
+    }
+
+    String packageName(Class<?> type) {
+        if (type == null || type.getPackage() == null) {
+            return "";
+        }
+        return type.getPackage().getName();
+    }
+
+    private static boolean startsWithAny(String packageName, List<String> prefixes) {
+        for (String prefix : prefixes) {
+            if (prefix != null && !prefix.isBlank() && packageName.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/control-panel-validation/src/main/java/io/micronaut/controlpanel/panels/validation/package-info.java
+++ b/control-panel-validation/src/main/java/io/micronaut/controlpanel/panels/validation/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Validation Control Panel classes.
+ */
+@Configuration
+@Requires(classes = ValidatorConfiguration.class)
+@Requires(property = ValidationControlPanel.ENABLED_PROPERTY, notEquals = StringUtils.FALSE)
+@Requires(condition = ControlPanelEnabledCondition.class)
+package io.micronaut.controlpanel.panels.validation;
+
+import io.micronaut.context.annotation.Configuration;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.controlpanel.core.config.ControlPanelEnabledCondition;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.validation.validator.ValidatorConfiguration;

--- a/control-panel-validation/src/main/resources/micronaut-control-panel/micronaut-control-panel.properties
+++ b/control-panel-validation/src/main/resources/micronaut-control-panel/micronaut-control-panel.properties
@@ -1,0 +1,3 @@
+micronaut.control-panel.panels.validation.title = Validation
+micronaut.control-panel.panels.validation.icon = fa-shield-halved
+micronaut.control-panel.panels.validation.order = 35

--- a/control-panel-validation/src/main/resources/views/validation/body.hbs
+++ b/control-panel-validation/src/main/resources/views/validation/body.hbs
@@ -1,0 +1,27 @@
+{{#with controlPanel.body }}
+    <p class="card-text">
+        <strong>{{status}}</strong>: {{statusDescription}}
+    </p>
+    <div class="cp-data-table-container cp-vertical-table">
+        <table class="table cp-data-table-table">
+            <tbody>
+            <tr>
+                <th scope="row">Constraints</th>
+                <td><span class="badge badge-primary">{{totalConstraints}}</span></td>
+            </tr>
+            <tr>
+                <th scope="row">Routes</th>
+                <td>{{routes.size}} validated route entries</td>
+            </tr>
+            <tr>
+                <th scope="row">Methods</th>
+                <td>{{methods.size}} validated bean method entries</td>
+            </tr>
+            <tr>
+                <th scope="row">Configuration</th>
+                <td>{{configurationProperties.size}} validated configuration beans</td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+{{/with}}

--- a/control-panel-validation/src/main/resources/views/validation/detail.hbs
+++ b/control-panel-validation/src/main/resources/views/validation/detail.hbs
@@ -68,7 +68,7 @@
                             </thead>
                             <tbody>
                             {{#each summary as |item|}}
-                                <tr>
+                                <tr data-filter-table-row>
                                     <td>{{item.label}}</td>
                                     <td><code class="cp-table-code">{{item.value}}</code></td>
                                     <td>{{item.source}}</td>
@@ -144,7 +144,7 @@
                                     </thead>
                                     <tbody>
                                     {{#each components as |component|}}
-                                        <tr>
+                                        <tr data-filter-table-row>
                                             <td>{{component.kind}}</td>
                                             <td><code class="cp-table-code">{{component.beanType}}</code></td>
                                             <td><code class="cp-table-code">{{component.qualifier}}</code></td>

--- a/control-panel-validation/src/main/resources/views/validation/detail.hbs
+++ b/control-panel-validation/src/main/resources/views/validation/detail.hbs
@@ -1,0 +1,167 @@
+{{#with controlPanel.body }}
+    <div class="cp-dashboard-stack">
+        <div class="card card-light">
+            <div class="card-header">
+                <div class="cp-card-heading">
+                    <span class="cp-card-icon"><i class="fas fa-shield-halved" aria-hidden="true"></i></span>
+                    <h3 class="card-title">Validation status</h3>
+                </div>
+                <div class="card-tools">
+                    {{#if validationEnabled}}
+                        <span class="badge badge-primary">Enabled</span>
+                    {{else}}
+                        <span class="badge badge-secondary">Disabled</span>
+                    {{/if}}
+                </div>
+            </div>
+            <div class="card-body">
+                <p>{{statusDescription}}</p>
+                {{#if hasMessages}}
+                    <div class="cp-data-table-container">
+                        <table class="table cp-data-table-table">
+                            <thead>
+                            <tr>
+                                <th>State</th>
+                                <th>Message</th>
+                                <th>Details</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            {{#each messages as |message|}}
+                                <tr>
+                                    <td><span class="badge badge-secondary">{{message.state}}</span></td>
+                                    <td>{{message.title}}</td>
+                                    <td>{{message.message}}</td>
+                                </tr>
+                            {{/each}}
+                            </tbody>
+                        </table>
+                    </div>
+                {{/if}}
+            </div>
+        </div>
+
+        <div class="card card-light">
+            <div class="card-header">
+                <div class="cp-card-heading">
+                    <span class="cp-card-icon"><i class="fas fa-list-check" aria-hidden="true"></i></span>
+                    <h3 class="card-title">Detected capabilities</h3>
+                </div>
+            </div>
+            <div class="card-body">
+                <div class="cp-data-table cp-data-table-paged" data-filter-table data-filter-table-page-size="10" data-filter-table-label="capability" data-filter-table-label-plural="capabilities">
+                    <div class="cp-data-table-toolbar">
+                        <div class="cp-data-table-summary" data-filter-table-summary>{{summary.size}} capabilities</div>
+                        <div class="cp-data-table-search">
+                            <input type="text" class="form-control" data-filter-table-search placeholder="Search capabilities" aria-label="Search validation capabilities">
+                        </div>
+                    </div>
+                    <div class="cp-data-table-container">
+                        <table class="table cp-data-table-table cp-data-table-fixed">
+                            <thead>
+                            <tr>
+                                <th>Capability</th>
+                                <th>Value</th>
+                                <th>Source</th>
+                                <th>State</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            {{#each summary as |item|}}
+                                <tr>
+                                    <td>{{item.label}}</td>
+                                    <td><code class="cp-table-code">{{item.value}}</code></td>
+                                    <td>{{item.source}}</td>
+                                    <td><span class="badge badge-secondary">{{item.state}}</span></td>
+                                </tr>
+                            {{/each}}
+                            <tr data-filter-table-empty hidden>
+                                <td class="cp-data-table-empty-cell" colspan="4">No capabilities found.</td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="card card-light">
+            <div class="card-body">
+                <div class="tabs cp-fill-tabs" data-tabs>
+                    <div class="tabs-list" role="tablist" aria-label="Validation metadata groups">
+                        <button type="button" class="tabs-trigger active" id="tab-validation-routes" role="tab" aria-selected="true" aria-controls="panel-validation-routes" data-tabs-trigger="validation-routes">
+                            Routes
+                            <span class="badge badge-secondary">{{routes.size}}</span>
+                        </button>
+                        <button type="button" class="tabs-trigger" id="tab-validation-methods" role="tab" aria-selected="false" aria-controls="panel-validation-methods" data-tabs-trigger="validation-methods">
+                            Methods
+                            <span class="badge badge-secondary">{{methods.size}}</span>
+                        </button>
+                        <button type="button" class="tabs-trigger" id="tab-validation-configuration" role="tab" aria-selected="false" aria-controls="panel-validation-configuration" data-tabs-trigger="validation-configuration">
+                            Configuration
+                            <span class="badge badge-secondary">{{configurationProperties.size}}</span>
+                        </button>
+                        <button type="button" class="tabs-trigger" id="tab-validation-classes" role="tab" aria-selected="false" aria-controls="panel-validation-classes" data-tabs-trigger="validation-classes">
+                            Classes
+                            <span class="badge badge-secondary">{{classes.size}}</span>
+                        </button>
+                        <button type="button" class="tabs-trigger" id="tab-validation-components" role="tab" aria-selected="false" aria-controls="panel-validation-components" data-tabs-trigger="validation-components">
+                            Validators
+                            <span class="badge badge-secondary">{{components.size}}</span>
+                        </button>
+                    </div>
+
+                    <div class="tabs-panel" id="panel-validation-routes" role="tabpanel" aria-labelledby="tab-validation-routes" data-tabs-panel="validation-routes">
+                        {{> "views/validation/elements" rows=routes label="route" labelPlural="routes" }}
+                    </div>
+                    <div class="tabs-panel" id="panel-validation-methods" role="tabpanel" aria-labelledby="tab-validation-methods" data-tabs-panel="validation-methods" hidden>
+                        {{> "views/validation/elements" rows=methods label="method" labelPlural="methods" }}
+                    </div>
+                    <div class="tabs-panel" id="panel-validation-configuration" role="tabpanel" aria-labelledby="tab-validation-configuration" data-tabs-panel="validation-configuration" hidden>
+                        {{> "views/validation/elements" rows=configurationProperties label="configuration bean" labelPlural="configuration beans" }}
+                    </div>
+                    <div class="tabs-panel" id="panel-validation-classes" role="tabpanel" aria-labelledby="tab-validation-classes" data-tabs-panel="validation-classes" hidden>
+                        {{> "views/validation/elements" rows=classes label="class" labelPlural="classes" }}
+                    </div>
+                    <div class="tabs-panel" id="panel-validation-components" role="tabpanel" aria-labelledby="tab-validation-components" data-tabs-panel="validation-components" hidden>
+                        <div class="cp-data-table cp-data-table-paged" data-filter-table data-filter-table-page-size="10" data-filter-table-label="validator" data-filter-table-label-plural="validators">
+                            <div class="cp-data-table-toolbar">
+                                <div class="cp-data-table-summary" data-filter-table-summary>{{components.size}} validators</div>
+                                <div class="cp-data-table-search">
+                                    <input type="text" class="form-control" data-filter-table-search placeholder="Search validators" aria-label="Search validators">
+                                </div>
+                            </div>
+                            <div class="cp-data-table-container">
+                                <table class="table cp-data-table-table cp-data-table-fixed">
+                                    <thead>
+                                    <tr>
+                                        <th>Kind</th>
+                                        <th>Bean</th>
+                                        <th>Qualifier</th>
+                                        <th>Scope</th>
+                                        <th>Origin</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    {{#each components as |component|}}
+                                        <tr>
+                                            <td>{{component.kind}}</td>
+                                            <td><code class="cp-table-code">{{component.beanType}}</code></td>
+                                            <td><code class="cp-table-code">{{component.qualifier}}</code></td>
+                                            <td>{{component.scope}}</td>
+                                            <td><span class="badge badge-secondary">{{component.origin}}</span></td>
+                                        </tr>
+                                    {{/each}}
+                                    <tr data-filter-table-empty hidden>
+                                        <td class="cp-data-table-empty-cell" colspan="5">No validators found.</td>
+                                    </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+{{/with}}

--- a/control-panel-validation/src/main/resources/views/validation/elements.hbs
+++ b/control-panel-validation/src/main/resources/views/validation/elements.hbs
@@ -1,0 +1,114 @@
+<div class="cp-data-table cp-data-table-paged" data-filter-table data-filter-table-page-size="10" data-filter-table-label="{{label}}" data-filter-table-label-plural="{{labelPlural}}">
+    <div class="cp-data-table-toolbar">
+        <div class="cp-data-table-summary" data-filter-table-summary>{{rows.size}} {{labelPlural}}</div>
+        <div class="cp-data-table-search">
+            <input type="text" class="form-control" data-filter-table-search placeholder="Search {{labelPlural}}" aria-label="Search validation {{labelPlural}}">
+        </div>
+    </div>
+    <div class="cp-data-table-container">
+        <table class="table cp-data-table-table cp-data-table-fixed">
+            <thead>
+            <tr>
+                <th>Name</th>
+                <th>Source</th>
+                <th>Constraints</th>
+                <th>Cascade</th>
+                <th>Details</th>
+            </tr>
+            </thead>
+            <tbody>
+            {{#each rows as |row|}}
+                <tr>
+                    <td><code class="cp-table-code">{{row.name}}</code></td>
+                    <td>{{row.source}}</td>
+                    <td><span class="badge badge-primary">{{row.constraintCount}}</span></td>
+                    <td>
+                        {{#if row.cascaded}}
+                            <span class="badge badge-primary">Cascaded</span>
+                        {{else}}
+                            <span class="badge badge-secondary">No cascade</span>
+                        {{/if}}
+                    </td>
+                    <td>
+                        {{#if row.constraints}}
+                            <details>
+                                <summary>{{row.constraints.size}} constraint rows</summary>
+                                <div class="cp-data-table-container">
+                                    <table class="table cp-data-table-table">
+                                        <thead>
+                                        <tr>
+                                            <th>Constraint</th>
+                                            <th>Target</th>
+                                            <th>Groups</th>
+                                            <th>Cascade</th>
+                                            <th>Attributes</th>
+                                        </tr>
+                                        </thead>
+                                        <tbody>
+                                        {{#each row.constraints as |constraint|}}
+                                            <tr>
+                                                <td><code class="cp-table-code">{{constraint.name}}</code></td>
+                                                <td>{{constraint.target}}</td>
+                                                <td>
+                                                    {{#if constraint.hasGroups}}
+                                                        {{#each constraint.groups as |group|}}
+                                                            <code class="cp-table-code">{{group}}</code>
+                                                        {{/each}}
+                                                    {{else}}
+                                                        <span class="badge badge-secondary">Default</span>
+                                                    {{/if}}
+                                                </td>
+                                                <td>
+                                                    {{#if constraint.cascaded}}
+                                                        <span class="badge badge-primary">Cascaded</span>
+                                                    {{else}}
+                                                        <span class="badge badge-secondary">No cascade</span>
+                                                    {{/if}}
+                                                </td>
+                                                <td>
+                                                    {{#if constraint.hasAttributes}}
+                                                        {{#each constraint.attributes as |attribute|}}
+                                                            <div>
+                                                                <code class="cp-table-code">{{attribute.name}}</code> =
+                                                                <code class="cp-table-code">{{attribute.value}}</code>
+                                                                {{#if attribute.redacted}}<span class="badge badge-secondary">redacted</span>{{/if}}
+                                                            </div>
+                                                        {{/each}}
+                                                    {{else}}
+                                                        <span class="badge badge-secondary">Hidden</span>
+                                                    {{/if}}
+                                                </td>
+                                            </tr>
+                                        {{/each}}
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </details>
+                        {{else}}
+                            <span class="badge badge-secondary">Metadata marker only</span>
+                        {{/if}}
+                    </td>
+                </tr>
+            {{/each}}
+            <tr data-filter-table-empty hidden>
+                <td class="cp-data-table-empty-cell" colspan="5">No {{labelPlural}} found.</td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+    <div class="cp-data-table-footer">
+        <label class="cp-data-table-page-size">
+            Rows per page
+            <select class="form-control" data-filter-table-page-size-select aria-label="Validation {{labelPlural}} per page">
+                <option value="5">5</option>
+                <option value="10" selected>10</option>
+                <option value="20">20</option>
+            </select>
+        </label>
+        <div class="cp-data-table-pagination">
+            <span class="cp-data-table-page" data-filter-table-page>Page 1 of 1</span>
+            <button type="button" class="btn btn-secondary btn-sm" data-filter-table-prev>Previous</button>
+            <button type="button" class="btn btn-secondary btn-sm" data-filter-table-next>Next</button>
+        </div>
+    </div>
+</div>

--- a/control-panel-validation/src/main/resources/views/validation/elements.hbs
+++ b/control-panel-validation/src/main/resources/views/validation/elements.hbs
@@ -18,7 +18,7 @@
             </thead>
             <tbody>
             {{#each rows as |row|}}
-                <tr>
+                <tr data-filter-table-row>
                     <td><code class="cp-table-code">{{row.name}}</code></td>
                     <td>{{row.source}}</td>
                     <td><span class="badge badge-primary">{{row.constraintCount}}</span></td>

--- a/control-panel-validation/src/test/java/io/micronaut/controlpanel/panels/validation/ValidationControlPanelTest.java
+++ b/control-panel-validation/src/test/java/io/micronaut/controlpanel/panels/validation/ValidationControlPanelTest.java
@@ -74,7 +74,7 @@ class ValidationControlPanelTest {
     void panelCanBeDisabled() {
         try (ApplicationContext context = ApplicationContext.run(Map.of(ValidationControlPanel.ENABLED_PROPERTY, false))) {
             assertFalse(context.containsBean(ValidationControlPanel.class));
-            assertFalse(context.getBean(ValidationConfiguration.class).getIncludePackages().contains("missing"));
+            assertFalse(context.containsBean(ValidationConfiguration.class));
         }
     }
 

--- a/control-panel-validation/src/test/java/io/micronaut/controlpanel/panels/validation/ValidationControlPanelTest.java
+++ b/control-panel-validation/src/test/java/io/micronaut/controlpanel/panels/validation/ValidationControlPanelTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.validation;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.validation.validator.constraints.ConstraintValidator;
+import io.micronaut.validation.validator.constraints.ConstraintValidatorContext;
+import jakarta.inject.Singleton;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.Map;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ValidationControlPanelTest {
+
+    @Test
+    void collectsValidationMetadata() {
+        try (ApplicationContext context = ApplicationContext.run(Map.of(
+            "micronaut.control-panel.validation.include-packages[0]", "io.micronaut.controlpanel.panels.validation",
+            "micronaut.control-panel.validation.show-constraint-attributes", "safe"
+        ))) {
+            ValidationControlPanel panel = context.getBean(ValidationControlPanel.class);
+            ValidationDiagnostics body = panel.getBody();
+
+            assertTrue(body.validationEnabled());
+            assertTrue(body.totalConstraints() >= 4);
+            assertTrue(body.routes().stream().anyMatch(row -> row.name().contains("/validation-test/orders")));
+            assertTrue(body.classes().stream().anyMatch(row -> row.name().endsWith("ValidationRequest")));
+            assertTrue(body.configurationProperties().stream().anyMatch(row -> row.name().endsWith("ValidationSettings")));
+            assertTrue(body.components().stream().anyMatch(row -> row.beanType().endsWith("TenantCodeValidator")));
+            assertTrue(body.routes().stream()
+                .flatMap(row -> row.constraints().stream())
+                .anyMatch(row -> row.target().startsWith("parameter") || row.target().equals("method")));
+        }
+    }
+
+    @Test
+    void panelCanBeDisabled() {
+        try (ApplicationContext context = ApplicationContext.run(Map.of(ValidationControlPanel.ENABLED_PROPERTY, false))) {
+            assertFalse(context.containsBean(ValidationControlPanel.class));
+            assertFalse(context.getBean(ValidationConfiguration.class).getIncludePackages().contains("missing"));
+        }
+    }
+
+    @Test
+    void reportsDisabledRuntimeStateGracefully() {
+        try (ApplicationContext context = ApplicationContext.run(Map.of(
+            "micronaut.validator.enabled", false,
+            "micronaut.control-panel.validation.include-packages[0]", "io.micronaut.controlpanel.panels.validation"
+        ))) {
+            ValidationDiagnostics body = context.getBean(ValidationControlPanel.class).getBody();
+
+            assertFalse(body.validationEnabled());
+            assertTrue(body.hasMessages());
+            assertTrue(body.messages().stream().anyMatch(message -> message.state().equals("disabled")));
+        }
+    }
+
+    @Test
+    void packageFilterHonorsIncludesAndExcludes() {
+        ValidationPackageFilter filter = new ValidationPackageFilter();
+        ValidationConfiguration configuration = new ValidationConfiguration();
+        configuration.setIncludePackages(java.util.List.of("io.micronaut.controlpanel.panels.validation"));
+        configuration.setExcludePackages(java.util.List.of("io.micronaut.controlpanel.panels.validation.internal"));
+
+        assertTrue(filter.includes(ValidationControlPanelTest.class, configuration));
+        assertFalse(filter.includes(String.class, configuration));
+    }
+
+    @Test
+    void sanitizerRedactsSecretLikeAttributes() {
+        ValidationAttributeSanitizer sanitizer = new ValidationAttributeSanitizer();
+        var rows = sanitizer.sanitize(Map.of("apiKey", "abc123", "min", 2), ValidationConfiguration.AttributeMode.SAFE);
+
+        assertTrue(rows.stream().anyMatch(row -> row.name().equals("apiKey") && row.redacted()));
+        assertTrue(rows.stream().anyMatch(row -> row.name().equals("min") && row.value().equals("2")));
+    }
+
+    @Controller("/validation-test")
+    static class ValidationController {
+
+        @Post("/orders/{tenant}")
+        ValidationResponse create(@TenantCode String tenant, @Body @Valid ValidationRequest request) {
+            return new ValidationResponse(tenant, request.email());
+        }
+    }
+
+    @Introspected
+    record ValidationRequest(
+        @NotBlank
+        @Size(max = 20)
+        String name,
+
+        @Email
+        String email,
+
+        @Valid
+        Nested nested
+    ) {
+    }
+
+    @Introspected
+    record Nested(@NotBlank String value) {
+    }
+
+    record ValidationResponse(String tenant, String email) {
+    }
+
+    @ConfigurationProperties("validation.test")
+    static class ValidationSettings {
+        @NotBlank
+        private String endpoint = "https://example.com";
+
+        @Positive
+        private int retries = 1;
+
+        public String getEndpoint() {
+            return endpoint;
+        }
+
+        public void setEndpoint(String endpoint) {
+            this.endpoint = endpoint;
+        }
+
+        public int getRetries() {
+            return retries;
+        }
+
+        public void setRetries(int retries) {
+            this.retries = retries;
+        }
+    }
+
+    @Documented
+    @Constraint(validatedBy = {})
+    @Target({ FIELD, PARAMETER, ANNOTATION_TYPE })
+    @Retention(RUNTIME)
+    @interface TenantCode {
+        String message() default "must be a tenant code";
+
+        Class<?>[] groups() default {};
+
+        Class<? extends Payload>[] payload() default {};
+    }
+
+    @Singleton
+    static class TenantCodeValidator implements ConstraintValidator<TenantCode, String> {
+        @Override
+        public boolean isValid(String value, AnnotationValue<TenantCode> annotationMetadata, ConstraintValidatorContext context) {
+            return value != null && value.matches("[A-Z][A-Z0-9_-]+");
+        }
+    }
+}

--- a/control-panel-validation/src/test/java/io/micronaut/controlpanel/panels/validation/ValidationControlPanelTest.java
+++ b/control-panel-validation/src/test/java/io/micronaut/controlpanel/panels/validation/ValidationControlPanelTest.java
@@ -17,6 +17,7 @@ package io.micronaut.controlpanel.panels.validation;
 
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.annotation.AnnotationClassValue;
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.http.annotation.Body;
@@ -99,6 +100,21 @@ class ValidationControlPanelTest {
     }
 
     @Test
+    void reportsEmptyStateAndEmptyBadgeWhenFiltersHideApplicationMetadata() {
+        try (ApplicationContext context = ApplicationContext.run(Map.of(
+            "micronaut.control-panel.validation.include-packages[0]", "example.missing"
+        ))) {
+            ValidationControlPanel panel = context.getBean(ValidationControlPanel.class);
+            ValidationDiagnostics body = panel.getBody();
+
+            assertTrue(panel.getBadge().isEmpty());
+            assertTrue(body.messages().stream().anyMatch(message -> message.state().equals("empty")));
+            assertFalse(body.hasRoutes());
+            assertFalse(body.hasComponents());
+        }
+    }
+
+    @Test
     void packageFilterHonorsIncludesAndExcludes() {
         ValidationPackageFilter filter = new ValidationPackageFilter();
         ValidationConfiguration configuration = new ValidationConfiguration();
@@ -107,6 +123,21 @@ class ValidationControlPanelTest {
 
         assertTrue(filter.includes(ValidationControlPanelTest.class, configuration));
         assertFalse(filter.includes(String.class, configuration));
+        assertFalse(filter.includes(null, configuration));
+        assertTrue(filter.packageName(null).isEmpty());
+    }
+
+    @Test
+    void configurationSettersPreserveSafeDefaultsForNullValues() {
+        ValidationConfiguration configuration = new ValidationConfiguration();
+
+        configuration.setIncludePackages(null);
+        configuration.setExcludePackages(null);
+        configuration.setShowConstraintAttributes(null);
+
+        assertTrue(configuration.getIncludePackages().isEmpty());
+        assertTrue(configuration.getExcludePackages().isEmpty());
+        assertTrue(configuration.getShowConstraintAttributes() == ValidationConfiguration.AttributeMode.SAFE);
     }
 
     @Test
@@ -141,6 +172,69 @@ class ValidationControlPanelTest {
         assertTrue(rows.stream().anyMatch(row -> row.name().equals("pattern") && row.value().endsWith("[truncated]")));
         assertTrue(rows.stream().anyMatch(row -> row.name().equals("values") && row.value().contains("9 total")));
         assertTrue(rows.stream().anyMatch(row -> row.name().equals("custom") && row.redacted()));
+    }
+
+    @Test
+    void sanitizerFormatsClassesEnumsAndIterables() {
+        ValidationAttributeSanitizer sanitizer = new ValidationAttributeSanitizer();
+        Map<CharSequence, Object> values = Map.of(
+            "type", ValidationControlPanelTest.class,
+            "annotationClass", new AnnotationClassValue<>(ValidationController.class),
+            "mode", TestMode.ONE,
+            "flags", List.of(true, TestMode.TWO)
+        );
+        var rows = sanitizer.sanitize(values, ValidationConfiguration.AttributeMode.SAFE);
+
+        assertTrue(rows.stream().anyMatch(row -> row.name().equals("type")
+            && row.value().equals(ValidationControlPanelTest.class.getName())));
+        assertTrue(rows.stream().anyMatch(row -> row.name().equals("annotationClass")
+            && row.value().equals(ValidationController.class.getName())));
+        assertTrue(rows.stream().anyMatch(row -> row.name().equals("mode") && row.value().equals("ONE")));
+        assertTrue(rows.stream().anyMatch(row -> row.name().equals("flags") && row.value().equals("[true, TWO]")));
+    }
+
+    @Test
+    void diagnosticsHelperMethodsReportPresentSections() {
+        ValidationDiagnostics.ConstraintRow constraint = new ValidationDiagnostics.ConstraintRow(
+            "NotBlank",
+            "property name",
+            List.of(DefaultGroup.class.getName()),
+            true,
+            List.of(new ValidationDiagnostics.AttributeRow("min", "1", false)),
+            "test"
+        );
+        ValidationDiagnostics.ValidatedElementRow element = new ValidationDiagnostics.ValidatedElementRow(
+            "Class",
+            "example.Validated",
+            "test",
+            "example",
+            List.of(constraint),
+            true,
+            true
+        );
+        ValidationDiagnostics diagnostics = new ValidationDiagnostics(
+            true,
+            "Enabled",
+            "description",
+            List.of(new ValidationDiagnostics.SummaryItem("Runtime validation", "Enabled", "test", "available")),
+            List.of(new ValidationDiagnostics.ComponentRow("Validator", "example.Validator", "default", "singleton", "application", "test")),
+            List.of(element),
+            List.of(element),
+            List.of(element),
+            List.of(element),
+            List.of(new ValidationDiagnostics.StateMessage("partial", "title", "message")),
+            1
+        );
+
+        assertTrue(diagnostics.hasRoutes());
+        assertTrue(diagnostics.hasMethods());
+        assertTrue(diagnostics.hasConfigurationProperties());
+        assertTrue(diagnostics.hasClasses());
+        assertTrue(diagnostics.hasComponents());
+        assertTrue(diagnostics.hasMessages());
+        assertTrue(element.constraintCount() == 1);
+        assertTrue(constraint.hasGroups());
+        assertTrue(constraint.hasAttributes());
     }
 
     @Controller("/validation-test")
@@ -218,5 +312,13 @@ class ValidationControlPanelTest {
         public boolean isValid(String value, AnnotationValue<TenantCode> annotationMetadata, ConstraintValidatorContext context) {
             return value != null && value.matches("[A-Z][A-Z0-9_-]+");
         }
+    }
+
+    enum TestMode {
+        ONE,
+        TWO
+    }
+
+    interface DefaultGroup {
     }
 }

--- a/control-panel-validation/src/test/java/io/micronaut/controlpanel/panels/validation/ValidationControlPanelTest.java
+++ b/control-panel-validation/src/test/java/io/micronaut/controlpanel/panels/validation/ValidationControlPanelTest.java
@@ -37,13 +37,13 @@ import org.junit.jupiter.api.Test;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
+import java.util.List;
 import java.util.Map;
 
 import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -62,11 +62,17 @@ class ValidationControlPanelTest {
             assertTrue(body.totalConstraints() >= 4);
             assertTrue(body.routes().stream().anyMatch(row -> row.name().contains("/validation-test/orders")));
             assertTrue(body.classes().stream().anyMatch(row -> row.name().endsWith("ValidationRequest")));
+            assertFalse(body.classes().stream().anyMatch(row -> row.name().endsWith("ValidationSettings")));
             assertTrue(body.configurationProperties().stream().anyMatch(row -> row.name().endsWith("ValidationSettings")));
             assertTrue(body.components().stream().anyMatch(row -> row.beanType().endsWith("TenantCodeValidator")));
             assertTrue(body.routes().stream()
                 .flatMap(row -> row.constraints().stream())
                 .anyMatch(row -> row.target().startsWith("parameter") || row.target().equals("method")));
+            assertTrue(body.classes().stream()
+                .filter(row -> row.name().endsWith("ValidationRequest"))
+                .flatMap(row -> row.constraints().stream())
+                .anyMatch(row -> row.target().contains("nestedTags")
+                    && row.target().indexOf("type argument") != row.target().lastIndexOf("type argument")));
         }
     }
 
@@ -112,6 +118,31 @@ class ValidationControlPanelTest {
         assertTrue(rows.stream().anyMatch(row -> row.name().equals("min") && row.value().equals("2")));
     }
 
+    @Test
+    void sanitizerSupportsHiddenAndVerboseModes() {
+        ValidationAttributeSanitizer sanitizer = new ValidationAttributeSanitizer();
+        Map<CharSequence, Object> values = Map.of("pattern", "abcdefghijklmnopqrstuvwxyz", "values", new int[] {1, 2, 3});
+
+        assertTrue(sanitizer.sanitize(values, ValidationConfiguration.AttributeMode.NONE).isEmpty());
+        assertTrue(sanitizer.sanitize(values, ValidationConfiguration.AttributeMode.ALL).stream()
+            .anyMatch(row -> row.name().equals("values") && row.value().equals("[1, 2, 3]")));
+    }
+
+    @Test
+    void sanitizerTruncatesLargeSafeValues() {
+        ValidationAttributeSanitizer sanitizer = new ValidationAttributeSanitizer();
+        Map<CharSequence, Object> values = Map.of(
+            "pattern", "x".repeat(140),
+            "values", new int[] {1, 2, 3, 4, 5, 6, 7, 8, 9},
+            "custom", new Object()
+        );
+        var rows = sanitizer.sanitize(values, ValidationConfiguration.AttributeMode.SAFE);
+
+        assertTrue(rows.stream().anyMatch(row -> row.name().equals("pattern") && row.value().endsWith("[truncated]")));
+        assertTrue(rows.stream().anyMatch(row -> row.name().equals("values") && row.value().contains("9 total")));
+        assertTrue(rows.stream().anyMatch(row -> row.name().equals("custom") && row.redacted()));
+    }
+
     @Controller("/validation-test")
     static class ValidationController {
 
@@ -131,7 +162,9 @@ class ValidationControlPanelTest {
         String email,
 
         @Valid
-        Nested nested
+        Nested nested,
+
+        List<List<@NotBlank String>> nestedTags
     ) {
     }
 

--- a/doc-examples/example-java/build.gradle.kts
+++ b/doc-examples/example-java/build.gradle.kts
@@ -71,6 +71,8 @@ dependencies {
     testImplementation(libs.playwright)
     testResourcesImplementation(mn.micronaut.jackson.databind)
     testRuntimeOnly(mnTest.junit.platform.suite)
+    testResourcesRuntimeOnly(mn.micronaut.discovery.core)
+    testResourcesRuntimeOnly(mn.micronaut.management)
 }
 
 micronaut {

--- a/doc-examples/example-java/build.gradle.kts
+++ b/doc-examples/example-java/build.gradle.kts
@@ -50,6 +50,13 @@ dependencies {
     implementation(libs.avro)
     implementation(libs.avro.serde)
 
+    // Validation
+    annotationProcessor(platform(libs.micronaut.validation))
+    annotationProcessor("io.micronaut.validation:micronaut-validation-processor")
+    implementation(projects.micronautControlPanelValidation)
+    implementation(platform(libs.micronaut.validation))
+    implementation("io.micronaut.validation:micronaut-validation")
+
     // OpenAPI + Swagger UI (views generated at compile-time)
     annotationProcessor(mnOpenapi.micronaut.openapi)
     testAnnotationProcessor(mnOpenapi.micronaut.openapi)

--- a/doc-examples/example-java/src/main/java/example/TenantCode.java
+++ b/doc-examples/example-java/src/main/java/example/TenantCode.java
@@ -1,0 +1,26 @@
+package example;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Documented
+@Constraint(validatedBy = {})
+@Target({ FIELD, PARAMETER, ANNOTATION_TYPE })
+@Retention(RUNTIME)
+public @interface TenantCode {
+
+    String message() default "must be an uppercase tenant code";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/doc-examples/example-java/src/main/java/example/TenantCodeValidator.java
+++ b/doc-examples/example-java/src/main/java/example/TenantCodeValidator.java
@@ -1,0 +1,15 @@
+package example;
+
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.validation.validator.constraints.ConstraintValidator;
+import io.micronaut.validation.validator.constraints.ConstraintValidatorContext;
+import jakarta.inject.Singleton;
+
+@Singleton
+class TenantCodeValidator implements ConstraintValidator<TenantCode, String> {
+
+    @Override
+    public boolean isValid(String value, AnnotationValue<TenantCode> annotationMetadata, ConstraintValidatorContext context) {
+        return value != null && value.matches("[A-Z][A-Z0-9_-]{1,31}");
+    }
+}

--- a/doc-examples/example-java/src/main/java/example/ValidationDemoConfiguration.java
+++ b/doc-examples/example-java/src/main/java/example/ValidationDemoConfiguration.java
@@ -1,0 +1,33 @@
+package example;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.annotation.Introspected;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+
+@Introspected
+@ConfigurationProperties("demo.validation")
+class ValidationDemoConfiguration {
+
+    @NotBlank
+    private String supportEmail = "support@example.com";
+
+    @Positive
+    private int retryLimit = 3;
+
+    public String getSupportEmail() {
+        return supportEmail;
+    }
+
+    public void setSupportEmail(String supportEmail) {
+        this.supportEmail = supportEmail;
+    }
+
+    public int getRetryLimit() {
+        return retryLimit;
+    }
+
+    public void setRetryLimit(int retryLimit) {
+        this.retryLimit = retryLimit;
+    }
+}

--- a/doc-examples/example-java/src/main/java/example/ValidationDemoController.java
+++ b/doc-examples/example-java/src/main/java/example/ValidationDemoController.java
@@ -1,0 +1,47 @@
+package example;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.serde.annotation.Serdeable;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@Controller("/validation-demo")
+class ValidationDemoController {
+
+    @Post("/orders/{tenant}")
+    ValidationResponse create(@TenantCode String tenant, @Body @Valid ValidationRequest request) {
+        return new ValidationResponse(tenant, request.email());
+    }
+
+    @Introspected
+    @Serdeable
+    record ValidationRequest(
+        @NotBlank
+        @Size(max = 80)
+        String name,
+
+        @Email
+        String email,
+
+        @Valid
+        Address address
+    ) {
+    }
+
+    @Introspected
+    @Serdeable
+    record Address(
+        @NotBlank
+        String city
+    ) {
+    }
+
+    @Serdeable
+    record ValidationResponse(String tenant, String email) {
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ micronaut-testresources = "4.0.0"
 micronaut-gradle-plugin = "5.0.0-M1"
 micronaut-openapi = "7.0.0"
 micronaut-kafka = "6.0.0"
+micronaut-validation = "5.0.0"
 kotlin-gradle-plugin = "2.3.21"
 micronaut-shared-settings = "8.0.0"
 playwright = "1.59.0"
@@ -58,6 +59,7 @@ micronaut-sql = { module = "io.micronaut.sql:micronaut-sql-bom", version.ref = "
 micronaut-data = { module = "io.micronaut.data:micronaut-data-bom", version.ref = "micronaut-data" }
 micronaut-testresources = { module = 'io.micronaut.testresources:micronaut-test-resources-bom', version.ref = "micronaut-testresources" }
 micronaut-kafka = { module = "io.micronaut.kafka:micronaut-kafka-bom", version.ref = "micronaut-kafka" }
+micronaut-validation = { module = "io.micronaut.validation:micronaut-validation-bom", version.ref = "micronaut-validation" }
 avro = { module = "org.apache.avro:avro", version.ref = "avro" }
 avro-serde = { module = "io.confluent:kafka-streams-avro-serde", version.ref = "avro-serde" }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,6 +22,7 @@ include("control-panel-datasource")
 include("control-panel-hibernate")
 include("control-panel-ui")
 include("control-panel-kafka")
+include("control-panel-validation")
 
 include("doc-examples:example-java")
 

--- a/src/main/docs/guide/controlPanels/validation.adoc
+++ b/src/main/docs/guide/controlPanels/validation.adoc
@@ -1,7 +1,7 @@
 The Validation control panel provides read-only diagnostics for applications that use Micronaut Validation.
 It is intended for development-time troubleshooting when route validation, method validation, request body cascades, custom validators, or configuration-property constraints do not behave as expected.
 
-dependency:io.micronaut.controlpanel:micronaut-control-panel-validation[]
+dependency:io.micronaut.controlpanel:micronaut-control-panel-validation[scope=developmentOnly]
 
 The application must also include Micronaut Validation and the validation annotation processor, as it normally would for runtime validation:
 

--- a/src/main/docs/guide/controlPanels/validation.adoc
+++ b/src/main/docs/guide/controlPanels/validation.adoc
@@ -1,0 +1,59 @@
+The Validation control panel provides read-only diagnostics for applications that use Micronaut Validation.
+It is intended for development-time troubleshooting when route validation, method validation, request body cascades, custom validators, or configuration-property constraints do not behave as expected.
+
+dependency:io.micronaut.controlpanel:micronaut-control-panel-validation[]
+
+The application must also include Micronaut Validation and the validation annotation processor, as it normally would for runtime validation:
+
+dependency:io.micronaut.validation:micronaut-validation[]
+dependency:io.micronaut.validation:micronaut-validation-processor[scope="annotationProcessor"]
+
+When `micronaut-validation` is not on the classpath, the panel is not registered.
+When the validation classes are present but runtime validation is disabled, the panel renders an explicit disabled state and still shows compile-time metadata that can be inspected safely.
+
+[configuration]
+----
+micronaut:
+  control-panel:
+    panels:
+      validation:
+        enabled: true
+    validation:
+      include-packages:
+        - example
+      exclude-packages:
+        - example.internal
+      show-constraint-attributes: safe
+  validator:
+    enabled: true
+----
+
+The panel enable flag is `micronaut.control-panel.panels.validation.enabled`.
+Micronaut Validation runtime behavior is still controlled by `micronaut.validator.enabled`.
+
+The `micronaut.control-panel.validation.include-packages` and `micronaut.control-panel.validation.exclude-packages` settings limit which application classes appear in route, method, class, configuration-property, and custom-validator views.
+When no include packages are configured, framework packages such as `java.*`, `jakarta.*`, and `io.micronaut.*` are hidden by default so the panel focuses on application metadata.
+
+The `micronaut.control-panel.validation.show-constraint-attributes` setting controls annotation member display:
+
+* `none` hides constraint attributes.
+* `safe` is the default. It redacts secret-like member names, truncates large strings and arrays, and summarizes non-scalar values.
+* `all` displays annotation values collected from Micronaut metadata. This should be used only in trusted development environments.
+
+The detail view separates metadata by source:
+
+* Detected capabilities show the active provider beans, validator configuration, package filters, and attribute mode.
+* Routes show validation metadata from `Router` and route `ExecutableMethod` arguments, return values, and method annotations.
+* Methods show application bean methods with validation constraints or cascade markers.
+* Configuration shows validated `@ConfigurationProperties` beans.
+* Classes show reachable request body/data classes and configuration classes with introspection metadata.
+* Validators show application `ConstraintValidator` beans.
+
+The panel does not execute validators, capture request payloads, display rejected values, or call provider-specific APIs such as Hibernate Validator internals.
+If a replacement provider hides Micronaut provider beans, the panel marks that provider metadata as unavailable and continues showing compile-time metadata.
+
+Validation metadata can reveal domain model names, property names, message keys, regular expressions, and business rules.
+Keep Control Panel protected and development-scoped, following the same exposure model as the other Control Panel modules.
+
+The panel consumes Micronaut compile-time metadata and bean introspections already generated for the application.
+It does not introduce reflection scans for native-image builds.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -10,6 +10,7 @@ controlPanels:
   datasource: Datasource
   hibernate: Hibernate
   kafka: Kafka
+  validation: Validation
 
 custom: Creating Custom Control Panels
 repository: Repository


### PR DESCRIPTION
## Summary

- Add `micronaut-control-panel-validation`, a read-only diagnostics panel for Micronaut Validation metadata, provider/configuration state, custom validators, validated routes/methods, configuration-property beans, and reachable data classes.
- Add validation fixtures to the example app and user guide documentation for setup, enable/disable behavior, package filters, attribute display modes, provider limits, and privacy boundaries.
- Align the new optional module with existing package-level Control Panel guards so helper beans are absent when validation classes or the panel/global enablement requirements are not met.

## Release and Issue Routing

- Paperclip issue: DEV-476.
- Linked GitHub issue: none recorded, so no GitHub closing keyword applies.
- Type label: `type: enhancement`.
- Target branch: `2.0.x`.
- Organization projects selected by QA: `5.0.0-M3` and `5.0.0 Release`.
- Ambiguity: no open Micronaut organization project was named for Control Panel `2.0.0`; these are Micronaut Platform release boards.

## Screenshots

Desktop 1440x900:

![Validation panel desktop](https://raw.githubusercontent.com/micronaut-projects/micronaut-control-panel/824195a9d50a4fc8c529c892aaf971502ba09152/assets/pr-559/535735e9ac2e/validation-desktop-1440x900.png)

Mobile 390x844:

![Validation panel mobile](https://raw.githubusercontent.com/micronaut-projects/micronaut-control-panel/4998b5de76d34a71ea8a5505874485fbe5c4eac4/assets/pr-559/535735e9ac2e/validation-mobile-390x844.png)

## Verification

- `./gradlew :micronaut-control-panel-validation:checkstyleMain :micronaut-control-panel-validation:test :micronaut-doc-examples:micronaut-example-java:compileJava`
- `./gradlew spotlessCheck publishGuide`
- `git diff --check origin/2.0.x...HEAD`

---
###### ✨ This message was AI-generated using GPT-5
