### PR TITLE
Add email diagnostics control panel

### DIFF
--- a/control-panel-core/src/main/java/io/micronaut/controlpanel/core/security/ControlPanelSecurityPaths.java
+++ b/control-panel-core/src/main/java/io/micronaut/controlpanel/core/security/ControlPanelSecurityPaths.java
@@ -31,6 +31,7 @@ public final class ControlPanelSecurityPaths {
     public static final String CONTROL_PANEL = "${" + ControlPanelModuleConfiguration.PROPERTY_PATH + ":" + ControlPanelModuleConfiguration.DEFAULT_PATH + "}";
     public static final String CACHE_PATH = "/cache-control-panel-controller";
     public static final String DATASOURCE_PATH = "/datasource-control-panel-controller";
+    public static final String EMAIL_PATH = "/email-control-panel-controller";
     public static final String HIBERNATE_PATH = "/hibernate-control-panel-controller";
     public static final String KAFKA_PATH = "/kafka-control-panel-controller";
     public static final String LOGGERS_PATH = "/loggers-control-panel-controller";
@@ -38,13 +39,14 @@ public final class ControlPanelSecurityPaths {
     public static final String APPLICATION_PATH = "/application-control-panel-controller";
     public static final String CACHE = CONTROL_PANEL + CACHE_PATH;
     public static final String DATASOURCE = CONTROL_PANEL + DATASOURCE_PATH;
+    public static final String EMAIL = CONTROL_PANEL + EMAIL_PATH;
     public static final String HIBERNATE = CONTROL_PANEL + HIBERNATE_PATH;
     public static final String KAFKA = CONTROL_PANEL + KAFKA_PATH;
     public static final String LOGGERS = CONTROL_PANEL + LOGGERS_PATH;
     public static final String OBJECT_STORAGE = CONTROL_PANEL + OBJECT_STORAGE_PATH;
     public static final String APPLICATION = CONTROL_PANEL + APPLICATION_PATH;
 
-    private static final List<String> HELPER_PATHS = List.of(CACHE_PATH, DATASOURCE_PATH, HIBERNATE_PATH, KAFKA_PATH, LOGGERS_PATH, OBJECT_STORAGE_PATH, APPLICATION_PATH);
+    private static final List<String> HELPER_PATHS = List.of(CACHE_PATH, DATASOURCE_PATH, EMAIL_PATH, HIBERNATE_PATH, KAFKA_PATH, LOGGERS_PATH, OBJECT_STORAGE_PATH, APPLICATION_PATH);
 
     private ControlPanelSecurityPaths() {
     }
@@ -75,6 +77,7 @@ public final class ControlPanelSecurityPaths {
             return isHelperPath(controlPanelPath, LOGGERS_PATH, path)
                 || isHelperPath(controlPanelPath, KAFKA_PATH, path)
                 || isHelperPath(controlPanelPath, APPLICATION_PATH, path)
+                || isHelperPath(controlPanelPath, EMAIL_PATH, path)
                 || isObjectStorageUpload(controlPanelPath, path)
                 || isDatasourceQuery(controlPanelPath, path)
                 || isHibernateStatisticsToggle(controlPanelPath, path);

--- a/control-panel-core/src/test/java/io/micronaut/controlpanel/core/security/ControlPanelSecurityRuleTest.java
+++ b/control-panel-core/src/test/java/io/micronaut/controlpanel/core/security/ControlPanelSecurityRuleTest.java
@@ -263,6 +263,7 @@ class ControlPanelSecurityRuleTest {
             HttpRequest.POST(controlPanelPath + ControlPanelSecurityPaths.LOGGERS_PATH + "/ROOT", "{}"),
             HttpRequest.POST(controlPanelPath + ControlPanelSecurityPaths.KAFKA_PATH + "/messages", "{}"),
             HttpRequest.POST(controlPanelPath + ControlPanelSecurityPaths.KAFKA_PATH + "/topics", "{}"),
+            HttpRequest.POST(controlPanelPath + ControlPanelSecurityPaths.EMAIL_PATH + "/default/test-send", "{}"),
             HttpRequest.POST(controlPanelPath + ControlPanelSecurityPaths.APPLICATION_PATH + "/refresh", "{}"),
             HttpRequest.POST(controlPanelPath + ControlPanelSecurityPaths.APPLICATION_PATH + "/stop", ""),
             HttpRequest.POST(controlPanelPath + ControlPanelSecurityPaths.OBJECT_STORAGE_PATH + "/default", ""),

--- a/control-panel-email/build.gradle.kts
+++ b/control-panel-email/build.gradle.kts
@@ -1,0 +1,27 @@
+plugins {
+    io.micronaut.build.internal.`control-panel-module`
+}
+
+dependencies {
+    annotationProcessor(mnSerde.micronaut.serde.processor)
+
+    api(projects.micronautControlPanelCore)
+    implementation(mnReactor.micronaut.reactor)
+    implementation(mn.micronaut.http.server)
+    implementation(mnSerde.micronaut.serde.api)
+
+    compileOnly(mnEmail.micronaut.email)
+
+    testImplementation(mnEmail.micronaut.email)
+    testImplementation(mnSerde.micronaut.serde.jackson)
+    testImplementation(mn.micronaut.http.server.netty)
+    testImplementation(mn.micronaut.http.client)
+    testImplementation(mnTest.micronaut.test.junit5)
+    testImplementation(mnTest.mockito.junit.jupiter)
+    testRuntimeOnly(mnTest.junit.jupiter.engine)
+    testAnnotationProcessor(mn.micronaut.inject.java)
+}
+
+micronautBuild {
+    binaryCompatibility.enabledAfter("2.0.0")
+}

--- a/control-panel-email/build.gradle.kts
+++ b/control-panel-email/build.gradle.kts
@@ -23,5 +23,5 @@ dependencies {
 }
 
 micronautBuild {
-    binaryCompatibility.enabledAfter("2.0.0")
+    binaryCompatibility.enabledAfter("2.0.1")
 }

--- a/control-panel-email/src/main/java/io/micronaut/controlpanel/panels/email/EmailControlPanel.java
+++ b/control-panel-email/src/main/java/io/micronaut/controlpanel/panels/email/EmailControlPanel.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.email;
+
+import io.micronaut.controlpanel.core.AbstractEachBeanControlPanel;
+import io.micronaut.controlpanel.core.ControlPanel;
+import io.micronaut.controlpanel.core.config.ControlPanelConfiguration;
+
+import static io.micronaut.core.util.StringUtils.EMPTY_STRING;
+
+/**
+ * Control panel for a Micronaut Email sender.
+ */
+public class EmailControlPanel extends AbstractEachBeanControlPanel<EmailDiagnosticModel> {
+
+    public static final String NAME = "email";
+    public static final String ENABLED_PROPERTY = ControlPanelConfiguration.PREFIX + "." + NAME + ".enabled";
+    public static final String DEFAULT_ICON_CLASS = "fas fa-envelope";
+    public static final ControlPanel.Category CATEGORY = new ControlPanel.Category(NAME, "Email", DEFAULT_ICON_CLASS);
+
+    private final EmailSenderDescriptor descriptor;
+    private final EmailDiagnosticsAnalyzer analyzer;
+
+    EmailControlPanel(EmailSenderDescriptor descriptor,
+                      EmailDiagnosticsAnalyzer analyzer,
+                      ControlPanelConfiguration configuration) {
+        super(NAME, configuration);
+        this.descriptor = descriptor;
+        this.analyzer = analyzer;
+    }
+
+    @Override
+    protected String getBeanName() {
+        return descriptor.name();
+    }
+
+    @Override
+    protected String getPanelName() {
+        return NAME;
+    }
+
+    @Override
+    public String getTitle() {
+        return "Email: " + descriptor.name();
+    }
+
+    @Override
+    public EmailDiagnosticModel getBody() {
+        return analyzer.analyze(descriptor);
+    }
+
+    @Override
+    public String getBadge() {
+        return EMPTY_STRING;
+    }
+
+    @Override
+    public ControlPanel.Category getCategory() {
+        return CATEGORY;
+    }
+
+    @Override
+    public String getIcon() {
+        return DEFAULT_ICON_CLASS;
+    }
+}

--- a/control-panel-email/src/main/java/io/micronaut/controlpanel/panels/email/EmailControlPanelConfiguration.java
+++ b/control-panel-email/src/main/java/io/micronaut/controlpanel/panels/email/EmailControlPanelConfiguration.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.email;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.annotation.ReflectiveAccess;
+
+/**
+ * Email control panel configuration.
+ */
+@ConfigurationProperties(EmailControlPanelConfiguration.PREFIX)
+@ReflectiveAccess
+public final class EmailControlPanelConfiguration {
+
+    public static final String PREFIX = "micronaut.control-panel.email";
+
+    private TestSendConfiguration testSend = new TestSendConfiguration();
+
+    public TestSendConfiguration getTestSend() {
+        return testSend;
+    }
+
+    public void setTestSend(TestSendConfiguration testSend) {
+        this.testSend = testSend;
+    }
+
+    /**
+     * Test send configuration.
+     */
+    @ConfigurationProperties("test-send")
+    @ReflectiveAccess
+    public static final class TestSendConfiguration {
+        private boolean enabled;
+        private String recipient;
+        private String subjectPrefix = "[Micronaut Control Panel]";
+        private boolean allowArbitraryRecipient;
+        private boolean includeConfigurationSummary;
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public String getRecipient() {
+            return recipient;
+        }
+
+        public void setRecipient(String recipient) {
+            this.recipient = recipient;
+        }
+
+        public String getSubjectPrefix() {
+            return subjectPrefix;
+        }
+
+        public void setSubjectPrefix(String subjectPrefix) {
+            this.subjectPrefix = subjectPrefix;
+        }
+
+        public boolean isAllowArbitraryRecipient() {
+            return allowArbitraryRecipient;
+        }
+
+        public void setAllowArbitraryRecipient(boolean allowArbitraryRecipient) {
+            this.allowArbitraryRecipient = allowArbitraryRecipient;
+        }
+
+        public boolean isIncludeConfigurationSummary() {
+            return includeConfigurationSummary;
+        }
+
+        public void setIncludeConfigurationSummary(boolean includeConfigurationSummary) {
+            this.includeConfigurationSummary = includeConfigurationSummary;
+        }
+    }
+}

--- a/control-panel-email/src/main/java/io/micronaut/controlpanel/panels/email/EmailControlPanelConfiguration.java
+++ b/control-panel-email/src/main/java/io/micronaut/controlpanel/panels/email/EmailControlPanelConfiguration.java
@@ -17,6 +17,7 @@ package io.micronaut.controlpanel.panels.email;
 
 import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.core.annotation.ReflectiveAccess;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Email control panel configuration.
@@ -44,7 +45,7 @@ public final class EmailControlPanelConfiguration {
     @ReflectiveAccess
     public static final class TestSendConfiguration {
         private boolean enabled;
-        private String recipient;
+        private @Nullable String recipient;
         private String subjectPrefix = "[Micronaut Control Panel]";
         private boolean allowArbitraryRecipient;
         private boolean includeConfigurationSummary;
@@ -57,11 +58,11 @@ public final class EmailControlPanelConfiguration {
             this.enabled = enabled;
         }
 
-        public String getRecipient() {
+        public @Nullable String getRecipient() {
             return recipient;
         }
 
-        public void setRecipient(String recipient) {
+        public void setRecipient(@Nullable String recipient) {
             this.recipient = recipient;
         }
 

--- a/control-panel-email/src/main/java/io/micronaut/controlpanel/panels/email/EmailControlPanelLoader.java
+++ b/control-panel-email/src/main/java/io/micronaut/controlpanel/panels/email/EmailControlPanelLoader.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.email;
+
+import io.micronaut.context.annotation.Context;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.controlpanel.core.ControlPanel;
+import io.micronaut.controlpanel.core.ControlPanelLoader;
+import io.micronaut.controlpanel.core.config.ControlPanelConfiguration;
+import jakarta.inject.Named;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Loads one email panel per stable sender name.
+ */
+@Context
+@Requires(beans = ControlPanelConfiguration.class)
+public class EmailControlPanelLoader implements ControlPanelLoader {
+
+    private final EmailSenderRegistry registry;
+    private final EmailDiagnosticsAnalyzer analyzer;
+    private final ControlPanelConfiguration configuration;
+
+    EmailControlPanelLoader(EmailSenderRegistry registry,
+                            EmailDiagnosticsAnalyzer analyzer,
+                            @Named(EmailControlPanel.NAME) ControlPanelConfiguration configuration) {
+        this.registry = registry;
+        this.analyzer = analyzer;
+        this.configuration = configuration;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <CP extends ControlPanel<?>> List<CP> loadControlPanels() {
+        List<EmailSenderDescriptor> descriptors = registry.descriptors();
+        if (descriptors.isEmpty()) {
+            return (List<CP>) List.of(new EmptyEmailControlPanel(analyzer, configuration));
+        }
+        List<EmailControlPanel> panels = new ArrayList<>();
+        for (EmailSenderDescriptor descriptor : descriptors) {
+            panels.add(new EmailControlPanel(descriptor, analyzer, configuration));
+        }
+        return (List<CP>) panels;
+    }
+}

--- a/control-panel-email/src/main/java/io/micronaut/controlpanel/panels/email/EmailControlPanelLoader.java
+++ b/control-panel-email/src/main/java/io/micronaut/controlpanel/panels/email/EmailControlPanelLoader.java
@@ -46,15 +46,15 @@ public class EmailControlPanelLoader implements ControlPanelLoader {
 
     @Override
     @SuppressWarnings("unchecked")
-    public <CP extends ControlPanel<?>> List<CP> loadControlPanels() {
+    public <T extends ControlPanel<?>> List<T> loadControlPanels() {
         List<EmailSenderDescriptor> descriptors = registry.descriptors();
         if (descriptors.isEmpty()) {
-            return (List<CP>) List.of(new EmptyEmailControlPanel(analyzer, configuration));
+            return (List<T>) List.of(new EmptyEmailControlPanel(analyzer, configuration));
         }
         List<EmailControlPanel> panels = new ArrayList<>();
         for (EmailSenderDescriptor descriptor : descriptors) {
             panels.add(new EmailControlPanel(descriptor, analyzer, configuration));
         }
-        return (List<CP>) panels;
+        return (List<T>) panels;
     }
 }

--- a/control-panel-email/src/main/java/io/micronaut/controlpanel/panels/email/EmailController.java
+++ b/control-panel-email/src/main/java/io/micronaut/controlpanel/panels/email/EmailController.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.email;
+
+import io.micronaut.controlpanel.core.security.ControlPanelSecurityPaths;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.email.Email;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.scheduling.TaskExecutors;
+import io.micronaut.scheduling.annotation.ExecuteOn;
+import io.micronaut.serde.annotation.Serdeable;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+
+import java.time.Instant;
+
+/**
+ * Guarded helper endpoint for controlled test sends.
+ */
+@Controller(ControlPanelSecurityPaths.EMAIL)
+@ExecuteOn(TaskExecutors.BLOCKING)
+@Internal
+public final class EmailController {
+
+    private static final Logger LOG = LoggerFactory.getLogger(EmailController.class);
+
+    private final EmailSenderRegistry registry;
+    private final EmailDiagnosticsAnalyzer analyzer;
+    private final EmailControlPanelConfiguration configuration;
+    private final EmailRedactor redactor;
+
+    EmailController(EmailSenderRegistry registry,
+                    EmailDiagnosticsAnalyzer analyzer,
+                    EmailControlPanelConfiguration configuration,
+                    EmailRedactor redactor) {
+        this.registry = registry;
+        this.analyzer = analyzer;
+        this.configuration = configuration;
+        this.redactor = redactor;
+    }
+
+    @Post("/{sender}/test-send")
+    public HttpResponse<TestSendResult> testSend(String sender, @Nullable @Body TestSendRequest request) {
+        long started = System.nanoTime();
+        var testSend = configuration.getTestSend();
+        if (!testSend.isEnabled()) {
+            return HttpResponse.badRequest(TestSendResult.disabled("Test send is disabled.", elapsed(started)));
+        }
+        String recipient = recipient(request);
+        if (StringUtils.isEmpty(recipient)) {
+            return HttpResponse.badRequest(TestSendResult.disabled("No safe test recipient is configured.", elapsed(started)));
+        }
+        if (request != null && StringUtils.isNotEmpty(request.recipient()) && !testSend.isAllowArbitraryRecipient()) {
+            return HttpResponse.badRequest(TestSendResult.disabled("Arbitrary recipients are disabled for test send.", elapsed(started)));
+        }
+        var descriptor = registry.find(sender);
+        if (descriptor.isEmpty()) {
+            return HttpResponse.notFound(TestSendResult.failure("Unknown sender.", "NotFound", elapsed(started)));
+        }
+        EmailDiagnosticModel diagnostics = analyzer.analyze(descriptor.get());
+        try {
+            send(descriptor.get(), recipient, diagnostics);
+            return HttpResponse.ok(TestSendResult.success("Test send completed.", elapsed(started)));
+        } catch (RuntimeException e) {
+            String message = redactor.redact(e.getMessage());
+            LOG.debug("Email test send failed for sender '{}': {} {}", sender, e.getClass().getName(), message);
+            return HttpResponse.serverError(TestSendResult.failure(message, e.getClass().getSimpleName(), elapsed(started)));
+        }
+    }
+
+    private String recipient(@Nullable TestSendRequest request) {
+        if (request != null && StringUtils.isNotEmpty(request.recipient()) && configuration.getTestSend().isAllowArbitraryRecipient()) {
+            return request.recipient();
+        }
+        return configuration.getTestSend().getRecipient();
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    private void send(EmailSenderDescriptor descriptor, String recipient, EmailDiagnosticModel diagnostics) {
+        String subjectPrefix = configuration.getTestSend().getSubjectPrefix();
+        if (StringUtils.isEmpty(subjectPrefix)) {
+            subjectPrefix = "[Micronaut Control Panel]";
+        }
+        String body = "Micronaut Control Panel email test\n"
+            + "Sender: " + diagnostics.senderName() + "\n"
+            + "Provider: " + diagnostics.provider() + "\n"
+            + "Timestamp: " + Instant.now() + "\n";
+        if (configuration.getTestSend().isIncludeConfigurationSummary()) {
+            body += "Default from: " + diagnostics.defaultFromStatus() + "\n";
+        }
+        Email.Builder builder = Email.builder()
+            .to(recipient)
+            .subject(subjectPrefix + " Email test")
+            .body(body);
+        if (descriptor.emailSender().isPresent()) {
+            descriptor.emailSender().get().send(builder);
+            return;
+        }
+        Email email = builder.build();
+        if (descriptor.transactionalEmailSender().isPresent()) {
+            descriptor.transactionalEmailSender().get().send(email);
+            return;
+        }
+        if (descriptor.asyncEmailSender().isPresent()) {
+            Mono.from(((io.micronaut.email.AsyncEmailSender) descriptor.asyncEmailSender().get()).sendAsync(builder)).block();
+            return;
+        }
+        if (descriptor.asyncTransactionalEmailSender().isPresent()) {
+            Mono.from(((io.micronaut.email.AsyncTransactionalEmailSender) descriptor.asyncTransactionalEmailSender().get()).sendAsync(email)).block();
+            return;
+        }
+        throw new IllegalStateException("No supported send path is available.");
+    }
+
+    private long elapsed(long started) {
+        return (System.nanoTime() - started) / 1_000_000;
+    }
+
+    /**
+     * Test send request body.
+     *
+     * @param recipient optional recipient, honored only when arbitrary recipients are enabled
+     */
+    @Introspected
+    @Serdeable.Deserializable
+    public record TestSendRequest(@Nullable String recipient) {
+    }
+
+    /**
+     * Test send result body.
+     *
+     * @param success whether the send completed
+     * @param status safe status label
+     * @param message redacted human-readable result message
+     * @param exception redacted exception class name for failed sends
+     * @param elapsedMillis elapsed send time in milliseconds
+     */
+    @Serdeable
+    @Introspected
+    public record TestSendResult(boolean success, String status, String message, @Nullable String exception, long elapsedMillis) {
+        static TestSendResult success(String message, long elapsedMillis) {
+            return new TestSendResult(true, "sent", message, null, elapsedMillis);
+        }
+
+        static TestSendResult disabled(String message, long elapsedMillis) {
+            return new TestSendResult(false, "unavailable", message, null, elapsedMillis);
+        }
+
+        static TestSendResult failure(String message, String exception, long elapsedMillis) {
+            return new TestSendResult(false, "failed", message, exception, elapsedMillis);
+        }
+    }
+}

--- a/control-panel-email/src/main/java/io/micronaut/controlpanel/panels/email/EmailController.java
+++ b/control-panel-email/src/main/java/io/micronaut/controlpanel/panels/email/EmailController.java
@@ -19,7 +19,11 @@ import io.micronaut.controlpanel.core.security.ControlPanelSecurityPaths;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.util.StringUtils;
+import io.micronaut.email.AsyncEmailSender;
+import io.micronaut.email.AsyncTransactionalEmailSender;
 import io.micronaut.email.Email;
+import io.micronaut.email.EmailSender;
+import io.micronaut.email.TransactionalEmailSender;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Controller;
@@ -66,13 +70,14 @@ public final class EmailController {
         if (!testSend.isEnabled()) {
             return HttpResponse.badRequest(TestSendResult.disabled("Test send is disabled.", elapsed(started)));
         }
-        String recipient = recipient(request);
-        if (StringUtils.isEmpty(recipient)) {
+        String configuredRecipient = testSend.getRecipient();
+        if (StringUtils.isEmpty(configuredRecipient)) {
             return HttpResponse.badRequest(TestSendResult.disabled("No safe test recipient is configured.", elapsed(started)));
         }
         if (request != null && StringUtils.isNotEmpty(request.recipient()) && !testSend.isAllowArbitraryRecipient()) {
             return HttpResponse.badRequest(TestSendResult.disabled("Arbitrary recipients are disabled for test send.", elapsed(started)));
         }
+        String recipient = recipient(request, configuredRecipient);
         var descriptor = registry.find(sender);
         if (descriptor.isEmpty()) {
             return HttpResponse.notFound(TestSendResult.failure("Unknown sender.", "NotFound", elapsed(started)));
@@ -88,14 +93,13 @@ public final class EmailController {
         }
     }
 
-    private String recipient(@Nullable TestSendRequest request) {
+    private String recipient(@Nullable TestSendRequest request, String configuredRecipient) {
         if (request != null && StringUtils.isNotEmpty(request.recipient()) && configuration.getTestSend().isAllowArbitraryRecipient()) {
             return request.recipient();
         }
-        return configuration.getTestSend().getRecipient();
+        return configuredRecipient;
     }
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
     private void send(EmailSenderDescriptor descriptor, String recipient, EmailDiagnosticModel diagnostics) {
         String subjectPrefix = configuration.getTestSend().getSubjectPrefix();
         if (StringUtils.isEmpty(subjectPrefix)) {
@@ -112,21 +116,25 @@ public final class EmailController {
             .to(recipient)
             .subject(subjectPrefix + " Email test")
             .body(body);
-        if (descriptor.emailSender().isPresent()) {
-            descriptor.emailSender().get().send(builder);
+        EmailSender<?, ?> emailSender = descriptor.emailSender().orElse(null);
+        if (emailSender != null) {
+            emailSender.send(builder);
             return;
         }
         Email email = builder.build();
-        if (descriptor.transactionalEmailSender().isPresent()) {
-            descriptor.transactionalEmailSender().get().send(email);
+        TransactionalEmailSender<?, ?> transactionalEmailSender = descriptor.transactionalEmailSender().orElse(null);
+        if (transactionalEmailSender != null) {
+            transactionalEmailSender.send(email);
             return;
         }
-        if (descriptor.asyncEmailSender().isPresent()) {
-            Mono.from(((io.micronaut.email.AsyncEmailSender) descriptor.asyncEmailSender().get()).sendAsync(builder)).block();
+        AsyncEmailSender<?, ?> asyncEmailSender = descriptor.asyncEmailSender().orElse(null);
+        if (asyncEmailSender != null) {
+            Mono.from(asyncEmailSender.sendAsync(builder)).block();
             return;
         }
-        if (descriptor.asyncTransactionalEmailSender().isPresent()) {
-            Mono.from(((io.micronaut.email.AsyncTransactionalEmailSender) descriptor.asyncTransactionalEmailSender().get()).sendAsync(email)).block();
+        AsyncTransactionalEmailSender<?, ?> asyncTransactionalEmailSender = descriptor.asyncTransactionalEmailSender().orElse(null);
+        if (asyncTransactionalEmailSender != null) {
+            Mono.from(asyncTransactionalEmailSender.sendAsync(email)).block();
             return;
         }
         throw new IllegalStateException("No supported send path is available.");

--- a/control-panel-email/src/main/java/io/micronaut/controlpanel/panels/email/EmailController.java
+++ b/control-panel-email/src/main/java/io/micronaut/controlpanel/panels/email/EmailController.java
@@ -87,7 +87,7 @@ public final class EmailController {
             send(descriptor.get(), recipient, diagnostics);
             return HttpResponse.ok(TestSendResult.success("Test send completed.", elapsed(started)));
         } catch (RuntimeException e) {
-            String message = redactor.redact(e.getMessage());
+            String message = redactor.redact(e.getMessage() == null ? "" : e.getMessage());
             LOG.debug("Email test send failed for sender '{}': {} {}", sender, e.getClass().getName(), message);
             return HttpResponse.serverError(TestSendResult.failure(message, e.getClass().getSimpleName(), elapsed(started)));
         }

--- a/control-panel-email/src/main/java/io/micronaut/controlpanel/panels/email/EmailDiagnosticModel.java
+++ b/control-panel-email/src/main/java/io/micronaut/controlpanel/panels/email/EmailDiagnosticModel.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.email;
+
+import io.micronaut.core.annotation.ReflectiveAccess;
+
+import java.util.List;
+
+@ReflectiveAccess
+record EmailDiagnosticModel(
+    String senderName,
+    String provider,
+    List<String> supportedInterfaces,
+    List<String> implementationTypes,
+    String defaultFromStatus,
+    String defaultFrom,
+    String templateSupportStatus,
+    List<ConfigurationEntry> configuration,
+    List<ChecklistItem> checklist,
+    TestSendState testSend,
+    boolean empty
+) {
+    boolean hasConfiguration() {
+        return !configuration.isEmpty();
+    }
+
+    boolean hasChecklist() {
+        return !checklist.isEmpty();
+    }
+
+    @ReflectiveAccess
+    record ConfigurationEntry(String label, String value, String status) { }
+
+    @ReflectiveAccess
+    record ChecklistItem(String label, String status, String message) { }
+
+    @ReflectiveAccess
+    record TestSendState(boolean enabled, boolean configured, boolean allowArbitraryRecipient, String status, String message) { }
+}

--- a/control-panel-email/src/main/java/io/micronaut/controlpanel/panels/email/EmailDiagnosticsAnalyzer.java
+++ b/control-panel-email/src/main/java/io/micronaut/controlpanel/panels/email/EmailDiagnosticsAnalyzer.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.email;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.env.Environment;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.email.configuration.FromConfiguration;
+import jakarta.inject.Singleton;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+@Internal
+@Singleton
+class EmailDiagnosticsAnalyzer {
+
+    private static final String DEFAULT_FROM_PROPERTY = "micronaut.email.from.email";
+
+    private final Environment environment;
+    private final BeanContext beanContext;
+    private final EmailControlPanelConfiguration configuration;
+    private final EmailRedactor redactor;
+
+    EmailDiagnosticsAnalyzer(Environment environment,
+                             BeanContext beanContext,
+                             EmailControlPanelConfiguration configuration,
+                             EmailRedactor redactor) {
+        this.environment = environment;
+        this.beanContext = beanContext;
+        this.configuration = configuration;
+        this.redactor = redactor;
+    }
+
+    EmailDiagnosticModel analyze(EmailSenderDescriptor descriptor) {
+        EmailProvider provider = detectProvider(descriptor);
+        List<EmailDiagnosticModel.ConfigurationEntry> entries = new ArrayList<>();
+        addProviderSettings(provider, entries);
+        DefaultFrom defaultFrom = defaultFrom();
+        boolean templatePresent = classPresent("io.micronaut.email.template.TemplateBody");
+        EmailDiagnosticModel.TestSendState testSend = testSendState();
+        List<EmailDiagnosticModel.ChecklistItem> checklist = new ArrayList<>();
+        checklist.add(new EmailDiagnosticModel.ChecklistItem("Sender bean", "available", "Sender bean is active."));
+        checklist.add(new EmailDiagnosticModel.ChecklistItem("Default from", defaultFrom.configured() ? "configured" : "missing", defaultFrom.message()));
+        checklist.add(new EmailDiagnosticModel.ChecklistItem("Secrets", "hidden", "Secret-like settings are shown only as presence indicators."));
+        checklist.add(new EmailDiagnosticModel.ChecklistItem("Templates", templatePresent ? "available" : "not available", templatePresent ? "Micronaut Email template support is on the classpath." : "Template support is not on the classpath."));
+        checklist.add(new EmailDiagnosticModel.ChecklistItem("Test send", testSend.configured() ? "configured" : "disabled", testSend.message()));
+        return new EmailDiagnosticModel(
+            descriptor.name(),
+            provider.label(),
+            descriptor.supportedInterfaces().stream().toList(),
+            descriptor.implementationTypes().stream().map(redactor::redact).sorted().toList(),
+            defaultFrom.configured() ? "configured" : "missing",
+            defaultFrom.value(),
+            templatePresent ? "present" : "not available",
+            entries,
+            checklist,
+            testSend,
+            false
+        );
+    }
+
+    EmailDiagnosticModel empty() {
+        return new EmailDiagnosticModel(
+            "no-senders",
+            "Custom/Unknown",
+            List.of(),
+            List.of(),
+            "missing",
+            "not configured",
+            classPresent("io.micronaut.email.template.TemplateBody") ? "present" : "not available",
+            List.of(),
+            List.of(
+                new EmailDiagnosticModel.ChecklistItem("Sender beans", "missing", "No Micronaut Email sender beans were detected."),
+                new EmailDiagnosticModel.ChecklistItem("Micronaut Email", "available", "Micronaut Email API is on the classpath."),
+                new EmailDiagnosticModel.ChecklistItem("Provider module", "not configured", "Add and configure a Micronaut Email provider module.")
+            ),
+            testSendState(),
+            true
+        );
+    }
+
+    EmailProvider detectProvider(EmailSenderDescriptor descriptor) {
+        String haystack = (descriptor.name() + " " + String.join(" ", descriptor.implementationTypes())).toLowerCase(Locale.ROOT);
+        if (haystack.contains("javamail") || haystack.contains("javaxmail") || haystack.contains("smtp")) {
+            return EmailProvider.JAVAMAIL;
+        }
+        if (haystack.contains("sendgrid")) {
+            return EmailProvider.SENDGRID;
+        }
+        if (haystack.contains("mailjet")) {
+            return EmailProvider.MAILJET;
+        }
+        if (haystack.contains("mailtrap")) {
+            return EmailProvider.MAILTRAP;
+        }
+        if (haystack.contains("postmark")) {
+            return EmailProvider.POSTMARK;
+        }
+        if (haystack.equals("ses") || haystack.startsWith("ses ") || haystack.contains(".ses") || haystack.contains("amazon") || haystack.contains("aws") || haystack.contains(" ses")) {
+            return EmailProvider.SES;
+        }
+        return EmailProvider.CUSTOM;
+    }
+
+    private void addProviderSettings(EmailProvider provider, List<EmailDiagnosticModel.ConfigurationEntry> entries) {
+        switch (provider) {
+            case JAVAMAIL -> {
+                addSafe(entries, "SMTP host", "javamail.properties.mail.smtp.host");
+                addSafe(entries, "SMTP port", "javamail.properties.mail.smtp.port");
+                addSafe(entries, "SMTP auth", "javamail.properties.mail.smtp.auth");
+                addSafe(entries, "SMTP startTLS", "javamail.properties.mail.smtp.starttls.enable");
+                addHiddenPresence(entries, "SMTP password", "javamail.properties.mail.smtp.password");
+            }
+            case SENDGRID -> addHiddenPresence(entries, "API key", "sendgrid.api-key");
+            case MAILJET -> {
+                addSafe(entries, "API version", "mailjet.version");
+                addHiddenPresence(entries, "API key", "mailjet.api-key");
+                addHiddenPresence(entries, "API secret", "mailjet.api-secret");
+            }
+            case MAILTRAP -> {
+                addSafe(entries, "API URL", "mailtrap.api-url");
+                addSafe(entries, "Inbox ID", "mailtrap.inbox-id");
+                addHiddenPresence(entries, "API token", "mailtrap.api-token");
+            }
+            case POSTMARK -> {
+                addSafe(entries, "Track opens", "postmark.track-opens");
+                addSafe(entries, "Track links", "postmark.track-links");
+                addHiddenPresence(entries, "Server token", "postmark.server-token");
+            }
+            case SES -> {
+                addSafe(entries, "Region", "aws.region");
+                addSafe(entries, "Endpoint override", "aws.services.ses.endpoint-override");
+                addHiddenPresence(entries, "Access key", "aws.access-key-id");
+                addHiddenPresence(entries, "Secret key", "aws.secret-access-key");
+            }
+            case CUSTOM -> {
+            }
+            default -> throw new IllegalStateException("Unknown email provider: " + provider);
+        }
+        entries.sort(Comparator.comparing(EmailDiagnosticModel.ConfigurationEntry::label));
+    }
+
+    private void addSafe(List<EmailDiagnosticModel.ConfigurationEntry> entries, String label, String key) {
+        Optional<Object> value = environment.getProperty(key, Object.class);
+        value.ifPresent(object -> entries.add(new EmailDiagnosticModel.ConfigurationEntry(label, redactor.safeValue(key, object), "configured")));
+    }
+
+    private void addHiddenPresence(List<EmailDiagnosticModel.ConfigurationEntry> entries, String label, String key) {
+        boolean configured = environment.containsProperty(key);
+        entries.add(new EmailDiagnosticModel.ConfigurationEntry(label, configured ? "present (hidden)" : "not configured", configured ? "hidden" : "missing"));
+    }
+
+    private DefaultFrom defaultFrom() {
+        Optional<String> property = environment.getProperty(DEFAULT_FROM_PROPERTY, String.class)
+            .filter(StringUtils::isNotEmpty);
+        if (property.isPresent()) {
+            return new DefaultFrom(true, redactor.redact(property.get()), "Default from is configured.");
+        }
+        Optional<FromConfiguration> fromConfiguration = beanContext.findBean(FromConfiguration.class);
+        if (fromConfiguration.isPresent() && fromConfiguration.get().getFrom() != null) {
+            return new DefaultFrom(true, redactor.redact(fromConfiguration.get().getFrom().getEmail()), "Default from configuration bean is available.");
+        }
+        return new DefaultFrom(false, "not configured", "No default from address was detected.");
+    }
+
+    private EmailDiagnosticModel.TestSendState testSendState() {
+        var testSend = configuration.getTestSend();
+        boolean hasRecipient = StringUtils.isNotEmpty(testSend.getRecipient());
+        boolean configured = testSend.isEnabled() && hasRecipient;
+        String status = configured ? "available" : "disabled";
+        String message;
+        if (!testSend.isEnabled()) {
+            message = "Test send is disabled.";
+        } else if (!hasRecipient) {
+            message = "Test send is enabled but no safe recipient is configured.";
+        } else {
+            message = "Test send will use the configured safe recipient.";
+        }
+        return new EmailDiagnosticModel.TestSendState(testSend.isEnabled(), configured, testSend.isAllowArbitraryRecipient(), status, message);
+    }
+
+    private boolean classPresent(String className) {
+        try {
+            Class.forName(className, false, beanContext.getClassLoader());
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
+    private record DefaultFrom(boolean configured, String value, String message) {
+    }
+}

--- a/control-panel-email/src/main/java/io/micronaut/controlpanel/panels/email/EmailDiagnosticsAnalyzer.java
+++ b/control-panel-email/src/main/java/io/micronaut/controlpanel/panels/email/EmailDiagnosticsAnalyzer.java
@@ -168,7 +168,7 @@ class EmailDiagnosticsAnalyzer {
 
     private void addSafe(List<EmailDiagnosticModel.ConfigurationEntry> entries, String label, String key) {
         Optional<Object> value = environment.getProperty(key, Object.class);
-        value.ifPresent(object -> entries.add(new EmailDiagnosticModel.ConfigurationEntry(label, redactor.safeValue(key, object), "configured")));
+        value.ifPresent(object -> entries.add(new EmailDiagnosticModel.ConfigurationEntry(label, redactor.safeValue(key, object), CONFIGURED)));
     }
 
     private void addHiddenPresence(List<EmailDiagnosticModel.ConfigurationEntry> entries, String label, String key) {

--- a/control-panel-email/src/main/java/io/micronaut/controlpanel/panels/email/EmailDiagnosticsAnalyzer.java
+++ b/control-panel-email/src/main/java/io/micronaut/controlpanel/panels/email/EmailDiagnosticsAnalyzer.java
@@ -33,6 +33,13 @@ import java.util.Optional;
 class EmailDiagnosticsAnalyzer {
 
     private static final String DEFAULT_FROM_PROPERTY = "micronaut.email.from.email";
+    private static final String AVAILABLE = "available";
+    private static final String CONFIGURED = "configured";
+    private static final String DISABLED = "disabled";
+    private static final String HIDDEN = "hidden";
+    private static final String MISSING = "missing";
+    private static final String NOT_AVAILABLE = "not available";
+    private static final String NOT_CONFIGURED = "not configured";
 
     private final Environment environment;
     private final BeanContext beanContext;
@@ -57,19 +64,19 @@ class EmailDiagnosticsAnalyzer {
         boolean templatePresent = classPresent("io.micronaut.email.template.TemplateBody");
         EmailDiagnosticModel.TestSendState testSend = testSendState();
         List<EmailDiagnosticModel.ChecklistItem> checklist = new ArrayList<>();
-        checklist.add(new EmailDiagnosticModel.ChecklistItem("Sender bean", "available", "Sender bean is active."));
-        checklist.add(new EmailDiagnosticModel.ChecklistItem("Default from", defaultFrom.configured() ? "configured" : "missing", defaultFrom.message()));
-        checklist.add(new EmailDiagnosticModel.ChecklistItem("Secrets", "hidden", "Secret-like settings are shown only as presence indicators."));
-        checklist.add(new EmailDiagnosticModel.ChecklistItem("Templates", templatePresent ? "available" : "not available", templatePresent ? "Micronaut Email template support is on the classpath." : "Template support is not on the classpath."));
-        checklist.add(new EmailDiagnosticModel.ChecklistItem("Test send", testSend.configured() ? "configured" : "disabled", testSend.message()));
+        checklist.add(new EmailDiagnosticModel.ChecklistItem("Sender bean", AVAILABLE, "Sender bean is active."));
+        checklist.add(new EmailDiagnosticModel.ChecklistItem("Default from", defaultFrom.configured() ? CONFIGURED : MISSING, defaultFrom.message()));
+        checklist.add(new EmailDiagnosticModel.ChecklistItem("Secrets", HIDDEN, "Secret-like settings are shown only as presence indicators."));
+        checklist.add(new EmailDiagnosticModel.ChecklistItem("Templates", templatePresent ? AVAILABLE : NOT_AVAILABLE, templatePresent ? "Micronaut Email template support is on the classpath." : "Template support is not on the classpath."));
+        checklist.add(new EmailDiagnosticModel.ChecklistItem("Test send", testSend.configured() ? CONFIGURED : DISABLED, testSend.message()));
         return new EmailDiagnosticModel(
             descriptor.name(),
             provider.label(),
             descriptor.supportedInterfaces().stream().toList(),
             descriptor.implementationTypes().stream().map(redactor::redact).sorted().toList(),
-            defaultFrom.configured() ? "configured" : "missing",
+            defaultFrom.configured() ? CONFIGURED : MISSING,
             defaultFrom.value(),
-            templatePresent ? "present" : "not available",
+            templatePresent ? "present" : NOT_AVAILABLE,
             entries,
             checklist,
             testSend,
@@ -83,14 +90,14 @@ class EmailDiagnosticsAnalyzer {
             "Custom/Unknown",
             List.of(),
             List.of(),
-            "missing",
-            "not configured",
-            classPresent("io.micronaut.email.template.TemplateBody") ? "present" : "not available",
+            MISSING,
+            NOT_CONFIGURED,
+            classPresent("io.micronaut.email.template.TemplateBody") ? "present" : NOT_AVAILABLE,
             List.of(),
             List.of(
-                new EmailDiagnosticModel.ChecklistItem("Sender beans", "missing", "No Micronaut Email sender beans were detected."),
-                new EmailDiagnosticModel.ChecklistItem("Micronaut Email", "available", "Micronaut Email API is on the classpath."),
-                new EmailDiagnosticModel.ChecklistItem("Provider module", "not configured", "Add and configure a Micronaut Email provider module.")
+                new EmailDiagnosticModel.ChecklistItem("Sender beans", MISSING, "No Micronaut Email sender beans were detected."),
+                new EmailDiagnosticModel.ChecklistItem("Micronaut Email", AVAILABLE, "Micronaut Email API is on the classpath."),
+                new EmailDiagnosticModel.ChecklistItem("Provider module", NOT_CONFIGURED, "Add and configure a Micronaut Email provider module.")
             ),
             testSendState(),
             true
@@ -152,6 +159,7 @@ class EmailDiagnosticsAnalyzer {
                 addHiddenPresence(entries, "Secret key", "aws.secret-access-key");
             }
             case CUSTOM -> {
+                // Custom senders have no provider-specific safe settings to display.
             }
             default -> throw new IllegalStateException("Unknown email provider: " + provider);
         }
@@ -165,7 +173,7 @@ class EmailDiagnosticsAnalyzer {
 
     private void addHiddenPresence(List<EmailDiagnosticModel.ConfigurationEntry> entries, String label, String key) {
         boolean configured = environment.containsProperty(key);
-        entries.add(new EmailDiagnosticModel.ConfigurationEntry(label, configured ? "present (hidden)" : "not configured", configured ? "hidden" : "missing"));
+        entries.add(new EmailDiagnosticModel.ConfigurationEntry(label, configured ? "present (hidden)" : NOT_CONFIGURED, configured ? HIDDEN : MISSING));
     }
 
     private DefaultFrom defaultFrom() {
@@ -175,17 +183,17 @@ class EmailDiagnosticsAnalyzer {
             return new DefaultFrom(true, redactor.redact(property.get()), "Default from is configured.");
         }
         Optional<FromConfiguration> fromConfiguration = beanContext.findBean(FromConfiguration.class);
-        if (fromConfiguration.isPresent() && fromConfiguration.get().getFrom() != null) {
+        if (fromConfiguration.isPresent()) {
             return new DefaultFrom(true, redactor.redact(fromConfiguration.get().getFrom().getEmail()), "Default from configuration bean is available.");
         }
-        return new DefaultFrom(false, "not configured", "No default from address was detected.");
+        return new DefaultFrom(false, NOT_CONFIGURED, "No default from address was detected.");
     }
 
     private EmailDiagnosticModel.TestSendState testSendState() {
         var testSend = configuration.getTestSend();
         boolean hasRecipient = StringUtils.isNotEmpty(testSend.getRecipient());
         boolean configured = testSend.isEnabled() && hasRecipient;
-        String status = configured ? "available" : "disabled";
+        String status = configured ? AVAILABLE : DISABLED;
         String message;
         if (!testSend.isEnabled()) {
             message = "Test send is disabled.";
@@ -201,7 +209,7 @@ class EmailDiagnosticsAnalyzer {
         try {
             Class.forName(className, false, beanContext.getClassLoader());
             return true;
-        } catch (ClassNotFoundException e) {
+        } catch (ClassNotFoundException _) {
             return false;
         }
     }

--- a/control-panel-email/src/main/java/io/micronaut/controlpanel/panels/email/EmailProvider.java
+++ b/control-panel-email/src/main/java/io/micronaut/controlpanel/panels/email/EmailProvider.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.email;
+
+/**
+ * Supported provider labels for diagnostics.
+ */
+enum EmailProvider {
+    JAVAMAIL("JavaMail/SMTP"),
+    SES("Amazon SES"),
+    SENDGRID("SendGrid"),
+    MAILJET("Mailjet"),
+    MAILTRAP("Mailtrap"),
+    POSTMARK("Postmark"),
+    CUSTOM("Custom/Unknown");
+
+    private final String label;
+
+    EmailProvider(String label) {
+        this.label = label;
+    }
+
+    String label() {
+        return label;
+    }
+}

--- a/control-panel-email/src/main/java/io/micronaut/controlpanel/panels/email/EmailRedactor.java
+++ b/control-panel-email/src/main/java/io/micronaut/controlpanel/panels/email/EmailRedactor.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.email;
+
+import io.micronaut.core.annotation.Internal;
+import jakarta.inject.Singleton;
+
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+/**
+ * Redacts secret-like email diagnostics values before they reach models or responses.
+ */
+@Internal
+@Singleton
+public final class EmailRedactor {
+
+    public static final String REDACTED = "[redacted]";
+
+    private static final Pattern URI_USERINFO = Pattern.compile("(?i)([a-z][a-z0-9+.-]*://)[^\\s/@:]+:[^\\s/@]+@");
+    private static final Pattern AUTH_HEADER = Pattern.compile("(?i)(authorization\\s*[:=]\\s*)(bearer|basic)\\s+[^\\s,;]+");
+    private static final Pattern AUTH_TOKEN = Pattern.compile("(?i)\\b(bearer|basic)\\s+[^\\s,;]+");
+    private static final Pattern KEY_VALUE = Pattern.compile("(?i)\\b(password|secret|token|api[-_]?key|api[-_]?secret|api[-_]?token|access[-_]?key|secret[-_]?key|private[-_]?key|credential|authorization)\\b\\s*[:= ]\\s*[^\\s,;]+");
+
+    boolean isSecretKey(String key) {
+        String normalized = key.toLowerCase(Locale.ROOT);
+        return normalized.contains("password")
+            || normalized.contains("secret")
+            || normalized.contains("token")
+            || normalized.contains("credential")
+            || normalized.contains("authorization")
+            || normalized.contains("api-key")
+            || normalized.contains("api.secret")
+            || normalized.contains("api-secret")
+            || normalized.contains("api.token")
+            || normalized.contains("api-token")
+            || normalized.contains("access-key")
+            || normalized.contains("secret-key")
+            || normalized.contains("private-key")
+            || normalized.endsWith(".key")
+            || normalized.endsWith("-key")
+            || normalized.endsWith("_key")
+            || normalized.contains(".api-key");
+    }
+
+    String safeValue(String key, Object value) {
+        if (value == null) {
+            return "not configured";
+        }
+        if (isSecretKey(key)) {
+            return "present (hidden)";
+        }
+        return redact(String.valueOf(value));
+    }
+
+    String redact(String value) {
+        if (value == null || value.isBlank()) {
+            return "";
+        }
+        String redacted = URI_USERINFO.matcher(value).replaceAll("$1" + REDACTED + "@");
+        redacted = AUTH_HEADER.matcher(redacted).replaceAll("$1" + REDACTED);
+        redacted = AUTH_TOKEN.matcher(redacted).replaceAll("$1 " + REDACTED);
+        redacted = KEY_VALUE.matcher(redacted).replaceAll("$1=" + REDACTED);
+        return redacted;
+    }
+}

--- a/control-panel-email/src/main/java/io/micronaut/controlpanel/panels/email/EmailRedactor.java
+++ b/control-panel-email/src/main/java/io/micronaut/controlpanel/panels/email/EmailRedactor.java
@@ -33,7 +33,6 @@ public final class EmailRedactor {
     private static final Pattern URI_USERINFO = Pattern.compile("(?i)([a-z][a-z0-9+.-]*://)[^\\s/@:]+:[^\\s/@]+@");
     private static final Pattern AUTH_HEADER = Pattern.compile("(?i)(authorization\\s*[:=]\\s*)(bearer|basic)\\s+[^\\s,;]+");
     private static final Pattern AUTH_TOKEN = Pattern.compile("(?i)\\b(bearer|basic)\\s+[^\\s,;]+");
-    private static final Pattern KEY_VALUE = Pattern.compile("(?i)\\b(password|secret|token|api[-_]?key|api[-_]?secret|api[-_]?token|access[-_]?key|secret[-_]?key|private[-_]?key|credential|authorization)\\b\\s*[:= ]\\s*[^\\s,;]+");
 
     boolean isSecretKey(String key) {
         String normalized = key.toLowerCase(Locale.ROOT);
@@ -73,7 +72,69 @@ public final class EmailRedactor {
         String redacted = URI_USERINFO.matcher(value).replaceAll("$1" + REDACTED + "@");
         redacted = AUTH_HEADER.matcher(redacted).replaceAll("$1" + REDACTED);
         redacted = AUTH_TOKEN.matcher(redacted).replaceAll("$1 " + REDACTED);
-        redacted = KEY_VALUE.matcher(redacted).replaceAll("$1=" + REDACTED);
-        return redacted;
+        return redactKeyValues(redacted);
+    }
+
+    private String redactKeyValues(String value) {
+        StringBuilder redacted = new StringBuilder(value.length());
+        int index = 0;
+        while (index < value.length()) {
+            char current = value.charAt(index);
+            if (!isKeyCharacter(current)) {
+                redacted.append(current);
+                index++;
+                continue;
+            }
+            int keyStart = index;
+            while (index < value.length() && isKeyCharacter(value.charAt(index))) {
+                index++;
+            }
+            String key = value.substring(keyStart, index);
+            if (isSecretMessageKey(key)) {
+                int valueStart = valueStart(value, index);
+                if (valueStart > index && valueStart < value.length() && !isValueDelimiter(value.charAt(valueStart))) {
+                    redacted.append(key).append('=').append(REDACTED);
+                    index = valueStart;
+                    while (index < value.length() && !isValueDelimiter(value.charAt(index))) {
+                        index++;
+                    }
+                    continue;
+                }
+            }
+            redacted.append(key);
+        }
+        return redacted.toString();
+    }
+
+    private boolean isSecretMessageKey(String key) {
+        String normalized = key.toLowerCase(Locale.ROOT);
+        return normalized.contains("password")
+            || normalized.contains("secret")
+            || normalized.contains("token")
+            || normalized.contains("credential")
+            || normalized.contains("authorization")
+            || normalized.contains("key");
+    }
+
+    private int valueStart(String value, int separatorStart) {
+        int index = separatorStart;
+        while (index < value.length() && Character.isWhitespace(value.charAt(index))) {
+            index++;
+        }
+        if (index < value.length() && (value.charAt(index) == ':' || value.charAt(index) == '=')) {
+            index++;
+            while (index < value.length() && Character.isWhitespace(value.charAt(index))) {
+                index++;
+            }
+        }
+        return index;
+    }
+
+    private boolean isKeyCharacter(char character) {
+        return Character.isLetterOrDigit(character) || character == '_' || character == '-' || character == '.';
+    }
+
+    private boolean isValueDelimiter(char character) {
+        return Character.isWhitespace(character) || character == ',' || character == ';';
     }
 }

--- a/control-panel-email/src/main/java/io/micronaut/controlpanel/panels/email/EmailRedactor.java
+++ b/control-panel-email/src/main/java/io/micronaut/controlpanel/panels/email/EmailRedactor.java
@@ -79,31 +79,48 @@ public final class EmailRedactor {
         StringBuilder redacted = new StringBuilder(value.length());
         int index = 0;
         while (index < value.length()) {
-            char current = value.charAt(index);
-            if (!isKeyCharacter(current)) {
-                redacted.append(current);
-                index++;
-                continue;
-            }
-            int keyStart = index;
-            while (index < value.length() && isKeyCharacter(value.charAt(index))) {
-                index++;
-            }
-            String key = value.substring(keyStart, index);
-            if (isSecretMessageKey(key)) {
-                int valueStart = valueStart(value, index);
-                if (valueStart > index && valueStart < value.length() && !isValueDelimiter(value.charAt(valueStart))) {
-                    redacted.append(key).append('=').append(REDACTED);
-                    index = valueStart;
-                    while (index < value.length() && !isValueDelimiter(value.charAt(index))) {
-                        index++;
-                    }
-                    continue;
-                }
-            }
-            redacted.append(key);
+            index = appendNextToken(value, index, redacted);
         }
         return redacted.toString();
+    }
+
+    private int appendNextToken(String value, int index, StringBuilder redacted) {
+        if (!isKeyCharacter(value.charAt(index))) {
+            redacted.append(value.charAt(index));
+            return index + 1;
+        }
+        int keyEnd = keyEnd(value, index);
+        String key = value.substring(index, keyEnd);
+        int valueStart = valueStart(value, keyEnd);
+        if (hasSecretValue(value, key, keyEnd, valueStart)) {
+            redacted.append(key).append('=').append(REDACTED);
+            return valueEnd(value, valueStart);
+        }
+        redacted.append(key);
+        return keyEnd;
+    }
+
+    private int keyEnd(String value, int keyStart) {
+        int index = keyStart;
+        while (index < value.length() && isKeyCharacter(value.charAt(index))) {
+            index++;
+        }
+        return index;
+    }
+
+    private boolean hasSecretValue(String value, String key, int keyEnd, int valueStart) {
+        return isSecretMessageKey(key)
+            && valueStart > keyEnd
+            && valueStart < value.length()
+            && !isValueDelimiter(value.charAt(valueStart));
+    }
+
+    private int valueEnd(String value, int valueStart) {
+        int index = valueStart;
+        while (index < value.length() && !isValueDelimiter(value.charAt(index))) {
+            index++;
+        }
+        return index;
     }
 
     private boolean isSecretMessageKey(String key) {

--- a/control-panel-email/src/main/java/io/micronaut/controlpanel/panels/email/EmailSenderDescriptor.java
+++ b/control-panel-email/src/main/java/io/micronaut/controlpanel/panels/email/EmailSenderDescriptor.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.email;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.email.AsyncEmailSender;
+import io.micronaut.email.AsyncTransactionalEmailSender;
+import io.micronaut.email.EmailSender;
+import io.micronaut.email.TransactionalEmailSender;
+
+import java.util.LinkedHashSet;
+import java.util.Optional;
+import java.util.Set;
+
+@Internal
+final class EmailSenderDescriptor {
+    private final String name;
+    private EmailSender<?, ?> emailSender;
+    private TransactionalEmailSender<?, ?> transactionalEmailSender;
+    private AsyncEmailSender<?, ?> asyncEmailSender;
+    private AsyncTransactionalEmailSender<?, ?> asyncTransactionalEmailSender;
+    private final Set<String> implementationTypes = new LinkedHashSet<>();
+
+    EmailSenderDescriptor(String name) {
+        this.name = name;
+    }
+
+    String name() {
+        return name;
+    }
+
+    Optional<EmailSender<?, ?>> emailSender() {
+        return Optional.ofNullable(emailSender);
+    }
+
+    Optional<TransactionalEmailSender<?, ?>> transactionalEmailSender() {
+        return Optional.ofNullable(transactionalEmailSender);
+    }
+
+    Optional<AsyncEmailSender<?, ?>> asyncEmailSender() {
+        return Optional.ofNullable(asyncEmailSender);
+    }
+
+    Optional<AsyncTransactionalEmailSender<?, ?>> asyncTransactionalEmailSender() {
+        return Optional.ofNullable(asyncTransactionalEmailSender);
+    }
+
+    Set<String> supportedInterfaces() {
+        Set<String> interfaces = new LinkedHashSet<>();
+        if (emailSender != null) {
+            interfaces.add("EmailSender");
+        }
+        if (transactionalEmailSender != null) {
+            interfaces.add("TransactionalEmailSender");
+        }
+        if (asyncEmailSender != null) {
+            interfaces.add("AsyncEmailSender");
+        }
+        if (asyncTransactionalEmailSender != null) {
+            interfaces.add("AsyncTransactionalEmailSender");
+        }
+        return interfaces;
+    }
+
+    Set<String> implementationTypes() {
+        return implementationTypes;
+    }
+
+    void addEmailSender(EmailSender<?, ?> sender) {
+        this.emailSender = sender;
+        implementationTypes.add(sender.getClass().getName());
+    }
+
+    void addTransactionalEmailSender(TransactionalEmailSender<?, ?> sender) {
+        this.transactionalEmailSender = sender;
+        implementationTypes.add(sender.getClass().getName());
+    }
+
+    void addAsyncEmailSender(AsyncEmailSender<?, ?> sender) {
+        this.asyncEmailSender = sender;
+        implementationTypes.add(sender.getClass().getName());
+    }
+
+    void addAsyncTransactionalEmailSender(AsyncTransactionalEmailSender<?, ?> sender) {
+        this.asyncTransactionalEmailSender = sender;
+        implementationTypes.add(sender.getClass().getName());
+    }
+}

--- a/control-panel-email/src/main/java/io/micronaut/controlpanel/panels/email/EmailSenderDescriptor.java
+++ b/control-panel-email/src/main/java/io/micronaut/controlpanel/panels/email/EmailSenderDescriptor.java
@@ -20,6 +20,7 @@ import io.micronaut.email.AsyncEmailSender;
 import io.micronaut.email.AsyncTransactionalEmailSender;
 import io.micronaut.email.EmailSender;
 import io.micronaut.email.TransactionalEmailSender;
+import org.jspecify.annotations.Nullable;
 
 import java.util.LinkedHashSet;
 import java.util.Optional;
@@ -28,10 +29,10 @@ import java.util.Set;
 @Internal
 final class EmailSenderDescriptor {
     private final String name;
-    private EmailSender<?, ?> emailSender;
-    private TransactionalEmailSender<?, ?> transactionalEmailSender;
-    private AsyncEmailSender<?, ?> asyncEmailSender;
-    private AsyncTransactionalEmailSender<?, ?> asyncTransactionalEmailSender;
+    private @Nullable EmailSender<?, ?> emailSender;
+    private @Nullable TransactionalEmailSender<?, ?> transactionalEmailSender;
+    private @Nullable AsyncEmailSender<?, ?> asyncEmailSender;
+    private @Nullable AsyncTransactionalEmailSender<?, ?> asyncTransactionalEmailSender;
     private final Set<String> implementationTypes = new LinkedHashSet<>();
 
     EmailSenderDescriptor(String name) {

--- a/control-panel-email/src/main/java/io/micronaut/controlpanel/panels/email/EmailSenderRegistry.java
+++ b/control-panel-email/src/main/java/io/micronaut/controlpanel/panels/email/EmailSenderRegistry.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.email;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.naming.Named;
+import io.micronaut.core.type.Argument;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.email.AsyncEmailSender;
+import io.micronaut.email.AsyncTransactionalEmailSender;
+import io.micronaut.email.EmailSender;
+import io.micronaut.email.TransactionalEmailSender;
+import jakarta.inject.Singleton;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TreeMap;
+
+@Internal
+@Singleton
+class EmailSenderRegistry {
+
+    @SuppressWarnings("unchecked")
+    private static final Argument<EmailSender<?, ?>> EMAIL_SENDER_ARGUMENT = (Argument<EmailSender<?, ?>>) (Argument<?>) Argument.of(EmailSender.class, Argument.ofTypeVariable(Object.class, "I"), Argument.ofTypeVariable(Object.class, "O"));
+    @SuppressWarnings("unchecked")
+    private static final Argument<TransactionalEmailSender<?, ?>> TRANSACTIONAL_EMAIL_SENDER_ARGUMENT = (Argument<TransactionalEmailSender<?, ?>>) (Argument<?>) Argument.of(TransactionalEmailSender.class, Argument.ofTypeVariable(Object.class, "I"), Argument.ofTypeVariable(Object.class, "O"));
+    @SuppressWarnings("unchecked")
+    private static final Argument<AsyncEmailSender<?, ?>> ASYNC_EMAIL_SENDER_ARGUMENT = (Argument<AsyncEmailSender<?, ?>>) (Argument<?>) Argument.of(AsyncEmailSender.class, Argument.ofTypeVariable(Object.class, "I"), Argument.ofTypeVariable(Object.class, "O"));
+    @SuppressWarnings("unchecked")
+    private static final Argument<AsyncTransactionalEmailSender<?, ?>> ASYNC_TRANSACTIONAL_EMAIL_SENDER_ARGUMENT = (Argument<AsyncTransactionalEmailSender<?, ?>>) (Argument<?>) Argument.of(AsyncTransactionalEmailSender.class, Argument.ofTypeVariable(Object.class, "I"), Argument.ofTypeVariable(Object.class, "O"));
+
+    private final BeanContext beanContext;
+
+    EmailSenderRegistry(BeanContext beanContext) {
+        this.beanContext = beanContext;
+    }
+
+    List<EmailSenderDescriptor> descriptors() {
+        Map<String, EmailSenderDescriptor> descriptors = new TreeMap<>();
+        beanContext.getBeanDefinitions(EMAIL_SENDER_ARGUMENT).forEach(beanDefinition -> {
+            EmailSender<?, ?> sender = beanContext.getBeanRegistration(beanDefinition).getBean();
+            descriptor(descriptors, beanDefinition.getName(), sender).addEmailSender(sender);
+        });
+        beanContext.getBeanDefinitions(TRANSACTIONAL_EMAIL_SENDER_ARGUMENT).forEach(beanDefinition -> {
+            TransactionalEmailSender<?, ?> sender = beanContext.getBeanRegistration(beanDefinition).getBean();
+            descriptor(descriptors, beanDefinition.getName(), sender).addTransactionalEmailSender(sender);
+        });
+        beanContext.getBeanDefinitions(ASYNC_EMAIL_SENDER_ARGUMENT).forEach(beanDefinition -> {
+            AsyncEmailSender<?, ?> sender = beanContext.getBeanRegistration(beanDefinition).getBean();
+            descriptor(descriptors, beanDefinition.getName(), sender).addAsyncEmailSender(sender);
+        });
+        beanContext.getBeanDefinitions(ASYNC_TRANSACTIONAL_EMAIL_SENDER_ARGUMENT).forEach(beanDefinition -> {
+            AsyncTransactionalEmailSender<?, ?> sender = beanContext.getBeanRegistration(beanDefinition).getBean();
+            descriptor(descriptors, beanDefinition.getName(), sender).addAsyncTransactionalEmailSender(sender);
+        });
+        return descriptors.values().stream().toList();
+    }
+
+    Optional<EmailSenderDescriptor> find(String senderName) {
+        return descriptors().stream()
+            .filter(descriptor -> descriptor.name().equals(senderName))
+            .findFirst();
+    }
+
+    private EmailSenderDescriptor descriptor(Map<String, EmailSenderDescriptor> descriptors, String beanName, Named sender) {
+        String senderName = sender.getName();
+        if (StringUtils.isEmpty(senderName)) {
+            senderName = beanName;
+        }
+        if (StringUtils.isEmpty(senderName)) {
+            senderName = "default";
+        }
+        return descriptors.computeIfAbsent(senderName, EmailSenderDescriptor::new);
+    }
+}

--- a/control-panel-email/src/main/java/io/micronaut/controlpanel/panels/email/EmptyEmailControlPanel.java
+++ b/control-panel-email/src/main/java/io/micronaut/controlpanel/panels/email/EmptyEmailControlPanel.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.email;
+
+import io.micronaut.controlpanel.core.AbstractControlPanel;
+import io.micronaut.controlpanel.core.ControlPanel;
+import io.micronaut.controlpanel.core.config.ControlPanelConfiguration;
+
+/**
+ * Empty-state panel shown when Micronaut Email is present but no senders are configured.
+ */
+final class EmptyEmailControlPanel extends AbstractControlPanel<EmailDiagnosticModel> {
+
+    private final EmailDiagnosticsAnalyzer analyzer;
+
+    EmptyEmailControlPanel(EmailDiagnosticsAnalyzer analyzer, ControlPanelConfiguration configuration) {
+        super(EmailControlPanel.NAME, configuration);
+        this.analyzer = analyzer;
+    }
+
+    @Override
+    public String getTitle() {
+        return "Email";
+    }
+
+    @Override
+    public EmailDiagnosticModel getBody() {
+        return analyzer.empty();
+    }
+
+    @Override
+    public View getBodyView() {
+        return new View("/views/email/body");
+    }
+
+    @Override
+    public View getDetailedView() {
+        return new View("/views/email/detail");
+    }
+
+    @Override
+    public ControlPanel.Category getCategory() {
+        return EmailControlPanel.CATEGORY;
+    }
+
+    @Override
+    public String getIcon() {
+        return EmailControlPanel.DEFAULT_ICON_CLASS;
+    }
+}

--- a/control-panel-email/src/main/java/io/micronaut/controlpanel/panels/email/package-info.java
+++ b/control-panel-email/src/main/java/io/micronaut/controlpanel/panels/email/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Email Control Panel classes.
+ */
+@Configuration
+@Requires(classes = EmailSender.class)
+@Requires(property = EmailControlPanel.ENABLED_PROPERTY, notEquals = StringUtils.FALSE)
+@Requires(condition = ControlPanelEnabledCondition.class)
+package io.micronaut.controlpanel.panels.email;
+
+import io.micronaut.context.annotation.Configuration;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.controlpanel.core.config.ControlPanelEnabledCondition;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.email.EmailSender;

--- a/control-panel-email/src/main/resources/micronaut-control-panel/micronaut-control-panel.properties
+++ b/control-panel-email/src/main/resources/micronaut-control-panel/micronaut-control-panel.properties
@@ -1,0 +1,3 @@
+micronaut.control-panel.panels.email.enabled = true
+micronaut.control-panel.panels.email.icon = fas fa-envelope
+micronaut.control-panel.panels.email.order = 30

--- a/control-panel-email/src/main/resources/views/email/body.hbs
+++ b/control-panel-email/src/main/resources/views/email/body.hbs
@@ -1,0 +1,19 @@
+{{#with controlPanel.body }}
+    {{#if empty}}
+        <p class="card-text">No Micronaut Email sender beans were detected.</p>
+        <p class="card-text"><span class="badge badge-secondary">No senders</span></p>
+    {{else}}
+        <p class="card-text">
+            <strong>Provider</strong>: <span class="badge badge-primary">{{provider}}</span>
+        </p>
+        <p class="card-text">
+            <strong>Sender</strong>: <code title="{{senderName}}">{{abbreviate senderName 40}}</code>
+        </p>
+        <p class="card-text">
+            <strong>Default From</strong>: <span class="badge badge-secondary">{{defaultFromStatus}}</span>
+        </p>
+        <p class="card-text">
+            <strong>Test send</strong>: <span class="badge badge-secondary">{{testSend.status}}</span>
+        </p>
+    {{/if}}
+{{/with}}

--- a/control-panel-email/src/main/resources/views/email/detail.hbs
+++ b/control-panel-email/src/main/resources/views/email/detail.hbs
@@ -1,0 +1,168 @@
+{{#with controlPanel.body }}
+    <div class="cp-dashboard-stack">
+        {{#if empty}}
+            <div class="card card-light">
+                <div class="card-header">
+                    <h3 class="card-title">Email</h3>
+                </div>
+                <div class="card-body">
+                    <div class="cp-data-table-empty">No Micronaut Email sender beans were detected.</div>
+                    <p>Add a Micronaut Email provider module and configure at least one sender to show diagnostics here.</p>
+                </div>
+            </div>
+        {{else}}
+            <div class="card card-light">
+                <div class="card-header">
+                    <h3 class="card-title">Overview</h3>
+                </div>
+                <div class="card-body">
+                    <dl class="row">
+                        <dt class="col-sm-3">Sender bean</dt>
+                        <dd class="col-sm-9"><code title="{{senderName}}">{{abbreviate senderName 70}}</code></dd>
+                        <dt class="col-sm-3">Provider</dt>
+                        <dd class="col-sm-9"><span class="badge badge-primary">{{provider}}</span></dd>
+                        <dt class="col-sm-3">Default From</dt>
+                        <dd class="col-sm-9">
+                            <span class="badge badge-secondary">{{defaultFromStatus}}</span>
+                            <code>{{defaultFrom}}</code>
+                        </dd>
+                        <dt class="col-sm-3">Templates</dt>
+                        <dd class="col-sm-9"><span class="badge badge-secondary">{{templateSupportStatus}}</span></dd>
+                        <dt class="col-sm-3">Supported interfaces</dt>
+                        <dd class="col-sm-9">
+                            {{#each supportedInterfaces as |senderInterface|}}
+                                <span class="badge badge-secondary">{{senderInterface}}</span>
+                            {{/each}}
+                        </dd>
+                    </dl>
+                </div>
+            </div>
+
+            <div class="card card-light">
+                <div class="card-header">
+                    <h3 class="card-title">Configuration</h3>
+                </div>
+                <div class="card-body">
+                    {{#if hasConfiguration}}
+                        <div class="cp-data-table">
+                            <div class="cp-data-table-container">
+                                <table class="table cp-data-table-table">
+                                    <thead>
+                                    <tr>
+                                        <th>Setting</th>
+                                        <th>Status</th>
+                                        <th>Value</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    {{#each configuration as |entry|}}
+                                        <tr>
+                                            <td>{{entry.label}}</td>
+                                            <td><span class="badge badge-secondary">{{entry.status}}</span></td>
+                                            <td><code title="{{entry.value}}">{{abbreviate entry.value 80}}</code></td>
+                                        </tr>
+                                    {{/each}}
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    {{else}}
+                        <div class="cp-data-table-empty">No provider-specific safe settings were detected.</div>
+                    {{/if}}
+                </div>
+            </div>
+        {{/if}}
+
+        <div class="card card-light">
+            <div class="card-header">
+                <h3 class="card-title">Checklist</h3>
+            </div>
+            <div class="card-body">
+                <div class="cp-data-table">
+                    <div class="cp-data-table-container">
+                        <table class="table cp-data-table-table">
+                            <thead>
+                            <tr>
+                                <th>Check</th>
+                                <th>Status</th>
+                                <th>Message</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            {{#each checklist as |item|}}
+                                <tr>
+                                    <td>{{item.label}}</td>
+                                    <td><span class="badge badge-secondary">{{item.status}}</span></td>
+                                    <td>{{item.message}}</td>
+                                </tr>
+                            {{/each}}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        {{#not empty}}
+            <div class="card card-light">
+                <div class="card-header">
+                    <h3 class="card-title">Test send</h3>
+                </div>
+                <div class="card-body">
+                    <p>
+                        <span class="badge badge-secondary">{{testSend.status}}</span>
+                        {{testSend.message}}
+                    </p>
+                    {{#if testSend.configured}}
+                        {{#if testSend.allowArbitraryRecipient}}
+                            <div class="form-group">
+                                <label for="emailTestRecipient">Recipient</label>
+                                <input id="emailTestRecipient" class="form-control" type="email" autocomplete="off">
+                            </div>
+                        {{/if}}
+                        <button type="button" class="btn btn-primary" id="emailTestSendButton">
+                            <i class="fas fa-paper-plane"></i>
+                            Send test email
+                        </button>
+                        <div id="emailTestSendResult" class="cp-data-table-empty" role="status" aria-live="polite">Not run.</div>
+                    {{/if}}
+                </div>
+            </div>
+
+            {{#if testSend.configured}}
+                <script>
+                    (function() {
+                        var button = document.getElementById('emailTestSendButton');
+                        var result = document.getElementById('emailTestSendResult');
+                        var recipient = document.getElementById('emailTestRecipient');
+                        if (!button || !result) return;
+                        button.addEventListener('click', function() {
+                            button.disabled = true;
+                            result.textContent = 'Sending...';
+                            var payload = {};
+                            if (recipient && recipient.value) {
+                                payload.recipient = recipient.value;
+                            }
+                            $.ajax({
+                                url: '{{ ext.controlPanelPath }}/email-control-panel-controller/{{senderName}}/test-send',
+                                type: 'POST',
+                                data: JSON.stringify(payload),
+                                contentType: 'application/json; charset=utf-8',
+                                success: function(response) {
+                                    result.textContent = response.status + ': ' + response.message + ' (' + response.elapsedMillis + ' ms)';
+                                },
+                                error: function(xhr) {
+                                    var response = xhr.responseJSON || {};
+                                    result.textContent = (response.status || 'failed') + ': ' + (response.message || 'Test send failed.');
+                                },
+                                complete: function() {
+                                    button.disabled = false;
+                                }
+                            });
+                        });
+                    })();
+                </script>
+            {{/if}}
+        {{/not}}
+    </div>
+{{/with}}

--- a/control-panel-email/src/test/java/io/micronaut/controlpanel/panels/email/EmailControlPanelLoaderTest.java
+++ b/control-panel-email/src/test/java/io/micronaut/controlpanel/panels/email/EmailControlPanelLoaderTest.java
@@ -41,6 +41,10 @@ class EmailControlPanelLoaderTest {
             assertEquals("javamail", body.senderName());
             assertTrue(body.supportedInterfaces().contains("EmailSender"));
             assertTrue(body.supportedInterfaces().contains("TransactionalEmailSender"));
+            assertEquals("Email: javamail", mockPanel.getTitle());
+            assertEquals("", mockPanel.getBadge());
+            assertEquals(EmailControlPanel.CATEGORY, mockPanel.getCategory());
+            assertEquals(EmailControlPanel.DEFAULT_ICON_CLASS, mockPanel.getIcon());
         }
     }
 
@@ -65,10 +69,37 @@ class EmailControlPanelLoaderTest {
             ControlPanelRepository repository = context.getBean(ControlPanelRepository.class);
 
             assertTrue(repository.findByName("email").isPresent());
-            EmailDiagnosticModel body = (EmailDiagnosticModel) repository.findByName("email").orElseThrow().getBody();
+            EmptyEmailControlPanel panel = (EmptyEmailControlPanel) repository.findByName("email").orElseThrow();
+            EmailDiagnosticModel body = panel.getBody();
             assertTrue(body.empty());
             assertEquals("no-senders", body.senderName());
+            assertFalse(body.hasConfiguration());
+            assertTrue(body.hasChecklist());
+            assertEquals("Email", panel.getTitle());
+            assertEquals("/views/email/body", panel.getBodyView().file());
+            assertEquals("/views/email/detail", panel.getDetailedView().file());
+            assertEquals(EmailControlPanel.CATEGORY, panel.getCategory());
+            assertEquals(EmailControlPanel.DEFAULT_ICON_CLASS, panel.getIcon());
         }
+    }
+
+    @Test
+    void configurationPropertiesAreMutable() {
+        EmailControlPanelConfiguration configuration = new EmailControlPanelConfiguration();
+        EmailControlPanelConfiguration.TestSendConfiguration testSend = new EmailControlPanelConfiguration.TestSendConfiguration();
+
+        testSend.setEnabled(true);
+        testSend.setRecipient("safe@example.test");
+        testSend.setSubjectPrefix("[Test]");
+        testSend.setAllowArbitraryRecipient(true);
+        testSend.setIncludeConfigurationSummary(true);
+        configuration.setTestSend(testSend);
+
+        assertTrue(configuration.getTestSend().isEnabled());
+        assertEquals("safe@example.test", configuration.getTestSend().getRecipient());
+        assertEquals("[Test]", configuration.getTestSend().getSubjectPrefix());
+        assertTrue(configuration.getTestSend().isAllowArbitraryRecipient());
+        assertTrue(configuration.getTestSend().isIncludeConfigurationSummary());
     }
 
     private static Map<String, Object> properties() {

--- a/control-panel-email/src/test/java/io/micronaut/controlpanel/panels/email/EmailControlPanelLoaderTest.java
+++ b/control-panel-email/src/test/java/io/micronaut/controlpanel/panels/email/EmailControlPanelLoaderTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.email;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.controlpanel.core.ControlPanelRepository;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EmailControlPanelLoaderTest {
+
+    @Test
+    void groupsDuplicateSenderInterfacesBySenderName() {
+        try (ApplicationContext context = ApplicationContext.run(properties())) {
+            ControlPanelRepository repository = context.getBean(ControlPanelRepository.class);
+
+            assertTrue(repository.findByName("email-javamail").isPresent());
+            assertTrue(repository.findByName("email-failing").isPresent());
+            assertEquals(2, repository.findAllByCategory(EmailControlPanel.NAME).size());
+            EmailControlPanel mockPanel = (EmailControlPanel) repository.findByName("email-javamail").orElseThrow();
+            EmailDiagnosticModel body = mockPanel.getBody();
+
+            assertEquals("javamail", body.senderName());
+            assertTrue(body.supportedInterfaces().contains("EmailSender"));
+            assertTrue(body.supportedInterfaces().contains("TransactionalEmailSender"));
+        }
+    }
+
+    @Test
+    void modelContainsOnlySafeConfigurationValues() {
+        try (ApplicationContext context = ApplicationContext.run(properties())) {
+            EmailControlPanel panel = (EmailControlPanel) context.getBean(ControlPanelRepository.class)
+                .findByName("email-javamail")
+                .orElseThrow();
+
+            String renderedModel = panel.getBody().toString();
+
+            assertTrue(renderedModel.contains("configured@example.test"));
+            assertTrue(renderedModel.contains("present (hidden)"));
+            assertFalse(renderedModel.contains("smtp-password"));
+        }
+    }
+
+    @Test
+    void emptyStatePanelIsAvailableWhenNoSendersExist() {
+        try (ApplicationContext context = ApplicationContext.run(Map.of("spec.name", "email-empty"))) {
+            ControlPanelRepository repository = context.getBean(ControlPanelRepository.class);
+
+            assertTrue(repository.findByName("email").isPresent());
+            EmailDiagnosticModel body = (EmailDiagnosticModel) repository.findByName("email").orElseThrow().getBody();
+            assertTrue(body.empty());
+            assertEquals("no-senders", body.senderName());
+        }
+    }
+
+    private static Map<String, Object> properties() {
+        return Map.of(
+            "spec.name", "email-control-panel",
+            "micronaut.email.from.email", "configured@example.test",
+            "javamail.properties.mail.smtp.host", "localhost",
+            "javamail.properties.mail.smtp.password", "smtp-password",
+            "micronaut.control-panel.email.test-send.enabled", true,
+            "micronaut.control-panel.email.test-send.recipient", "safe@example.test"
+        );
+    }
+}

--- a/control-panel-email/src/test/java/io/micronaut/controlpanel/panels/email/EmailControllerTest.java
+++ b/control-panel-email/src/test/java/io/micronaut/controlpanel/panels/email/EmailControllerTest.java
@@ -34,12 +34,11 @@ class EmailControllerTest {
 
     @Test
     void disabledTestSendDoesNotInvokeSender() {
-        EmailTestFactory.MOCK.invocations();
         try (EmbeddedServer server = ApplicationContext.run(EmbeddedServer.class, baseProperties(false, null, false));
              HttpClient client = server.getApplicationContext().createBean(HttpClient.class, server.getURL())) {
             int before = EmailTestFactory.MOCK.invocations();
             HttpClientResponseException exception = assertThrows(HttpClientResponseException.class, () ->
-                client.toBlocking().exchange(HttpRequest.POST("/control-panel/email-control-panel-controller/javamail/test-send", Map.of()), EmailController.TestSendResult.class));
+                post(client, "javamail", Map.of()));
 
             assertEquals(HttpStatus.BAD_REQUEST, exception.getStatus());
             assertEquals(before, EmailTestFactory.MOCK.invocations());
@@ -65,9 +64,47 @@ class EmailControllerTest {
         try (EmbeddedServer server = ApplicationContext.run(EmbeddedServer.class, baseProperties(true, "safe@example.test", false));
              HttpClient client = server.getApplicationContext().createBean(HttpClient.class, server.getURL())) {
             HttpClientResponseException exception = assertThrows(HttpClientResponseException.class, () ->
-                client.toBlocking().exchange(HttpRequest.POST("/control-panel/email-control-panel-controller/javamail/test-send", Map.of("recipient", "other@example.test")), EmailController.TestSendResult.class));
+                post(client, "javamail", Map.of("recipient", "other@example.test")));
 
             assertEquals(HttpStatus.BAD_REQUEST, exception.getStatus());
+        }
+    }
+
+    @Test
+    void arbitraryRecipientRequiresConfiguredSafeRecipient() {
+        try (EmbeddedServer server = ApplicationContext.run(EmbeddedServer.class, baseProperties(true, "", true));
+             HttpClient client = server.getApplicationContext().createBean(HttpClient.class, server.getURL())) {
+            int before = EmailTestFactory.MOCK.invocations();
+            HttpClientResponseException exception = assertThrows(HttpClientResponseException.class, () ->
+                post(client, "javamail", Map.of("recipient", "other@example.test")));
+
+            assertEquals(HttpStatus.BAD_REQUEST, exception.getStatus());
+            assertEquals(before, EmailTestFactory.MOCK.invocations());
+        }
+    }
+
+    @Test
+    void arbitraryRecipientIsAcceptedWhenSafeRecipientIsConfigured() {
+        try (EmbeddedServer server = ApplicationContext.run(EmbeddedServer.class, baseProperties(true, "safe@example.test", true));
+             HttpClient client = server.getApplicationContext().createBean(HttpClient.class, server.getURL())) {
+            EmailController.TestSendResult result = client.toBlocking().retrieve(
+                HttpRequest.POST("/control-panel/email-control-panel-controller/javamail/test-send", Map.of("recipient", "other@example.test")),
+                EmailController.TestSendResult.class
+            );
+
+            assertTrue(result.success());
+            assertEquals("sent", result.status());
+        }
+    }
+
+    @Test
+    void unknownSenderIsNotFound() {
+        try (EmbeddedServer server = ApplicationContext.run(EmbeddedServer.class, baseProperties(true, "safe@example.test", false));
+             HttpClient client = server.getApplicationContext().createBean(HttpClient.class, server.getURL())) {
+            HttpClientResponseException exception = assertThrows(HttpClientResponseException.class, () ->
+                post(client, "missing", Map.of()));
+
+            assertEquals(HttpStatus.NOT_FOUND, exception.getStatus());
         }
     }
 
@@ -76,7 +113,7 @@ class EmailControllerTest {
         try (EmbeddedServer server = ApplicationContext.run(EmbeddedServer.class, baseProperties(true, "safe@example.test", false));
              HttpClient client = server.getApplicationContext().createBean(HttpClient.class, server.getURL())) {
             HttpClientResponseException exception = assertThrows(HttpClientResponseException.class, () ->
-                client.toBlocking().exchange(HttpRequest.POST("/control-panel/email-control-panel-controller/failing/test-send", Map.of()), EmailController.TestSendResult.class));
+                post(client, "failing", Map.of()));
 
             EmailController.TestSendResult result = exception.getResponse().getBody(EmailController.TestSendResult.class).orElseThrow();
             assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, exception.getStatus());
@@ -94,6 +131,13 @@ class EmailControllerTest {
             "micronaut.control-panel.email.test-send.enabled", enabled,
             "micronaut.control-panel.email.test-send.recipient", recipient == null ? "" : recipient,
             "micronaut.control-panel.email.test-send.allow-arbitrary-recipient", arbitrary
+        );
+    }
+
+    private static void post(HttpClient client, String sender, Map<String, Object> body) {
+        client.toBlocking().exchange(
+            HttpRequest.POST("/control-panel/email-control-panel-controller/" + sender + "/test-send", body),
+            EmailController.TestSendResult.class
         );
     }
 }

--- a/control-panel-email/src/test/java/io/micronaut/controlpanel/panels/email/EmailControllerTest.java
+++ b/control-panel-email/src/test/java/io/micronaut/controlpanel/panels/email/EmailControllerTest.java
@@ -17,6 +17,8 @@ package io.micronaut.controlpanel.panels.email;
 
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpStatus;
+import io.micronaut.http.MutableHttpRequest;
+import io.micronaut.http.client.BlockingHttpClient;
 import io.micronaut.http.client.HttpClient;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
 import io.micronaut.context.ApplicationContext;
@@ -37,8 +39,7 @@ class EmailControllerTest {
         try (EmbeddedServer server = ApplicationContext.run(EmbeddedServer.class, baseProperties(false, null, false));
              HttpClient client = server.getApplicationContext().createBean(HttpClient.class, server.getURL())) {
             int before = EmailTestFactory.MOCK.invocations();
-            HttpClientResponseException exception = assertThrows(HttpClientResponseException.class, () ->
-                post(client, "javamail", Map.of()));
+            HttpClientResponseException exception = postFailure(client, "javamail", Map.of());
 
             assertEquals(HttpStatus.BAD_REQUEST, exception.getStatus());
             assertEquals(before, EmailTestFactory.MOCK.invocations());
@@ -63,8 +64,7 @@ class EmailControllerTest {
     void arbitraryRecipientIsRejectedByDefault() {
         try (EmbeddedServer server = ApplicationContext.run(EmbeddedServer.class, baseProperties(true, "safe@example.test", false));
              HttpClient client = server.getApplicationContext().createBean(HttpClient.class, server.getURL())) {
-            HttpClientResponseException exception = assertThrows(HttpClientResponseException.class, () ->
-                post(client, "javamail", Map.of("recipient", "other@example.test")));
+            HttpClientResponseException exception = postFailure(client, "javamail", Map.of("recipient", "other@example.test"));
 
             assertEquals(HttpStatus.BAD_REQUEST, exception.getStatus());
         }
@@ -75,8 +75,7 @@ class EmailControllerTest {
         try (EmbeddedServer server = ApplicationContext.run(EmbeddedServer.class, baseProperties(true, "", true));
              HttpClient client = server.getApplicationContext().createBean(HttpClient.class, server.getURL())) {
             int before = EmailTestFactory.MOCK.invocations();
-            HttpClientResponseException exception = assertThrows(HttpClientResponseException.class, () ->
-                post(client, "javamail", Map.of("recipient", "other@example.test")));
+            HttpClientResponseException exception = postFailure(client, "javamail", Map.of("recipient", "other@example.test"));
 
             assertEquals(HttpStatus.BAD_REQUEST, exception.getStatus());
             assertEquals(before, EmailTestFactory.MOCK.invocations());
@@ -101,8 +100,7 @@ class EmailControllerTest {
     void unknownSenderIsNotFound() {
         try (EmbeddedServer server = ApplicationContext.run(EmbeddedServer.class, baseProperties(true, "safe@example.test", false));
              HttpClient client = server.getApplicationContext().createBean(HttpClient.class, server.getURL())) {
-            HttpClientResponseException exception = assertThrows(HttpClientResponseException.class, () ->
-                post(client, "missing", Map.of()));
+            HttpClientResponseException exception = postFailure(client, "missing", Map.of());
 
             assertEquals(HttpStatus.NOT_FOUND, exception.getStatus());
         }
@@ -112,8 +110,7 @@ class EmailControllerTest {
     void failureResponseIsRedacted() {
         try (EmbeddedServer server = ApplicationContext.run(EmbeddedServer.class, baseProperties(true, "safe@example.test", false));
              HttpClient client = server.getApplicationContext().createBean(HttpClient.class, server.getURL())) {
-            HttpClientResponseException exception = assertThrows(HttpClientResponseException.class, () ->
-                post(client, "failing", Map.of()));
+            HttpClientResponseException exception = postFailure(client, "failing", Map.of());
 
             EmailController.TestSendResult result = exception.getResponse().getBody(EmailController.TestSendResult.class).orElseThrow();
             assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, exception.getStatus());
@@ -134,10 +131,9 @@ class EmailControllerTest {
         );
     }
 
-    private static void post(HttpClient client, String sender, Map<String, Object> body) {
-        client.toBlocking().exchange(
-            HttpRequest.POST("/control-panel/email-control-panel-controller/" + sender + "/test-send", body),
-            EmailController.TestSendResult.class
-        );
+    private static HttpClientResponseException postFailure(HttpClient client, String sender, Map<String, Object> body) {
+        BlockingHttpClient blockingClient = client.toBlocking();
+        MutableHttpRequest<Map<String, Object>> request = HttpRequest.POST("/control-panel/email-control-panel-controller/" + sender + "/test-send", body);
+        return assertThrows(HttpClientResponseException.class, () -> blockingClient.exchange(request, EmailController.TestSendResult.class));
     }
 }

--- a/control-panel-email/src/test/java/io/micronaut/controlpanel/panels/email/EmailControllerTest.java
+++ b/control-panel-email/src/test/java/io/micronaut/controlpanel/panels/email/EmailControllerTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.email;
+
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.exceptions.HttpClientResponseException;
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.runtime.server.EmbeddedServer;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EmailControllerTest {
+
+    @Test
+    void disabledTestSendDoesNotInvokeSender() {
+        EmailTestFactory.MOCK.invocations();
+        try (EmbeddedServer server = ApplicationContext.run(EmbeddedServer.class, baseProperties(false, null, false));
+             HttpClient client = server.getApplicationContext().createBean(HttpClient.class, server.getURL())) {
+            int before = EmailTestFactory.MOCK.invocations();
+            HttpClientResponseException exception = assertThrows(HttpClientResponseException.class, () ->
+                client.toBlocking().exchange(HttpRequest.POST("/control-panel/email-control-panel-controller/javamail/test-send", Map.of()), EmailController.TestSendResult.class));
+
+            assertEquals(HttpStatus.BAD_REQUEST, exception.getStatus());
+            assertEquals(before, EmailTestFactory.MOCK.invocations());
+        }
+    }
+
+    @Test
+    void enabledTestSendSucceeds() {
+        try (EmbeddedServer server = ApplicationContext.run(EmbeddedServer.class, baseProperties(true, "safe@example.test", false));
+             HttpClient client = server.getApplicationContext().createBean(HttpClient.class, server.getURL())) {
+            EmailController.TestSendResult result = client.toBlocking().retrieve(
+                HttpRequest.POST("/control-panel/email-control-panel-controller/javamail/test-send", Map.of()),
+                EmailController.TestSendResult.class
+            );
+
+            assertTrue(result.success());
+            assertEquals("sent", result.status());
+        }
+    }
+
+    @Test
+    void arbitraryRecipientIsRejectedByDefault() {
+        try (EmbeddedServer server = ApplicationContext.run(EmbeddedServer.class, baseProperties(true, "safe@example.test", false));
+             HttpClient client = server.getApplicationContext().createBean(HttpClient.class, server.getURL())) {
+            HttpClientResponseException exception = assertThrows(HttpClientResponseException.class, () ->
+                client.toBlocking().exchange(HttpRequest.POST("/control-panel/email-control-panel-controller/javamail/test-send", Map.of("recipient", "other@example.test")), EmailController.TestSendResult.class));
+
+            assertEquals(HttpStatus.BAD_REQUEST, exception.getStatus());
+        }
+    }
+
+    @Test
+    void failureResponseIsRedacted() {
+        try (EmbeddedServer server = ApplicationContext.run(EmbeddedServer.class, baseProperties(true, "safe@example.test", false));
+             HttpClient client = server.getApplicationContext().createBean(HttpClient.class, server.getURL())) {
+            HttpClientResponseException exception = assertThrows(HttpClientResponseException.class, () ->
+                client.toBlocking().exchange(HttpRequest.POST("/control-panel/email-control-panel-controller/failing/test-send", Map.of()), EmailController.TestSendResult.class));
+
+            EmailController.TestSendResult result = exception.getResponse().getBody(EmailController.TestSendResult.class).orElseThrow();
+            assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, exception.getStatus());
+            assertEquals("failed", result.status());
+            assertFalse(result.message().contains("SG.secret"));
+            assertFalse(result.message().contains("abc123"));
+            assertTrue(result.message().contains(EmailRedactor.REDACTED));
+        }
+    }
+
+    private static Map<String, Object> baseProperties(boolean enabled, String recipient, boolean arbitrary) {
+        return Map.of(
+            "spec.name", "email-control-panel",
+            "micronaut.email.from.email", "configured@example.test",
+            "micronaut.control-panel.email.test-send.enabled", enabled,
+            "micronaut.control-panel.email.test-send.recipient", recipient == null ? "" : recipient,
+            "micronaut.control-panel.email.test-send.allow-arbitrary-recipient", arbitrary
+        );
+    }
+}

--- a/control-panel-email/src/test/java/io/micronaut/controlpanel/panels/email/EmailProviderDetectionTest.java
+++ b/control-panel-email/src/test/java/io/micronaut/controlpanel/panels/email/EmailProviderDetectionTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.email;
+
+import io.micronaut.context.ApplicationContext;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class EmailProviderDetectionTest {
+
+    @Test
+    void detectsKnownProviderNames() {
+        try (ApplicationContext context = ApplicationContext.run(Map.of("spec.name", "email-provider-detection"))) {
+            EmailDiagnosticsAnalyzer analyzer = context.getBean(EmailDiagnosticsAnalyzer.class);
+
+            assertEquals(EmailProvider.JAVAMAIL, analyzer.detectProvider(descriptor("javamail")));
+            assertEquals(EmailProvider.JAVAMAIL, analyzer.detectProvider(descriptor("javaxmail")));
+            assertEquals(EmailProvider.SES, analyzer.detectProvider(descriptor("ses")));
+            assertEquals(EmailProvider.SENDGRID, analyzer.detectProvider(descriptor("sendgrid")));
+            assertEquals(EmailProvider.MAILJET, analyzer.detectProvider(descriptor("mailjet")));
+            assertEquals(EmailProvider.MAILTRAP, analyzer.detectProvider(descriptor("mailtrap")));
+            assertEquals(EmailProvider.POSTMARK, analyzer.detectProvider(descriptor("postmark")));
+            assertEquals(EmailProvider.CUSTOM, analyzer.detectProvider(descriptor("custom")));
+        }
+    }
+
+    private static EmailSenderDescriptor descriptor(String name) {
+        return new EmailSenderDescriptor(name);
+    }
+}

--- a/control-panel-email/src/test/java/io/micronaut/controlpanel/panels/email/EmailProviderDetectionTest.java
+++ b/control-panel-email/src/test/java/io/micronaut/controlpanel/panels/email/EmailProviderDetectionTest.java
@@ -18,9 +18,12 @@ package io.micronaut.controlpanel.panels.email;
 import io.micronaut.context.ApplicationContext;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class EmailProviderDetectionTest {
 
@@ -40,7 +43,58 @@ class EmailProviderDetectionTest {
         }
     }
 
+    @Test
+    void analyzesSafeProviderConfiguration() {
+        Map<String, Object> properties = Map.ofEntries(
+            Map.entry("spec.name", "email-provider-detection"),
+            Map.entry("micronaut.email.from.email", "configured@example.test"),
+            Map.entry("micronaut.control-panel.email.test-send.enabled", true),
+            Map.entry("micronaut.control-panel.email.test-send.recipient", "safe@example.test"),
+            Map.entry("javamail.properties.mail.smtp.host", "localhost"),
+            Map.entry("javamail.properties.mail.smtp.port", 1025),
+            Map.entry("javamail.properties.mail.smtp.password", "smtp-secret"),
+            Map.entry("sendgrid.api-key", "SG.secret"),
+            Map.entry("mailjet.version", "v3.1"),
+            Map.entry("mailjet.api-key", "mj-key"),
+            Map.entry("mailjet.api-secret", "mj-secret"),
+            Map.entry("mailtrap.api-url", "http://localhost:8025"),
+            Map.entry("mailtrap.inbox-id", "123"),
+            Map.entry("mailtrap.api-token", "mt-secret"),
+            Map.entry("postmark.track-opens", true),
+            Map.entry("postmark.server-token", "pm-secret"),
+            Map.entry("aws.region", "us-east-1"),
+            Map.entry("aws.access-key-id", "AKIA-secret"),
+            Map.entry("aws.secret-access-key", "aws-secret")
+        );
+        try (ApplicationContext context = ApplicationContext.run(properties)) {
+            EmailDiagnosticsAnalyzer analyzer = context.getBean(EmailDiagnosticsAnalyzer.class);
+
+            assertEntry(analyzer.analyze(descriptor("javamail")).configuration(), "SMTP host", "localhost", "configured");
+            assertEntry(analyzer.analyze(descriptor("sendgrid")).configuration(), "API key", "present (hidden)", "hidden");
+            assertEntry(analyzer.analyze(descriptor("mailjet")).configuration(), "API version", "v3.1", "configured");
+            assertEntry(analyzer.analyze(descriptor("mailtrap")).configuration(), "API URL", "http://localhost:8025", "configured");
+            assertEntry(analyzer.analyze(descriptor("postmark")).configuration(), "Track opens", "true", "configured");
+            assertEntry(analyzer.analyze(descriptor("ses")).configuration(), "Region", "us-east-1", "configured");
+
+            EmailDiagnosticModel custom = analyzer.analyze(descriptor("custom"));
+            assertTrue(custom.configuration().isEmpty());
+            assertEquals("configured", custom.defaultFromStatus());
+            assertTrue(custom.testSend().configured());
+            assertFalse(custom.toString().contains("smtp-secret"));
+            assertFalse(custom.toString().contains("SG.secret"));
+        }
+    }
+
     private static EmailSenderDescriptor descriptor(String name) {
         return new EmailSenderDescriptor(name);
+    }
+
+    private static void assertEntry(List<EmailDiagnosticModel.ConfigurationEntry> entries, String label, String value, String status) {
+        EmailDiagnosticModel.ConfigurationEntry entry = entries.stream()
+            .filter(candidate -> candidate.label().equals(label))
+            .findFirst()
+            .orElseThrow();
+        assertEquals(value, entry.value());
+        assertEquals(status, entry.status());
     }
 }

--- a/control-panel-email/src/test/java/io/micronaut/controlpanel/panels/email/EmailRedactorTest.java
+++ b/control-panel-email/src/test/java/io/micronaut/controlpanel/panels/email/EmailRedactorTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.email;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EmailRedactorTest {
+
+    private final EmailRedactor redactor = new EmailRedactor();
+
+    @Test
+    void redactsSecretKeys() {
+        assertTrue(redactor.isSecretKey("sendgrid.api-key"));
+        assertTrue(redactor.isSecretKey("mailtrap.api-token"));
+        assertTrue(redactor.isSecretKey("aws.secret-access-key"));
+        assertFalse(redactor.isSecretKey("javamail.properties.mail.smtp.host"));
+        assertEquals("present (hidden)", redactor.safeValue("mailtrap.api-token", "mt-secret"));
+    }
+
+    @Test
+    void redactsSecretFragmentsFromMessages() {
+        String redacted = redactor.redact("smtp://user:password@smtp.example token abc123 Authorization: Bearer abc apiKey=SG.secret password: guess");
+
+        assertFalse(redacted.contains("password@smtp"));
+        assertFalse(redacted.contains("abc123"));
+        assertFalse(redacted.contains("SG.secret"));
+        assertFalse(redacted.contains("guess"));
+        assertTrue(redacted.contains(EmailRedactor.REDACTED));
+    }
+}

--- a/control-panel-email/src/test/java/io/micronaut/controlpanel/panels/email/EmailTestFactory.java
+++ b/control-panel-email/src/test/java/io/micronaut/controlpanel/panels/email/EmailTestFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.email;
+
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+@Factory
+@Requires(property = "spec.name", value = "email-control-panel")
+class EmailTestFactory {
+
+    static final TestEmailSender MOCK = new TestEmailSender("javamail", false);
+    static final TestEmailSender FAILING = new TestEmailSender("failing", true);
+
+    @Singleton
+    @Named("mock")
+    TestEmailSender mockSender() {
+        return MOCK;
+    }
+
+    @Singleton
+    @Named("failing")
+    TestEmailSender failingSender() {
+        return FAILING;
+    }
+}

--- a/control-panel-email/src/test/java/io/micronaut/controlpanel/panels/email/TestEmailSender.java
+++ b/control-panel-email/src/test/java/io/micronaut/controlpanel/panels/email/TestEmailSender.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.email;
+
+import io.micronaut.email.Email;
+import io.micronaut.email.EmailException;
+import io.micronaut.email.EmailSender;
+import io.micronaut.email.TransactionalEmailSender;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+final class TestEmailSender implements EmailSender<Object, Object>, TransactionalEmailSender<Object, Object> {
+
+    private final String name;
+    private final boolean fail;
+    private final AtomicInteger invocations = new AtomicInteger();
+
+    TestEmailSender(String name, boolean fail) {
+        this.name = name;
+        this.fail = fail;
+    }
+
+    @Override
+    public Object send(Email.Builder builder, Consumer<Object> requestCustomizer) throws EmailException {
+        invocations.incrementAndGet();
+        if (fail) {
+            throw new EmailException("provider rejected apiKey=SG.secret token abc123");
+        }
+        return new Object();
+    }
+
+    @Override
+    public Object send(Email email, Consumer<Object> requestCustomizer) throws EmailException {
+        invocations.incrementAndGet();
+        if (fail) {
+            throw new EmailException("provider rejected apiKey=SG.secret token abc123");
+        }
+        return new Object();
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    int invocations() {
+        return invocations.get();
+    }
+}

--- a/control-panel-email/src/test/resources/logback-test.xml
+++ b/control-panel-email/src/test/resources/logback-test.xml
@@ -1,0 +1,10 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="ERROR">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/doc-examples/example-java/build.gradle.kts
+++ b/doc-examples/example-java/build.gradle.kts
@@ -50,6 +50,10 @@ dependencies {
     implementation(libs.avro)
     implementation(libs.avro.serde)
 
+    // Email
+    implementation(projects.micronautControlPanelEmail)
+    implementation(mnEmail.micronaut.email)
+
     // OpenAPI + Swagger UI (views generated at compile-time)
     annotationProcessor(mnOpenapi.micronaut.openapi)
     testAnnotationProcessor(mnOpenapi.micronaut.openapi)

--- a/doc-examples/example-java/src/main/java/example/DemoEmailSender.java
+++ b/doc-examples/example-java/src/main/java/example/DemoEmailSender.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example;
+
+import io.micronaut.email.Email;
+import io.micronaut.email.EmailException;
+import io.micronaut.email.EmailSender;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+import java.util.function.Consumer;
+
+/**
+ * Local no-op email sender used by the example application.
+ */
+@Singleton
+@Named("demo")
+public class DemoEmailSender implements EmailSender<Object, Object> {
+
+    @Override
+    public Object send(Email.Builder builder, Consumer<Object> requestCustomizer) throws EmailException {
+        builder.build();
+        return new Object();
+    }
+
+    @Override
+    public String getName() {
+        return "demo";
+    }
+}

--- a/doc-examples/example-java/src/main/resources/application.yml
+++ b/doc-examples/example-java/src/main/resources/application.yml
@@ -11,6 +11,10 @@ micronaut:
 #end::control-panel[]
     env:
       show-values: true
+    email:
+      test-send:
+        enabled: true
+        recipient: dev-mailbox@example.test
   router:
     static-resources:
       swagger:
@@ -23,6 +27,10 @@ micronaut:
     local:
       my-local:
         path: /tmp/foo/
+  email:
+    from:
+      email: control-panel@example.test
+      name: Control Panel Example
   caches:
     my-caffeine:
       initial-capacity: 2

--- a/doc-examples/example-java/src/test/java/example/ControlPanelRenderingTest.java
+++ b/doc-examples/example-java/src/test/java/example/ControlPanelRenderingTest.java
@@ -18,4 +18,13 @@ class ControlPanelRenderingTest {
         assertTrue(body.contains("my-local"));
         assertTrue(body.contains("files stored."));
     }
+
+    @Test
+    void rendersEmailCategory(@Client("/") HttpClient client) {
+        var body = client.toBlocking().retrieve(HttpRequest.GET("/control-panel/categories/email"));
+
+        assertTrue(body.contains("Email: demo"));
+        assertTrue(body.contains("Custom/Unknown"));
+        assertTrue(body.contains("Test send"));
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ micronaut-testresources = "4.0.0"
 micronaut-gradle-plugin = "5.0.0-M1"
 micronaut-openapi = "7.0.0"
 micronaut-kafka = "6.0.0"
+micronaut-email = "3.0.0-RC1"
 kotlin-gradle-plugin = "2.3.21"
 micronaut-shared-settings = "8.0.0"
 playwright = "1.59.0"
@@ -58,6 +59,7 @@ micronaut-sql = { module = "io.micronaut.sql:micronaut-sql-bom", version.ref = "
 micronaut-data = { module = "io.micronaut.data:micronaut-data-bom", version.ref = "micronaut-data" }
 micronaut-testresources = { module = 'io.micronaut.testresources:micronaut-test-resources-bom', version.ref = "micronaut-testresources" }
 micronaut-kafka = { module = "io.micronaut.kafka:micronaut-kafka-bom", version.ref = "micronaut-kafka" }
+micronaut-email = { module = "io.micronaut.email:micronaut-email-bom", version.ref = "micronaut-email" }
 avro = { module = "org.apache.avro:avro", version.ref = "avro" }
 avro-serde = { module = "io.confluent:kafka-streams-avro-serde", version.ref = "avro-serde" }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,6 +22,7 @@ include("control-panel-datasource")
 include("control-panel-hibernate")
 include("control-panel-ui")
 include("control-panel-kafka")
+include("control-panel-email")
 
 include("doc-examples:example-java")
 
@@ -42,4 +43,5 @@ configure<MicronautBuildSettingsExtension> {
     importMicronautCatalog("micronaut-testresources")
     importMicronautCatalog("micronaut-openapi")
     importMicronautCatalog("micronaut-kafka")
+    importMicronautCatalog("micronaut-email")
 }

--- a/src/main/docs/guide/controlPanels/email.adoc
+++ b/src/main/docs/guide/controlPanels/email.adoc
@@ -1,0 +1,51 @@
+The Email control panel provides development-time diagnostics for applications that use https://micronaut-projects.github.io/micronaut-email/latest/guide/[Micronaut Email].
+
+Assuming your application already has `micronaut-email` and a Micronaut Email provider module, add the following dependency:
+
+dependency:io.micronaut.controlpanel:micronaut-control-panel-email[scope=developmentOnly]
+
+The module creates one panel for each usable Micronaut Email sender name. When Micronaut Email exposes wrapper and provider sender beans for the same sender name, the panel groups them into a single entry.
+
+Each panel shows:
+
+* The sender bean name and best-effort provider label
+* Supported sender interfaces such as `EmailSender`, `TransactionalEmailSender`, `AsyncEmailSender`, and `AsyncTransactionalEmailSender`
+* Default `from` status
+* Template support status
+* Whitelisted non-secret provider settings and secret presence indicators
+* A configuration checklist
+* An optional guarded test-send action
+
+The provider label is inferred from sender names, implementation package names, and safe configuration prefixes. JavaMail/SMTP, Amazon SES, SendGrid, Mailjet, Mailtrap, and Postmark are recognized. Custom senders are shown as `Custom/Unknown`.
+
+The control panel is automatically enabled when you include the module. You can disable it with:
+
+[configuration]
+----
+micronaut:
+  control-panel:
+    panels:
+      email:
+        enabled: false
+----
+
+Test send is disabled by default and is intended only for development or test environments. Enable it only with a safe configured recipient:
+
+[configuration]
+----
+micronaut:
+  control-panel:
+    email:
+      test-send:
+        enabled: true
+        recipient: dev-mailbox@example.test
+        subject-prefix: "[Micronaut Control Panel]"
+        allow-arbitrary-recipient: false
+        include-configuration-summary: false
+----
+
+By default the UI does not show an arbitrary recipient field and the endpoint rejects request-provided recipients. Set `allow-arbitrary-recipient=true` only in local environments where sending to arbitrary addresses is acceptable.
+
+Secrets are never shown as raw values in the panel body, detail view, serialized model output, controller responses, or test-send failure messages. Keys containing words such as `password`, `secret`, `token`, `key`, `credential`, or `authorization` are displayed only as `present (hidden)` or `not configured`, and exception messages are redacted before they are returned.
+
+The panel does not call provider APIs while rendering, does not store test-send history, does not retain message bodies or provider response bodies, and does not infer provider dashboard URLs from credentials. For local verification, use a mock sender or a local SMTP capture tool such as Mailpit instead of shared real-provider credentials.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -10,6 +10,7 @@ controlPanels:
   datasource: Datasource
   hibernate: Hibernate
   kafka: Kafka
+  email: Email
 
 custom: Creating Custom Control Panels
 repository: Repository


### PR DESCRIPTION
## Summary

- add `micronaut-control-panel-email` with grouped Micronaut Email sender diagnostics, provider inference, safe configuration checklist data, and an empty-state panel
- add a guarded, disabled-by-default test-send helper route with configured-recipient defaults and redacted success/failure responses
- document the email panel and wire a no-op sender into the Java example for UI verification

## Issue Linkage

Paperclip issue: DEV-484.

No linked GitHub issue was found during QA intake, Security review, or Code review, so no GitHub closing keyword or issue-creator reviewer is applicable.

## Organization Projects

Live Micronaut organization project association:

- `5.1.0 Release` (#147)

Target/project note: QA originally selected `5.0.0-M3` (#143) and `5.0.0 Release` (#47) for the earlier `2.0.x` target with a Control Panel release-line ambiguity note. PR #564 is now retargeted to `2.1.x`, and the live PR association is `5.1.0 Release`.

## Screenshots

Desktop light, 1440x900:

![Desktop light](https://raw.githubusercontent.com/micronaut-projects/micronaut-control-panel/3007f036b538cdad7910ac8f1aa3aae392e4e281/assets/pr-564/705c924ce71e/email-panel-desktop-light.png)

Desktop dark, 1440x900:

![Desktop dark](https://raw.githubusercontent.com/micronaut-projects/micronaut-control-panel/981c5810188bbfa35cf50f102c3a2c68e14ada1b/assets/pr-564/705c924ce71e/email-panel-desktop-dark.png)

Mobile dark, 390x844:

![Mobile dark](https://raw.githubusercontent.com/micronaut-projects/micronaut-control-panel/02737c7b6c740736f453e9a2fb05d0937330c492/assets/pr-564/705c924ce71e/email-panel-mobile-dark.png)

## Testing

- `./gradlew :micronaut-control-panel-email:check :micronaut-doc-examples:micronaut-example-java:test --tests example.ControlPanelRenderingTest --continue`
- `./gradlew docs`
- `git diff --check`

---
###### ✨ This message was AI-generated using gpt-5