### PR TITLE
Add Chatbots control panel diagnostics

### DIFF
--- a/control-panel-chatbots/build.gradle.kts
+++ b/control-panel-chatbots/build.gradle.kts
@@ -1,0 +1,31 @@
+plugins {
+    io.micronaut.build.internal.`control-panel-module`
+}
+
+dependencies {
+    api(projects.micronautControlPanelCore)
+
+    implementation(mnSerde.micronaut.serde.jackson)
+
+    compileOnly(mnChatbots.micronaut.chatbots.core)
+    compileOnly(mnChatbots.micronaut.chatbots.telegram.core)
+    compileOnly(mnChatbots.micronaut.chatbots.telegram.http)
+    compileOnly(mnChatbots.micronaut.chatbots.basecamp.core)
+    compileOnly(mnChatbots.micronaut.chatbots.basecamp.http)
+
+    testAnnotationProcessor(mn.micronaut.inject.java)
+    testImplementation(mnTest.micronaut.test.junit5)
+    testRuntimeOnly(mnTest.junit.jupiter.engine)
+    testImplementation(mn.micronaut.http.server.netty)
+    testImplementation(mnChatbots.micronaut.chatbots.core)
+    testImplementation(mnChatbots.micronaut.chatbots.telegram.core)
+    testImplementation(mnChatbots.micronaut.chatbots.telegram.http)
+    testImplementation(mnChatbots.micronaut.chatbots.basecamp.core)
+    testImplementation(mnChatbots.micronaut.chatbots.basecamp.http)
+    testImplementation(mnChatbots.micronaut.chatbots.telegram.api)
+    testImplementation(mnChatbots.micronaut.chatbots.basecamp.api)
+}
+
+micronautBuild {
+    binaryCompatibility.enabledAfter("2.0.0")
+}

--- a/control-panel-chatbots/build.gradle.kts
+++ b/control-panel-chatbots/build.gradle.kts
@@ -27,5 +27,5 @@ dependencies {
 }
 
 micronautBuild {
-    binaryCompatibility.enabledAfter("2.0.0")
+    binaryCompatibility.enabledAfter("2.0.1")
 }

--- a/control-panel-chatbots/src/main/java/io/micronaut/controlpanel/panels/chatbots/BasecampChatbotsContributor.java
+++ b/control-panel-chatbots/src/main/java/io/micronaut/controlpanel/panels/chatbots/BasecampChatbotsContributor.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.chatbots;
+
+import io.micronaut.chatbots.basecamp.core.BasecampBotConfiguration;
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.BeanRegistration;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.env.Environment;
+import io.micronaut.web.router.Router;
+import jakarta.inject.Singleton;
+
+@Singleton
+@Requires(classes = BasecampBotConfiguration.class)
+final class BasecampChatbotsContributor implements ChatbotsContributor {
+
+    private static final String CHANNEL = "Basecamp";
+    private static final String CONTROLLER_CLASS = "io.micronaut.chatbots.basecamp.http.BasecampController";
+    private static final String ENDPOINT_PREFIX = "micronaut.chatbots.basecamp.endpoint";
+    private static final String DEFAULT_PATH = "/basecamp";
+
+    private final BeanContext beanContext;
+    private final Environment environment;
+    private final Router router;
+
+    BasecampChatbotsContributor(BeanContext beanContext,
+                                Environment environment,
+                                Router router) {
+        this.beanContext = beanContext;
+        this.environment = environment;
+        this.router = router;
+    }
+
+    @Override
+    public void contribute(ChatbotsDiagnostics diagnostics) {
+        ChatbotsControlPanel.EndpointRow endpoint = EndpointResolver.endpoint(
+            environment,
+            router,
+            CHANNEL,
+            CONTROLLER_CLASS,
+            ENDPOINT_PREFIX + ".enabled",
+            ENDPOINT_PREFIX + ".path",
+            DEFAULT_PATH
+        );
+        diagnostics.endpoints.add(endpoint);
+        for (BeanRegistration<BasecampBotConfiguration> registration : beanContext.getBeanRegistrations(BasecampBotConfiguration.class)) {
+            BasecampBotConfiguration bot = registration.getBean();
+            diagnostics.bots.add(new ChatbotsControlPanel.BotRow(
+                CHANNEL,
+                bot.getName(),
+                "-",
+                bot.isEnabled(),
+                "not applicable"
+            ));
+            diagnostics.setupHints.add(new ChatbotsControlPanel.SetupHint(
+                CHANNEL,
+                "command_url for " + bot.getName(),
+                commandUrl(endpoint.path())
+            ));
+        }
+    }
+
+    private static String commandUrl(String path) {
+        return "Configure the Basecamp chat integration command_url as https://example.test" + path;
+    }
+}

--- a/control-panel-chatbots/src/main/java/io/micronaut/controlpanel/panels/chatbots/ChatbotsContributor.java
+++ b/control-panel-chatbots/src/main/java/io/micronaut/controlpanel/panels/chatbots/ChatbotsContributor.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.chatbots;
+
+interface ChatbotsContributor {
+
+    void contribute(ChatbotsDiagnostics diagnostics);
+}

--- a/control-panel-chatbots/src/main/java/io/micronaut/controlpanel/panels/chatbots/ChatbotsControlPanel.java
+++ b/control-panel-chatbots/src/main/java/io/micronaut/controlpanel/panels/chatbots/ChatbotsControlPanel.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.chatbots;
+
+import io.micronaut.chatbots.core.Handler;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.controlpanel.core.AbstractControlPanel;
+import io.micronaut.controlpanel.core.ControlPanel;
+import io.micronaut.controlpanel.core.config.ControlPanelConfiguration;
+import io.micronaut.core.annotation.ReflectiveAccess;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.runtime.context.scope.Refreshable;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Aggregate diagnostics panel for Micronaut Chatbots.
+ *
+ * @since 2.0.0
+ */
+@Singleton
+@Refreshable
+@Requires(classes = Handler.class)
+@Requires(property = ChatbotsControlPanel.ENABLED_PROPERTY, notEquals = StringUtils.FALSE)
+public class ChatbotsControlPanel extends AbstractControlPanel<ChatbotsControlPanel.Body> {
+
+    public static final String NAME = "chatbots";
+    public static final String ENABLED_PROPERTY = ControlPanelConfiguration.PREFIX + "." + NAME + ".enabled";
+    public static final ControlPanel.Category CATEGORY = new ControlPanel.Category(NAME, "Chatbots", "fas fa-robot", 25);
+
+    private final Collection<ChatbotsContributor> contributors;
+
+    public ChatbotsControlPanel(Collection<ChatbotsContributor> contributors,
+                                @Named(NAME) ControlPanelConfiguration configuration) {
+        super(NAME, configuration);
+        this.contributors = contributors;
+    }
+
+    @Override
+    public String getTitle() {
+        return "Chatbots";
+    }
+
+    @Override
+    public ControlPanel.Category getCategory() {
+        return CATEGORY;
+    }
+
+    @Override
+    public String getBadge() {
+        Body body = getBody();
+        return body.summary().totalBots() + " bots / " + body.summary().handlerCount() + " handlers";
+    }
+
+    @Override
+    public Body getBody() {
+        ChatbotsDiagnostics diagnostics = new ChatbotsDiagnostics();
+        contributors.forEach(contributor -> contributor.contribute(diagnostics));
+        List<BotRow> bots = diagnostics.bots.stream()
+            .sorted(Comparator.comparing(BotRow::channel).thenComparing(BotRow::name))
+            .toList();
+        List<EndpointRow> endpoints = diagnostics.endpoints.stream()
+            .sorted(Comparator.comparing(EndpointRow::channel))
+            .toList();
+        List<HandlerRow> handlers = diagnostics.handlers.stream()
+            .sorted(Comparator.comparingInt(HandlerRow::order).thenComparing(HandlerRow::beanName).thenComparing(HandlerRow::className))
+            .toList();
+        List<WebhookRow> webhooks = diagnostics.webhooks.stream()
+            .sorted(Comparator.comparing(WebhookRow::botName))
+            .toList();
+        return new Body(new Summary(
+            bots.size(),
+            (int) bots.stream().filter(BotRow::enabled).count(),
+            endpoints.size(),
+            (int) endpoints.stream().filter(EndpointRow::routeRegistered).count(),
+            handlers.size(),
+            webhookSummary(webhooks)
+        ), bots, endpoints, handlers, webhooks, diagnostics.setupHints);
+    }
+
+    private static String webhookSummary(List<WebhookRow> webhooks) {
+        if (webhooks.isEmpty()) {
+            return "No Telegram bots";
+        }
+        long available = webhooks.stream().filter(WebhookRow::available).count();
+        if (available > 0) {
+            return available + " available";
+        }
+        return webhooks.get(0).state();
+    }
+
+    @ReflectiveAccess
+    public record Body(Summary summary,
+                       List<BotRow> bots,
+                       List<EndpointRow> endpoints,
+                       List<HandlerRow> handlers,
+                       List<WebhookRow> webhooks,
+                       List<SetupHint> setupHints) { }
+
+    @ReflectiveAccess
+    public record Summary(int totalBots,
+                          int enabledBots,
+                          int endpointCount,
+                          int registeredEndpointCount,
+                          int handlerCount,
+                          String webhookLookupState) { }
+
+    @ReflectiveAccess
+    public record BotRow(String channel,
+                         String name,
+                         String username,
+                         boolean enabled,
+                         String tokenStatus) { }
+
+    @ReflectiveAccess
+    public record EndpointRow(String channel,
+                              boolean modulePresent,
+                              boolean configuredEnabled,
+                              boolean routeRegistered,
+                              String path,
+                              String state,
+                              String source) { }
+
+    @ReflectiveAccess
+    public record HandlerRow(String beanName,
+                             String className,
+                             String channel,
+                             int order,
+                             String outputType,
+                             String sourceInterface) { }
+
+    @ReflectiveAccess
+    public record WebhookRow(String botName,
+                             String state,
+                             boolean available,
+                             String expectedUrl,
+                             String returnedUrl,
+                             String matchStatus,
+                             String pendingUpdates,
+                             String lastError,
+                             String maxConnections,
+                             String allowedUpdates,
+                             String customCertificate) { }
+
+    @ReflectiveAccess
+    public record SetupHint(String channel,
+                            String label,
+                            String command) { }
+}

--- a/control-panel-chatbots/src/main/java/io/micronaut/controlpanel/panels/chatbots/ChatbotsControlPanel.java
+++ b/control-panel-chatbots/src/main/java/io/micronaut/controlpanel/panels/chatbots/ChatbotsControlPanel.java
@@ -39,6 +39,7 @@ import java.util.List;
 @Refreshable
 @Requires(classes = Handler.class)
 @Requires(property = ChatbotsControlPanel.ENABLED_PROPERTY, notEquals = StringUtils.FALSE)
+@SuppressWarnings("InjectMoreThanOneScopeAnnotationOnClass")
 public class ChatbotsControlPanel extends AbstractControlPanel<ChatbotsControlPanel.Body> {
 
     public static final String NAME = "chatbots";

--- a/control-panel-chatbots/src/main/java/io/micronaut/controlpanel/panels/chatbots/ChatbotsControlPanel.java
+++ b/control-panel-chatbots/src/main/java/io/micronaut/controlpanel/panels/chatbots/ChatbotsControlPanel.java
@@ -65,14 +65,13 @@ public class ChatbotsControlPanel extends AbstractControlPanel<ChatbotsControlPa
 
     @Override
     public String getBadge() {
-        Body body = getBody();
-        return body.summary().totalBots() + " bots / " + body.summary().handlerCount() + " handlers";
+        ChatbotsDiagnostics diagnostics = diagnostics(false);
+        return diagnostics.bots.size() + " bots / " + diagnostics.handlers.size() + " handlers";
     }
 
     @Override
     public Body getBody() {
-        ChatbotsDiagnostics diagnostics = new ChatbotsDiagnostics();
-        contributors.forEach(contributor -> contributor.contribute(diagnostics));
+        ChatbotsDiagnostics diagnostics = diagnostics(true);
         List<BotRow> bots = diagnostics.bots.stream()
             .sorted(Comparator.comparing(BotRow::channel).thenComparing(BotRow::name))
             .toList();
@@ -93,6 +92,12 @@ public class ChatbotsControlPanel extends AbstractControlPanel<ChatbotsControlPa
             handlers.size(),
             webhookSummary(webhooks)
         ), bots, endpoints, handlers, webhooks, diagnostics.setupHints);
+    }
+
+    private ChatbotsDiagnostics diagnostics(boolean includeWebhookLookup) {
+        ChatbotsDiagnostics diagnostics = new ChatbotsDiagnostics(includeWebhookLookup);
+        contributors.forEach(contributor -> contributor.contribute(diagnostics));
+        return diagnostics;
     }
 
     private static String webhookSummary(List<WebhookRow> webhooks) {

--- a/control-panel-chatbots/src/main/java/io/micronaut/controlpanel/panels/chatbots/ChatbotsControlPanel.java
+++ b/control-panel-chatbots/src/main/java/io/micronaut/controlpanel/panels/chatbots/ChatbotsControlPanel.java
@@ -111,6 +111,16 @@ public class ChatbotsControlPanel extends AbstractControlPanel<ChatbotsControlPa
         return webhooks.get(0).state();
     }
 
+    /**
+     * Body returned by the Chatbots control panel.
+     *
+     * @param summary    summary counts
+     * @param bots       configured bot rows
+     * @param endpoints  endpoint rows
+     * @param handlers   handler rows
+     * @param webhooks   Telegram webhook status rows
+     * @param setupHints setup command hints
+     */
     @ReflectiveAccess
     public record Body(Summary summary,
                        List<BotRow> bots,
@@ -119,6 +129,16 @@ public class ChatbotsControlPanel extends AbstractControlPanel<ChatbotsControlPa
                        List<WebhookRow> webhooks,
                        List<SetupHint> setupHints) { }
 
+    /**
+     * Summary counts for the Chatbots control panel.
+     *
+     * @param totalBots               total configured bots
+     * @param enabledBots             total enabled bots
+     * @param endpointCount           total inspected endpoints
+     * @param registeredEndpointCount total registered endpoints
+     * @param handlerCount            total discovered handlers
+     * @param webhookLookupState      webhook lookup summary state
+     */
     @ReflectiveAccess
     public record Summary(int totalBots,
                           int enabledBots,
@@ -127,6 +147,15 @@ public class ChatbotsControlPanel extends AbstractControlPanel<ChatbotsControlPa
                           int handlerCount,
                           String webhookLookupState) { }
 
+    /**
+     * Configured bot row for the Chatbots control panel.
+     *
+     * @param channel     bot channel
+     * @param name        bot name
+     * @param username    bot username
+     * @param enabled     whether the bot is enabled
+     * @param tokenStatus redacted token status
+     */
     @ReflectiveAccess
     public record BotRow(String channel,
                          String name,
@@ -134,6 +163,17 @@ public class ChatbotsControlPanel extends AbstractControlPanel<ChatbotsControlPa
                          boolean enabled,
                          String tokenStatus) { }
 
+    /**
+     * HTTP endpoint row for the Chatbots control panel.
+     *
+     * @param channel           endpoint channel
+     * @param modulePresent     whether the HTTP module is present
+     * @param configuredEnabled whether the endpoint is enabled by configuration
+     * @param routeRegistered   whether the endpoint route is registered
+     * @param path              effective endpoint path
+     * @param state             endpoint state label
+     * @param source            endpoint path source
+     */
     @ReflectiveAccess
     public record EndpointRow(String channel,
                               boolean modulePresent,
@@ -143,6 +183,16 @@ public class ChatbotsControlPanel extends AbstractControlPanel<ChatbotsControlPa
                               String state,
                               String source) { }
 
+    /**
+     * Handler bean row for the Chatbots control panel.
+     *
+     * @param beanName        bean name
+     * @param className       handler class name
+     * @param channel         handler channel
+     * @param order           handler order
+     * @param outputType      handler output type
+     * @param sourceInterface handler source interface
+     */
     @ReflectiveAccess
     public record HandlerRow(String beanName,
                              String className,
@@ -151,6 +201,21 @@ public class ChatbotsControlPanel extends AbstractControlPanel<ChatbotsControlPa
                              String outputType,
                              String sourceInterface) { }
 
+    /**
+     * Telegram webhook status row for the Chatbots control panel.
+     *
+     * @param botName           bot name
+     * @param state             webhook lookup state
+     * @param available         whether webhook status is available
+     * @param expectedUrl       expected webhook URL
+     * @param returnedUrl       returned webhook URL
+     * @param matchStatus       webhook URL match status
+     * @param pendingUpdates    pending update count
+     * @param lastError         last Telegram webhook error
+     * @param maxConnections    configured maximum connections
+     * @param allowedUpdates    allowed update types
+     * @param customCertificate custom certificate status
+     */
     @ReflectiveAccess
     public record WebhookRow(String botName,
                              String state,
@@ -164,6 +229,13 @@ public class ChatbotsControlPanel extends AbstractControlPanel<ChatbotsControlPa
                              String allowedUpdates,
                              String customCertificate) { }
 
+    /**
+     * Setup hint row for the Chatbots control panel.
+     *
+     * @param channel setup channel
+     * @param label   setup hint label
+     * @param command setup command with placeholders
+     */
     @ReflectiveAccess
     public record SetupHint(String channel,
                             String label,

--- a/control-panel-chatbots/src/main/java/io/micronaut/controlpanel/panels/chatbots/ChatbotsDiagnostics.java
+++ b/control-panel-chatbots/src/main/java/io/micronaut/controlpanel/panels/chatbots/ChatbotsDiagnostics.java
@@ -20,13 +20,13 @@ import java.util.List;
 
 final class ChatbotsDiagnostics {
 
-    private final boolean includeWebhookLookup;
-
     final List<ChatbotsControlPanel.BotRow> bots = new ArrayList<>();
     final List<ChatbotsControlPanel.EndpointRow> endpoints = new ArrayList<>();
     final List<ChatbotsControlPanel.HandlerRow> handlers = new ArrayList<>();
     final List<ChatbotsControlPanel.WebhookRow> webhooks = new ArrayList<>();
     final List<ChatbotsControlPanel.SetupHint> setupHints = new ArrayList<>();
+
+    private final boolean includeWebhookLookup;
 
     ChatbotsDiagnostics(boolean includeWebhookLookup) {
         this.includeWebhookLookup = includeWebhookLookup;

--- a/control-panel-chatbots/src/main/java/io/micronaut/controlpanel/panels/chatbots/ChatbotsDiagnostics.java
+++ b/control-panel-chatbots/src/main/java/io/micronaut/controlpanel/panels/chatbots/ChatbotsDiagnostics.java
@@ -20,9 +20,19 @@ import java.util.List;
 
 final class ChatbotsDiagnostics {
 
+    private final boolean includeWebhookLookup;
+
     final List<ChatbotsControlPanel.BotRow> bots = new ArrayList<>();
     final List<ChatbotsControlPanel.EndpointRow> endpoints = new ArrayList<>();
     final List<ChatbotsControlPanel.HandlerRow> handlers = new ArrayList<>();
     final List<ChatbotsControlPanel.WebhookRow> webhooks = new ArrayList<>();
     final List<ChatbotsControlPanel.SetupHint> setupHints = new ArrayList<>();
+
+    ChatbotsDiagnostics(boolean includeWebhookLookup) {
+        this.includeWebhookLookup = includeWebhookLookup;
+    }
+
+    boolean includeWebhookLookup() {
+        return includeWebhookLookup;
+    }
 }

--- a/control-panel-chatbots/src/main/java/io/micronaut/controlpanel/panels/chatbots/ChatbotsDiagnostics.java
+++ b/control-panel-chatbots/src/main/java/io/micronaut/controlpanel/panels/chatbots/ChatbotsDiagnostics.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.chatbots;
+
+import java.util.ArrayList;
+import java.util.List;
+
+final class ChatbotsDiagnostics {
+
+    final List<ChatbotsControlPanel.BotRow> bots = new ArrayList<>();
+    final List<ChatbotsControlPanel.EndpointRow> endpoints = new ArrayList<>();
+    final List<ChatbotsControlPanel.HandlerRow> handlers = new ArrayList<>();
+    final List<ChatbotsControlPanel.WebhookRow> webhooks = new ArrayList<>();
+    final List<ChatbotsControlPanel.SetupHint> setupHints = new ArrayList<>();
+}

--- a/control-panel-chatbots/src/main/java/io/micronaut/controlpanel/panels/chatbots/ChatbotsPanelConfiguration.java
+++ b/control-panel-chatbots/src/main/java/io/micronaut/controlpanel/panels/chatbots/ChatbotsPanelConfiguration.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.chatbots;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.controlpanel.core.config.ControlPanelModuleConfiguration;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Configuration for Chatbots diagnostics in Control Panel.
+ *
+ * @since 2.0.0
+ */
+@ConfigurationProperties(ChatbotsPanelConfiguration.PREFIX)
+public class ChatbotsPanelConfiguration {
+
+    public static final String PREFIX = ControlPanelModuleConfiguration.PREFIX + ".chatbots";
+
+    private Optional<String> publicUrl = Optional.empty();
+    private Telegram telegram = new Telegram();
+
+    /**
+     * @return Public application URL used to build expected webhook URLs.
+     */
+    public Optional<String> getPublicUrl() {
+        return publicUrl;
+    }
+
+    /**
+     * @param publicUrl Public application URL used to build expected webhook URLs.
+     */
+    public void setPublicUrl(Optional<String> publicUrl) {
+        this.publicUrl = publicUrl;
+    }
+
+    /**
+     * @return Telegram diagnostics configuration.
+     */
+    public Telegram getTelegram() {
+        return telegram;
+    }
+
+    /**
+     * @param telegram Telegram diagnostics configuration.
+     */
+    public void setTelegram(Telegram telegram) {
+        this.telegram = telegram;
+    }
+
+    /**
+     * Telegram diagnostics configuration.
+     */
+    @ConfigurationProperties("telegram")
+    public static class Telegram {
+        private WebhookStatus webhookStatus = new WebhookStatus();
+
+        /**
+         * @return Telegram webhook status lookup configuration.
+         */
+        public WebhookStatus getWebhookStatus() {
+            return webhookStatus;
+        }
+
+        /**
+         * @param webhookStatus Telegram webhook status lookup configuration.
+         */
+        public void setWebhookStatus(WebhookStatus webhookStatus) {
+            this.webhookStatus = webhookStatus;
+        }
+    }
+
+    /**
+     * Telegram webhook status lookup configuration.
+     */
+    @ConfigurationProperties("webhook-status")
+    public static class WebhookStatus {
+        public static final String DEFAULT_BASE_URL = "https://api.telegram.org";
+        public static final int DEFAULT_TIMEOUT_MILLIS = 2_000;
+
+        private boolean enabled;
+        private String baseUrl = DEFAULT_BASE_URL;
+        private int timeoutMillis = DEFAULT_TIMEOUT_MILLIS;
+        private Map<String, String> apiTokens = new LinkedHashMap<>();
+
+        /**
+         * @return Whether Telegram getWebhookInfo lookup is enabled.
+         */
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        /**
+         * @param enabled Whether Telegram getWebhookInfo lookup is enabled.
+         */
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        /**
+         * @return Base URL for the Telegram Bot API.
+         */
+        public String getBaseUrl() {
+            return baseUrl;
+        }
+
+        /**
+         * @param baseUrl Base URL for the Telegram Bot API.
+         */
+        public void setBaseUrl(String baseUrl) {
+            this.baseUrl = baseUrl;
+        }
+
+        /**
+         * @return Timeout in milliseconds for each webhook status lookup.
+         */
+        public int getTimeoutMillis() {
+            return timeoutMillis;
+        }
+
+        /**
+         * @param timeoutMillis Timeout in milliseconds for each webhook status lookup.
+         */
+        public void setTimeoutMillis(int timeoutMillis) {
+            this.timeoutMillis = timeoutMillis;
+        }
+
+        /**
+         * @return Per-bot Telegram Bot API tokens used only for getWebhookInfo lookup.
+         */
+        public Map<String, String> getApiTokens() {
+            return apiTokens;
+        }
+
+        /**
+         * @param apiTokens Per-bot Telegram Bot API tokens used only for getWebhookInfo lookup.
+         */
+        public void setApiTokens(Map<String, String> apiTokens) {
+            this.apiTokens = apiTokens;
+        }
+    }
+}

--- a/control-panel-chatbots/src/main/java/io/micronaut/controlpanel/panels/chatbots/EndpointResolver.java
+++ b/control-panel-chatbots/src/main/java/io/micronaut/controlpanel/panels/chatbots/EndpointResolver.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.chatbots;
+
+import io.micronaut.context.env.Environment;
+import io.micronaut.core.reflect.ClassUtils;
+import io.micronaut.web.router.Router;
+import io.micronaut.web.router.UriRouteInfo;
+
+final class EndpointResolver {
+
+    private EndpointResolver() {
+    }
+
+    static ChatbotsControlPanel.EndpointRow endpoint(Environment environment,
+                                                     Router router,
+                                                     String channel,
+                                                     String controllerClassName,
+                                                     String enabledProperty,
+                                                     String pathProperty,
+                                                     String defaultPath) {
+        boolean modulePresent = ClassUtils.isPresent(controllerClassName, EndpointResolver.class.getClassLoader());
+        boolean configuredEnabled = environment.getProperty(enabledProperty, Boolean.class).orElse(true);
+        String path = environment.getProperty(pathProperty, String.class).orElse(defaultPath);
+        boolean routeRegistered = modulePresent && router.uriRoutes()
+            .map(UriRouteInfo::getTargetMethod)
+            .anyMatch(method -> method.getDeclaringType().getName().equals(controllerClassName));
+        return new ChatbotsControlPanel.EndpointRow(
+            channel,
+            modulePresent,
+            configuredEnabled,
+            routeRegistered,
+            path,
+            state(modulePresent, configuredEnabled, routeRegistered),
+            environment.containsProperty(pathProperty) ? "configuration" : "default"
+        );
+    }
+
+    private static String state(boolean modulePresent, boolean configuredEnabled, boolean routeRegistered) {
+        if (!modulePresent) {
+            return "HTTP module absent";
+        }
+        if (!configuredEnabled) {
+            return "configured disabled";
+        }
+        if (routeRegistered) {
+            return "registered";
+        }
+        return "configured enabled but route not registered";
+    }
+}

--- a/control-panel-chatbots/src/main/java/io/micronaut/controlpanel/panels/chatbots/HandlerChatbotsContributor.java
+++ b/control-panel-chatbots/src/main/java/io/micronaut/controlpanel/panels/chatbots/HandlerChatbotsContributor.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.chatbots;
+
+import io.micronaut.chatbots.core.Handler;
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.BeanRegistration;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.order.Ordered;
+import io.micronaut.core.reflect.ClassUtils;
+import io.micronaut.core.type.Argument;
+import io.micronaut.inject.BeanDefinition;
+import jakarta.inject.Singleton;
+
+import java.util.Collection;
+import java.util.Optional;
+
+@Singleton
+@Requires(classes = Handler.class)
+final class HandlerChatbotsContributor implements ChatbotsContributor {
+
+    private static final String TELEGRAM_HANDLER = "io.micronaut.chatbots.telegram.core.TelegramHandler";
+    private static final String BASECAMP_HANDLER = "io.micronaut.chatbots.basecamp.core.BasecampHandler";
+
+    private final BeanContext beanContext;
+    private final Optional<Class<?>> telegramHandlerType;
+    private final Optional<Class<?>> basecampHandlerType;
+
+    HandlerChatbotsContributor(BeanContext beanContext) {
+        this.beanContext = beanContext;
+        ClassLoader classLoader = beanContext.getClassLoader();
+        this.telegramHandlerType = ClassUtils.forName(TELEGRAM_HANDLER, classLoader);
+        this.basecampHandlerType = ClassUtils.forName(BASECAMP_HANDLER, classLoader);
+    }
+
+    @Override
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public void contribute(ChatbotsDiagnostics diagnostics) {
+        Collection<BeanRegistration<Handler>> registrations = beanContext.getBeanRegistrations(Handler.class);
+        for (BeanRegistration<Handler> registration : registrations) {
+            Handler handler = registration.getBean();
+            BeanDefinition<Handler> definition = registration.getBeanDefinition();
+            diagnostics.handlers.add(new ChatbotsControlPanel.HandlerRow(
+                registration.getIdentifier().getName(),
+                handler.getClass().getName(),
+                channel(handler),
+                handler instanceof Ordered ordered ? ordered.getOrder() : Ordered.LOWEST_PRECEDENCE,
+                outputType(definition),
+                sourceInterface(handler)
+            ));
+        }
+    }
+
+    private String channel(Handler<?, ?, ?> handler) {
+        if (telegramHandlerType.filter(type -> type.isInstance(handler)).isPresent()) {
+            return "Telegram";
+        }
+        if (basecampHandlerType.filter(type -> type.isInstance(handler)).isPresent()) {
+            return "Basecamp";
+        }
+        return "Generic";
+    }
+
+    private String sourceInterface(Handler<?, ?, ?> handler) {
+        if (telegramHandlerType.filter(type -> type.isInstance(handler)).isPresent()) {
+            return "TelegramHandler";
+        }
+        if (basecampHandlerType.filter(type -> type.isInstance(handler)).isPresent()) {
+            return "BasecampHandler";
+        }
+        return "Handler";
+    }
+
+    private static String outputType(BeanDefinition<?> definition) {
+        return definition.getTypeArguments(Handler.class).stream()
+            .skip(2)
+            .findFirst()
+            .map(Argument::getSimpleName)
+            .orElse("unknown");
+    }
+}

--- a/control-panel-chatbots/src/main/java/io/micronaut/controlpanel/panels/chatbots/HandlerChatbotsContributor.java
+++ b/control-panel-chatbots/src/main/java/io/micronaut/controlpanel/panels/chatbots/HandlerChatbotsContributor.java
@@ -19,7 +19,6 @@ import io.micronaut.chatbots.core.Handler;
 import io.micronaut.context.BeanContext;
 import io.micronaut.context.BeanRegistration;
 import io.micronaut.context.annotation.Requires;
-import io.micronaut.core.order.Ordered;
 import io.micronaut.core.reflect.ClassUtils;
 import io.micronaut.core.type.Argument;
 import io.micronaut.inject.BeanDefinition;
@@ -57,7 +56,7 @@ final class HandlerChatbotsContributor implements ChatbotsContributor {
                 registration.getIdentifier().getName(),
                 handler.getClass().getName(),
                 channel(handler),
-                handler instanceof Ordered ordered ? ordered.getOrder() : Ordered.LOWEST_PRECEDENCE,
+                handler.getOrder(),
                 outputType(definition),
                 sourceInterface(handler)
             ));

--- a/control-panel-chatbots/src/main/java/io/micronaut/controlpanel/panels/chatbots/TelegramChatbotsContributor.java
+++ b/control-panel-chatbots/src/main/java/io/micronaut/controlpanel/panels/chatbots/TelegramChatbotsContributor.java
@@ -77,11 +77,13 @@ final class TelegramChatbotsContributor implements ChatbotsContributor {
                 tokenStatus(bot.getToken())
             ));
             String expectedUrl = expectedUrl(endpoint.path());
-            diagnostics.webhooks.add(webhookRow(bot.getName(), expectedUrl));
+            if (diagnostics.includeWebhookLookup()) {
+                diagnostics.webhooks.add(webhookRow(bot.getName(), expectedUrl));
+            }
             diagnostics.setupHints.add(new ChatbotsControlPanel.SetupHint(
                 CHANNEL,
                 "setWebhook for " + bot.getName(),
-                setupCommand(expectedUrl)
+                setupCommand(expectedUrl, endpoint.path())
             ));
         }
     }
@@ -118,8 +120,8 @@ final class TelegramChatbotsContributor implements ChatbotsContributor {
             .orElse("");
     }
 
-    private static String setupCommand(String expectedUrl) {
-        String url = expectedUrl == null || expectedUrl.isBlank() ? "https://example.test/telegram" : expectedUrl;
+    private static String setupCommand(String expectedUrl, String endpointPath) {
+        String url = expectedUrl == null || expectedUrl.isBlank() ? "https://example.test" + normalizePath(endpointPath) : expectedUrl;
         return "curl -X POST \"https://api.telegram.org/bot" + API_TOKEN_PLACEHOLDER + "/setWebhook\" "
             + "-d \"url=" + url + "\" "
             + "-d \"secret_token=" + SECRET_PLACEHOLDER + "\"";
@@ -131,5 +133,12 @@ final class TelegramChatbotsContributor implements ChatbotsContributor {
 
     private static String trimTrailingSlash(String url) {
         return url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
+    }
+
+    private static String normalizePath(String path) {
+        if (path == null || path.isBlank()) {
+            return DEFAULT_PATH;
+        }
+        return path.startsWith("/") ? path : "/" + path;
     }
 }

--- a/control-panel-chatbots/src/main/java/io/micronaut/controlpanel/panels/chatbots/TelegramChatbotsContributor.java
+++ b/control-panel-chatbots/src/main/java/io/micronaut/controlpanel/panels/chatbots/TelegramChatbotsContributor.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.chatbots;
+
+import io.micronaut.chatbots.telegram.core.TelegramBotConfiguration;
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.BeanRegistration;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.env.Environment;
+import io.micronaut.web.router.Router;
+import jakarta.inject.Singleton;
+
+import java.util.Map;
+
+@Singleton
+@Requires(classes = TelegramBotConfiguration.class)
+final class TelegramChatbotsContributor implements ChatbotsContributor {
+
+    private static final String CHANNEL = "Telegram";
+    private static final String CONTROLLER_CLASS = "io.micronaut.chatbots.telegram.http.TelegramController";
+    private static final String ENDPOINT_PREFIX = "micronaut.chatbots.telegram.endpoint";
+    private static final String DEFAULT_PATH = "/telegram";
+    private static final String WEBHOOK_STATUS_PREFIX = ChatbotsPanelConfiguration.PREFIX + ".telegram.webhook-status";
+    private static final String API_TOKEN_PLACEHOLDER = "<BOT_API_TOKEN>";
+    private static final String SECRET_PLACEHOLDER = "<SECRET_TOKEN>";
+
+    private final BeanContext beanContext;
+    private final Environment environment;
+    private final Router router;
+    private final ChatbotsPanelConfiguration configuration;
+    private final TelegramWebhookStatusClient webhookStatusClient;
+
+    TelegramChatbotsContributor(BeanContext beanContext,
+                                Environment environment,
+                                Router router,
+                                ChatbotsPanelConfiguration configuration,
+                                TelegramWebhookStatusClient webhookStatusClient) {
+        this.beanContext = beanContext;
+        this.environment = environment;
+        this.router = router;
+        this.configuration = configuration;
+        this.webhookStatusClient = webhookStatusClient;
+    }
+
+    @Override
+    public void contribute(ChatbotsDiagnostics diagnostics) {
+        ChatbotsControlPanel.EndpointRow endpoint = EndpointResolver.endpoint(
+            environment,
+            router,
+            CHANNEL,
+            CONTROLLER_CLASS,
+            ENDPOINT_PREFIX + ".enabled",
+            ENDPOINT_PREFIX + ".path",
+            DEFAULT_PATH
+        );
+        diagnostics.endpoints.add(endpoint);
+        for (BeanRegistration<TelegramBotConfiguration> registration : beanContext.getBeanRegistrations(TelegramBotConfiguration.class)) {
+            TelegramBotConfiguration bot = registration.getBean();
+            diagnostics.bots.add(new ChatbotsControlPanel.BotRow(
+                CHANNEL,
+                bot.getName(),
+                bot.getAtUsername(),
+                bot.isEnabled(),
+                tokenStatus(bot.getToken())
+            ));
+            String expectedUrl = expectedUrl(endpoint.path());
+            diagnostics.webhooks.add(webhookRow(bot.getName(), expectedUrl));
+            diagnostics.setupHints.add(new ChatbotsControlPanel.SetupHint(
+                CHANNEL,
+                "setWebhook for " + bot.getName(),
+                setupCommand(expectedUrl)
+            ));
+        }
+    }
+
+    private ChatbotsControlPanel.WebhookRow webhookRow(String botName, String expectedUrl) {
+        ChatbotsPanelConfiguration.WebhookStatus webhookStatus = webhookStatusConfiguration(botName);
+        if (!webhookStatus.isEnabled()) {
+            return TelegramWebhookStatusClient.unavailable(botName, "lookup disabled", expectedUrl);
+        }
+        Map<String, String> apiTokens = webhookStatus.getApiTokens();
+        String apiToken = apiTokens == null ? null : apiTokens.get(botName);
+        if (apiToken == null || apiToken.isBlank()) {
+            return TelegramWebhookStatusClient.unavailable(botName, "API token not configured", expectedUrl);
+        }
+        return webhookStatusClient.resolve(botName, apiToken, expectedUrl, webhookStatus);
+    }
+
+    private ChatbotsPanelConfiguration.WebhookStatus webhookStatusConfiguration(String botName) {
+        ChatbotsPanelConfiguration.WebhookStatus webhookStatus = new ChatbotsPanelConfiguration.WebhookStatus();
+        webhookStatus.setEnabled(environment.getProperty(WEBHOOK_STATUS_PREFIX + ".enabled", Boolean.class).orElse(false));
+        webhookStatus.setBaseUrl(environment.getProperty(WEBHOOK_STATUS_PREFIX + ".base-url", String.class)
+            .orElse(ChatbotsPanelConfiguration.WebhookStatus.DEFAULT_BASE_URL));
+        webhookStatus.setTimeoutMillis(environment.getProperty(WEBHOOK_STATUS_PREFIX + ".timeout-millis", Integer.class)
+            .orElse(ChatbotsPanelConfiguration.WebhookStatus.DEFAULT_TIMEOUT_MILLIS));
+        environment.getProperty(WEBHOOK_STATUS_PREFIX + ".api-tokens." + botName, String.class)
+            .ifPresent(token -> webhookStatus.setApiTokens(Map.of(botName, token)));
+        return webhookStatus;
+    }
+
+    private String expectedUrl(String endpointPath) {
+        return configuration.getPublicUrl()
+            .filter(url -> !url.isBlank())
+            .map(url -> trimTrailingSlash(url) + endpointPath)
+            .orElse("");
+    }
+
+    private static String setupCommand(String expectedUrl) {
+        String url = expectedUrl == null || expectedUrl.isBlank() ? "https://example.test/telegram" : expectedUrl;
+        return "curl -X POST \"https://api.telegram.org/bot" + API_TOKEN_PLACEHOLDER + "/setWebhook\" "
+            + "-d \"url=" + url + "\" "
+            + "-d \"secret_token=" + SECRET_PLACEHOLDER + "\"";
+    }
+
+    private static String tokenStatus(String token) {
+        return token == null || token.isBlank() ? "missing" : "configured";
+    }
+
+    private static String trimTrailingSlash(String url) {
+        return url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
+    }
+}

--- a/control-panel-chatbots/src/main/java/io/micronaut/controlpanel/panels/chatbots/TelegramWebhookStatusClient.java
+++ b/control-panel-chatbots/src/main/java/io/micronaut/controlpanel/panels/chatbots/TelegramWebhookStatusClient.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.chatbots;
+
+import io.micronaut.core.type.Argument;
+import io.micronaut.json.JsonMapper;
+import jakarta.inject.Singleton;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+@Singleton
+final class TelegramWebhookStatusClient {
+
+    private static final Argument<Map<String, Object>> MAP_ARGUMENT = Argument.mapOf(String.class, Object.class);
+
+    private final JsonMapper jsonMapper;
+
+    TelegramWebhookStatusClient(JsonMapper jsonMapper) {
+        this.jsonMapper = jsonMapper;
+    }
+
+    ChatbotsControlPanel.WebhookRow resolve(String botName,
+                                            String apiToken,
+                                            String expectedUrl,
+                                            ChatbotsPanelConfiguration.WebhookStatus configuration) {
+        HttpClient client;
+        HttpRequest request;
+        try {
+            Duration timeout = timeout(configuration);
+            URI uri = URI.create(trimTrailingSlash(configuration.getBaseUrl()) + "/bot" + apiToken + "/getWebhookInfo");
+            client = HttpClient.newBuilder()
+                .connectTimeout(timeout)
+                .build();
+            request = HttpRequest.newBuilder(uri)
+                .timeout(timeout)
+                .GET()
+                .build();
+        } catch (RuntimeException e) {
+            return unavailable(botName, "lookup configuration error", expectedUrl);
+        }
+        try {
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() == 401 || response.statusCode() == 403) {
+                return unavailable(botName, "invalid API token", expectedUrl);
+            }
+            if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                return unavailable(botName, "Telegram API returned HTTP " + response.statusCode(), expectedUrl);
+            }
+            return fromBody(botName, expectedUrl, response.body());
+        } catch (IOException e) {
+            return unavailable(botName, "network error", expectedUrl);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return unavailable(botName, "lookup interrupted", expectedUrl);
+        } catch (RuntimeException e) {
+            return unavailable(botName, "parse error", expectedUrl);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private ChatbotsControlPanel.WebhookRow fromBody(String botName, String expectedUrl, String body) throws IOException {
+        Map<String, Object> decoded = jsonMapper.readValue(body, MAP_ARGUMENT);
+        Object ok = decoded.get("ok");
+        if (Boolean.FALSE.equals(ok)) {
+            return unavailable(botName, "Telegram API error", expectedUrl);
+        }
+        Object result = decoded.get("result");
+        if (!(result instanceof Map<?, ?> resultMap)) {
+            return unavailable(botName, "parse error", expectedUrl);
+        }
+        Map<String, Object> values = (Map<String, Object>) resultMap;
+        String returnedUrl = string(values.get("url"));
+        return new ChatbotsControlPanel.WebhookRow(
+            botName,
+            "available",
+            true,
+            expectedUrl,
+            returnedUrl,
+            matchStatus(expectedUrl, returnedUrl),
+            string(values.get("pending_update_count")),
+            lastError(values),
+            string(values.get("max_connections")),
+            allowedUpdates(values.get("allowed_updates")),
+            Boolean.TRUE.equals(values.get("has_custom_certificate")) ? "present" : "not reported"
+        );
+    }
+
+    static ChatbotsControlPanel.WebhookRow unavailable(String botName, String state, String expectedUrl) {
+        return new ChatbotsControlPanel.WebhookRow(botName, state, false, expectedUrl, "-", "-", "-", "-", "-", "-", "-");
+    }
+
+    private static Duration timeout(ChatbotsPanelConfiguration.WebhookStatus configuration) {
+        return Duration.ofMillis(Math.max(1, configuration.getTimeoutMillis()));
+    }
+
+    private static String trimTrailingSlash(String url) {
+        return url != null && url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
+    }
+
+    private static String string(Object value) {
+        return value == null ? "-" : String.valueOf(value);
+    }
+
+    private static String matchStatus(String expectedUrl, String returnedUrl) {
+        if (expectedUrl == null || expectedUrl.isBlank()) {
+            return "expected URL not configured";
+        }
+        if (returnedUrl == null || returnedUrl.isBlank() || "-".equals(returnedUrl)) {
+            return "not configured";
+        }
+        return expectedUrl.equals(returnedUrl) ? "matches expected URL" : "configured but points elsewhere";
+    }
+
+    private static String lastError(Map<String, Object> values) {
+        String message = string(values.get("last_error_message"));
+        String date = string(values.get("last_error_date"));
+        if ("-".equals(message) && "-".equals(date)) {
+            return "none";
+        }
+        if ("-".equals(date)) {
+            return message;
+        }
+        if ("-".equals(message)) {
+            return date;
+        }
+        return date + ": " + message;
+    }
+
+    private static String allowedUpdates(Object value) {
+        if (value instanceof List<?> list) {
+            return list.isEmpty() ? "all update types" : String.join(", ", list.stream().map(String::valueOf).toList());
+        }
+        return string(value);
+    }
+}

--- a/control-panel-chatbots/src/main/java/io/micronaut/controlpanel/panels/chatbots/TelegramWebhookStatusClient.java
+++ b/control-panel-chatbots/src/main/java/io/micronaut/controlpanel/panels/chatbots/TelegramWebhookStatusClient.java
@@ -34,23 +34,21 @@ final class TelegramWebhookStatusClient {
     private static final Argument<Map<String, Object>> MAP_ARGUMENT = Argument.mapOf(String.class, Object.class);
 
     private final JsonMapper jsonMapper;
+    private final HttpClient client;
 
     TelegramWebhookStatusClient(JsonMapper jsonMapper) {
         this.jsonMapper = jsonMapper;
+        this.client = HttpClient.newHttpClient();
     }
 
     ChatbotsControlPanel.WebhookRow resolve(String botName,
                                             String apiToken,
                                             String expectedUrl,
                                             ChatbotsPanelConfiguration.WebhookStatus configuration) {
-        HttpClient client;
         HttpRequest request;
         try {
             Duration timeout = timeout(configuration);
             URI uri = URI.create(trimTrailingSlash(configuration.getBaseUrl()) + "/bot" + apiToken + "/getWebhookInfo");
-            client = HttpClient.newBuilder()
-                .connectTimeout(timeout)
-                .build();
             request = HttpRequest.newBuilder(uri)
                 .timeout(timeout)
                 .GET()

--- a/control-panel-chatbots/src/main/java/io/micronaut/controlpanel/panels/chatbots/TelegramWebhookStatusClient.java
+++ b/control-panel-chatbots/src/main/java/io/micronaut/controlpanel/panels/chatbots/TelegramWebhookStatusClient.java
@@ -18,6 +18,7 @@ package io.micronaut.controlpanel.panels.chatbots;
 import io.micronaut.core.type.Argument;
 import io.micronaut.json.JsonMapper;
 import jakarta.inject.Singleton;
+import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
 import java.net.URI;
@@ -78,6 +79,9 @@ final class TelegramWebhookStatusClient {
     @SuppressWarnings("unchecked")
     private ChatbotsControlPanel.WebhookRow fromBody(String botName, String expectedUrl, String body) throws IOException {
         Map<String, Object> decoded = jsonMapper.readValue(body, MAP_ARGUMENT);
+        if (decoded == null) {
+            return unavailable(botName, "parse error", expectedUrl);
+        }
         Object ok = decoded.get("ok");
         if (Boolean.FALSE.equals(ok)) {
             return unavailable(botName, "Telegram API error", expectedUrl);
@@ -115,7 +119,7 @@ final class TelegramWebhookStatusClient {
         return url != null && url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
     }
 
-    private static String string(Object value) {
+    private static String string(@Nullable Object value) {
         return value == null ? "-" : String.valueOf(value);
     }
 
@@ -144,7 +148,7 @@ final class TelegramWebhookStatusClient {
         return date + ": " + message;
     }
 
-    private static String allowedUpdates(Object value) {
+    private static String allowedUpdates(@Nullable Object value) {
         if (value instanceof List<?> list) {
             return list.isEmpty() ? "all update types" : String.join(", ", list.stream().map(String::valueOf).toList());
         }

--- a/control-panel-chatbots/src/main/java/io/micronaut/controlpanel/panels/chatbots/TelegramWebhookStatusClient.java
+++ b/control-panel-chatbots/src/main/java/io/micronaut/controlpanel/panels/chatbots/TelegramWebhookStatusClient.java
@@ -33,6 +33,7 @@ import java.util.Map;
 final class TelegramWebhookStatusClient {
 
     private static final Argument<Map<String, Object>> MAP_ARGUMENT = Argument.mapOf(String.class, Object.class);
+    private static final String PARSE_ERROR = "parse error";
 
     private final JsonMapper jsonMapper;
     private final HttpClient client;
@@ -72,7 +73,7 @@ final class TelegramWebhookStatusClient {
             Thread.currentThread().interrupt();
             return unavailable(botName, "lookup interrupted", expectedUrl);
         } catch (RuntimeException e) {
-            return unavailable(botName, "parse error", expectedUrl);
+            return unavailable(botName, PARSE_ERROR, expectedUrl);
         }
     }
 
@@ -80,7 +81,7 @@ final class TelegramWebhookStatusClient {
     private ChatbotsControlPanel.WebhookRow fromBody(String botName, String expectedUrl, String body) throws IOException {
         Map<String, Object> decoded = jsonMapper.readValue(body, MAP_ARGUMENT);
         if (decoded == null) {
-            return unavailable(botName, "parse error", expectedUrl);
+            return unavailable(botName, PARSE_ERROR, expectedUrl);
         }
         Object ok = decoded.get("ok");
         if (Boolean.FALSE.equals(ok)) {
@@ -88,7 +89,7 @@ final class TelegramWebhookStatusClient {
         }
         Object result = decoded.get("result");
         if (!(result instanceof Map<?, ?> resultMap)) {
-            return unavailable(botName, "parse error", expectedUrl);
+            return unavailable(botName, PARSE_ERROR, expectedUrl);
         }
         Map<String, Object> values = (Map<String, Object>) resultMap;
         String returnedUrl = string(values.get("url"));

--- a/control-panel-chatbots/src/main/java/io/micronaut/controlpanel/panels/chatbots/package-info.java
+++ b/control-panel-chatbots/src/main/java/io/micronaut/controlpanel/panels/chatbots/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Chatbots Control Panel classes.
+ */
+@Configuration
+@Requires(property = ChatbotsControlPanel.ENABLED_PROPERTY, notEquals = StringUtils.FALSE)
+@Requires(condition = ControlPanelEnabledCondition.class)
+package io.micronaut.controlpanel.panels.chatbots;
+
+import io.micronaut.context.annotation.Configuration;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.controlpanel.core.config.ControlPanelEnabledCondition;
+import io.micronaut.core.util.StringUtils;

--- a/control-panel-chatbots/src/main/resources/micronaut-control-panel/micronaut-control-panel.properties
+++ b/control-panel-chatbots/src/main/resources/micronaut-control-panel/micronaut-control-panel.properties
@@ -1,0 +1,3 @@
+micronaut.control-panel.panels.chatbots.enabled = true
+micronaut.control-panel.panels.chatbots.icon = fas fa-robot
+micronaut.control-panel.panels.chatbots.order = 25

--- a/control-panel-chatbots/src/main/resources/views/chatbots/body.hbs
+++ b/control-panel-chatbots/src/main/resources/views/chatbots/body.hbs
@@ -1,0 +1,11 @@
+{{#with body.summary as |summary|}}
+    <p class="card-text">
+        <strong>{{summary.enabledBots}}</strong> enabled of <strong>{{summary.totalBots}}</strong> configured bot(s).
+    </p>
+    <p class="card-text">
+        <strong>{{summary.handlerCount}}</strong> handler bean(s), <strong>{{summary.registeredEndpointCount}}</strong> registered endpoint(s).
+    </p>
+    <p class="card-text">
+        <strong>Webhook lookup</strong>: <span class="badge badge-secondary">{{summary.webhookLookupState}}</span>
+    </p>
+{{/with}}

--- a/control-panel-chatbots/src/main/resources/views/chatbots/detail.hbs
+++ b/control-panel-chatbots/src/main/resources/views/chatbots/detail.hbs
@@ -1,21 +1,21 @@
 {{#with controlPanel.body as |body|}}
     <div class="tabs" data-tabs>
         <div class="tabs-list" role="tablist" aria-label="Chatbots diagnostics">
-            <button type="button" class="tabs-trigger active" role="tab" aria-selected="true" data-tabs-trigger="overview">
+            <button type="button" class="tabs-trigger active" id="tab-chatbots-overview" role="tab" aria-selected="true" aria-controls="panel-chatbots-overview" data-tabs-trigger="overview">
                 Overview
             </button>
-            <button type="button" class="tabs-trigger" role="tab" aria-selected="false" data-tabs-trigger="bots">
+            <button type="button" class="tabs-trigger" id="tab-chatbots-bots" role="tab" aria-selected="false" aria-controls="panel-chatbots-bots" data-tabs-trigger="bots">
                 Bots
             </button>
-            <button type="button" class="tabs-trigger" role="tab" aria-selected="false" data-tabs-trigger="handlers">
+            <button type="button" class="tabs-trigger" id="tab-chatbots-handlers" role="tab" aria-selected="false" aria-controls="panel-chatbots-handlers" data-tabs-trigger="handlers">
                 Handlers
             </button>
-            <button type="button" class="tabs-trigger" role="tab" aria-selected="false" data-tabs-trigger="webhooks">
+            <button type="button" class="tabs-trigger" id="tab-chatbots-webhooks" role="tab" aria-selected="false" aria-controls="panel-chatbots-webhooks" data-tabs-trigger="webhooks">
                 Webhook
             </button>
         </div>
 
-        <div class="tabs-content active" role="tabpanel" data-tabs-content="overview">
+        <div class="tabs-panel" id="panel-chatbots-overview" role="tabpanel" aria-labelledby="tab-chatbots-overview" data-tabs-panel="overview">
             <div class="cp-detail-card-grid">
                 <div class="card card-light">
                     <div class="card-header">
@@ -97,7 +97,7 @@
             </div>
         </div>
 
-        <div class="tabs-content" role="tabpanel" data-tabs-content="bots" hidden>
+        <div class="tabs-panel" id="panel-chatbots-bots" role="tabpanel" aria-labelledby="tab-chatbots-bots" data-tabs-panel="bots" hidden>
             <div class="card card-light">
                 <div class="card-header">
                     <div class="cp-card-heading">
@@ -146,7 +146,7 @@
             </div>
         </div>
 
-        <div class="tabs-content" role="tabpanel" data-tabs-content="handlers" hidden>
+        <div class="tabs-panel" id="panel-chatbots-handlers" role="tabpanel" aria-labelledby="tab-chatbots-handlers" data-tabs-panel="handlers" hidden>
             <div class="card card-light">
                 <div class="card-header">
                     <div class="cp-card-heading">
@@ -195,7 +195,7 @@
             </div>
         </div>
 
-        <div class="tabs-content" role="tabpanel" data-tabs-content="webhooks" hidden>
+        <div class="tabs-panel" id="panel-chatbots-webhooks" role="tabpanel" aria-labelledby="tab-chatbots-webhooks" data-tabs-panel="webhooks" hidden>
             <div class="cp-detail-card-grid">
                 <div class="card card-light">
                     <div class="card-header">

--- a/control-panel-chatbots/src/main/resources/views/chatbots/detail.hbs
+++ b/control-panel-chatbots/src/main/resources/views/chatbots/detail.hbs
@@ -1,0 +1,286 @@
+{{#with controlPanel.body as |body|}}
+    <div class="tabs" data-tabs>
+        <div class="tabs-list" role="tablist" aria-label="Chatbots diagnostics">
+            <button type="button" class="tabs-trigger active" role="tab" aria-selected="true" data-tabs-trigger="overview">
+                Overview
+            </button>
+            <button type="button" class="tabs-trigger" role="tab" aria-selected="false" data-tabs-trigger="bots">
+                Bots
+            </button>
+            <button type="button" class="tabs-trigger" role="tab" aria-selected="false" data-tabs-trigger="handlers">
+                Handlers
+            </button>
+            <button type="button" class="tabs-trigger" role="tab" aria-selected="false" data-tabs-trigger="webhooks">
+                Webhook
+            </button>
+        </div>
+
+        <div class="tabs-content active" role="tabpanel" data-tabs-content="overview">
+            <div class="cp-detail-card-grid">
+                <div class="card card-light">
+                    <div class="card-header">
+                        <div class="cp-card-heading">
+                            <span class="cp-card-icon"><i class="fas fa-robot"></i></span>
+                            <h3 class="card-title">Summary</h3>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        <div class="cp-data-table-container cp-vertical-table">
+                            <table class="table cp-data-table-table">
+                                <tbody>
+                                <tr>
+                                    <th scope="row">Configured bots</th>
+                                    <td>{{body.summary.totalBots}}</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row">Enabled bots</th>
+                                    <td>{{body.summary.enabledBots}}</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row">Registered endpoints</th>
+                                    <td>{{body.summary.registeredEndpointCount}} / {{body.summary.endpointCount}}</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row">Handler beans</th>
+                                    <td>{{body.summary.handlerCount}}</td>
+                                </tr>
+                                <tr>
+                                    <th scope="row">Telegram webhook lookup</th>
+                                    <td><span class="badge badge-secondary">{{body.summary.webhookLookupState}}</span></td>
+                                </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="card card-light">
+                    <div class="card-header">
+                        <div class="cp-card-heading">
+                            <span class="cp-card-icon"><i class="fas fa-route"></i></span>
+                            <h3 class="card-title">Endpoints</h3>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        {{#if body.endpoints}}
+                            <div class="cp-data-table-container">
+                                <table class="table cp-data-table-table cp-data-table-fixed">
+                                    <thead>
+                                    <tr>
+                                        <th>Channel</th>
+                                        <th>Path</th>
+                                        <th>State</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    {{#each body.endpoints as |endpoint|}}
+                                        <tr>
+                                            <td>{{endpoint.channel}}</td>
+                                            <td><code class="cp-table-code">{{endpoint.path}}</code></td>
+                                            <td>
+                                                {{#if endpoint.routeRegistered}}
+                                                    <span class="badge badge-primary">{{endpoint.state}}</span>
+                                                {{else}}
+                                                    <span class="badge badge-secondary">{{endpoint.state}}</span>
+                                                {{/if}}
+                                            </td>
+                                        </tr>
+                                    {{/each}}
+                                    </tbody>
+                                </table>
+                            </div>
+                        {{else}}
+                            <div class="cp-data-table-empty">No Chatbots endpoint modules detected.</div>
+                        {{/if}}
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="tabs-content" role="tabpanel" data-tabs-content="bots" hidden>
+            <div class="card card-light">
+                <div class="card-header">
+                    <div class="cp-card-heading">
+                        <span class="cp-card-icon"><i class="fas fa-comments"></i></span>
+                        <h3 class="card-title">Configured bots</h3>
+                    </div>
+                </div>
+                <div class="card-body">
+                    {{#if body.bots}}
+                        <div class="cp-data-table" data-filter-table data-filter-table-label="bot" data-filter-table-label-plural="bots">
+                            <div class="cp-data-table-toolbar">
+                                <div class="cp-data-table-summary" data-filter-table-summary>{{body.bots.size}} bots</div>
+                                <div class="cp-data-table-search">
+                                    <input type="search" class="form-control" data-filter-table-input placeholder="Filter bots" aria-label="Filter bots">
+                                </div>
+                            </div>
+                            <div class="cp-data-table-container">
+                                <table class="table cp-data-table-table cp-data-table-fixed">
+                                    <thead>
+                                    <tr>
+                                        <th>Channel</th>
+                                        <th>Name</th>
+                                        <th>Username</th>
+                                        <th>Enabled</th>
+                                        <th>Token status</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    {{#each body.bots as |bot|}}
+                                        <tr>
+                                            <td>{{bot.channel}}</td>
+                                            <td><code class="cp-table-code">{{bot.name}}</code></td>
+                                            <td><code class="cp-table-code">{{bot.username}}</code></td>
+                                            <td>{{#if bot.enabled}}yes{{else}}no{{/if}}</td>
+                                            <td><span class="badge badge-secondary">{{bot.tokenStatus}}</span></td>
+                                        </tr>
+                                    {{/each}}
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    {{else}}
+                        <div class="cp-data-table-empty">No Telegram or Basecamp bot configurations detected.</div>
+                    {{/if}}
+                </div>
+            </div>
+        </div>
+
+        <div class="tabs-content" role="tabpanel" data-tabs-content="handlers" hidden>
+            <div class="card card-light">
+                <div class="card-header">
+                    <div class="cp-card-heading">
+                        <span class="cp-card-icon"><i class="fas fa-list-ol"></i></span>
+                        <h3 class="card-title">Handler beans</h3>
+                    </div>
+                </div>
+                <div class="card-body">
+                    {{#if body.handlers}}
+                        <div class="cp-data-table" data-filter-table data-filter-table-label="handler" data-filter-table-label-plural="handlers">
+                            <div class="cp-data-table-toolbar">
+                                <div class="cp-data-table-summary" data-filter-table-summary>{{body.handlers.size}} handlers</div>
+                                <div class="cp-data-table-search">
+                                    <input type="search" class="form-control" data-filter-table-input placeholder="Filter handlers" aria-label="Filter handlers">
+                                </div>
+                            </div>
+                            <div class="cp-data-table-container">
+                                <table class="table cp-data-table-table cp-data-table-fixed">
+                                    <thead>
+                                    <tr>
+                                        <th>Order</th>
+                                        <th>Bean</th>
+                                        <th>Class</th>
+                                        <th>Channel</th>
+                                        <th>Output</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    {{#each body.handlers as |handler|}}
+                                        <tr>
+                                            <td>{{handler.order}}</td>
+                                            <td><code class="cp-table-code">{{handler.beanName}}</code></td>
+                                            <td><code class="cp-table-code">{{handler.className}}</code></td>
+                                            <td>{{handler.channel}}</td>
+                                            <td><code class="cp-table-code">{{handler.outputType}}</code></td>
+                                        </tr>
+                                    {{/each}}
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    {{else}}
+                        <div class="cp-data-table-empty">No Chatbots handler beans detected.</div>
+                    {{/if}}
+                </div>
+            </div>
+        </div>
+
+        <div class="tabs-content" role="tabpanel" data-tabs-content="webhooks" hidden>
+            <div class="cp-detail-card-grid">
+                <div class="card card-light">
+                    <div class="card-header">
+                        <div class="cp-card-heading">
+                            <span class="cp-card-icon"><i class="fas fa-satellite-dish"></i></span>
+                            <h3 class="card-title">Telegram webhook status</h3>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        {{#if body.webhooks}}
+                            <div class="cp-data-table-container">
+                                <table class="table cp-data-table-table cp-data-table-fixed">
+                                    <thead>
+                                    <tr>
+                                        <th>Bot</th>
+                                        <th>State</th>
+                                        <th>Expected URL</th>
+                                        <th>Returned URL</th>
+                                        <th>Match</th>
+                                        <th>Pending</th>
+                                        <th>Last error</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    {{#each body.webhooks as |webhook|}}
+                                        <tr>
+                                            <td><code class="cp-table-code">{{webhook.botName}}</code></td>
+                                            <td>
+                                                {{#if webhook.available}}
+                                                    <span class="badge badge-primary">{{webhook.state}}</span>
+                                                {{else}}
+                                                    <span class="badge badge-secondary">{{webhook.state}}</span>
+                                                {{/if}}
+                                            </td>
+                                            <td><code class="cp-table-code">{{webhook.expectedUrl}}</code></td>
+                                            <td><code class="cp-table-code">{{webhook.returnedUrl}}</code></td>
+                                            <td>{{webhook.matchStatus}}</td>
+                                            <td>{{webhook.pendingUpdates}}</td>
+                                            <td>{{webhook.lastError}}</td>
+                                        </tr>
+                                    {{/each}}
+                                    </tbody>
+                                </table>
+                            </div>
+                        {{else}}
+                            <div class="cp-data-table-empty">No Telegram bots detected.</div>
+                        {{/if}}
+                    </div>
+                </div>
+
+                <div class="card card-light">
+                    <div class="card-header">
+                        <div class="cp-card-heading">
+                            <span class="cp-card-icon"><i class="fas fa-clipboard-list"></i></span>
+                            <h3 class="card-title">Setup hints</h3>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        {{#if body.setupHints}}
+                            <div class="cp-data-table-container">
+                                <table class="table cp-data-table-table cp-data-table-fixed">
+                                    <thead>
+                                    <tr>
+                                        <th>Channel</th>
+                                        <th>Hint</th>
+                                        <th>Command or value</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    {{#each body.setupHints as |hint|}}
+                                        <tr>
+                                            <td>{{hint.channel}}</td>
+                                            <td>{{hint.label}}</td>
+                                            <td><code class="cp-table-code">{{hint.command}}</code></td>
+                                        </tr>
+                                    {{/each}}
+                                    </tbody>
+                                </table>
+                            </div>
+                        {{else}}
+                            <div class="cp-data-table-empty">No setup hints available.</div>
+                        {{/if}}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+{{/with}}

--- a/control-panel-chatbots/src/test/java/io/micronaut/controlpanel/panels/chatbots/ChatbotsControlPanelTest.java
+++ b/control-panel-chatbots/src/test/java/io/micronaut/controlpanel/panels/chatbots/ChatbotsControlPanelTest.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.chatbots;
+
+import com.sun.net.httpserver.HttpServer;
+import io.micronaut.chatbots.basecamp.api.Query;
+import io.micronaut.chatbots.basecamp.core.BasecampBotConfiguration;
+import io.micronaut.chatbots.basecamp.core.BasecampHandler;
+import io.micronaut.chatbots.core.BotConfiguration;
+import io.micronaut.chatbots.core.Handler;
+import io.micronaut.chatbots.telegram.api.Update;
+import io.micronaut.chatbots.telegram.core.TelegramBotConfiguration;
+import io.micronaut.chatbots.telegram.core.TelegramHandler;
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.core.order.Ordered;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+final class ChatbotsControlPanelTest {
+
+    private static final String TELEGRAM_SECRET = "telegram-secret-token-value";
+    private static final String BOT_API_TOKEN = "123456:bot-api-token-value";
+
+    @Test
+    void panelRendersConfiguredBotsEndpointsHandlersAndRedactsSecrets() {
+        try (ApplicationContext context = ApplicationContext.run(properties())) {
+            ChatbotsControlPanel.Body body = context.getBean(ChatbotsControlPanel.class).getBody();
+
+            Assertions.assertEquals(2, body.summary().totalBots());
+            Assertions.assertEquals(3, body.summary().handlerCount());
+            Assertions.assertTrue(body.bots().stream().anyMatch(bot ->
+                bot.channel().equals("Telegram")
+                    && bot.name().equals("support")
+                    && bot.username().equals("@SupportExampleBot")
+                    && bot.enabled()
+                    && bot.tokenStatus().equals("configured")));
+            Assertions.assertTrue(body.bots().stream().anyMatch(bot ->
+                bot.channel().equals("Basecamp")
+                    && bot.name().equals("ops")
+                    && bot.enabled()
+                    && bot.tokenStatus().equals("not applicable")));
+            Assertions.assertTrue(body.endpoints().stream().anyMatch(endpoint ->
+                endpoint.channel().equals("Telegram")
+                    && endpoint.path().equals("/custom-telegram")
+                    && endpoint.configuredEnabled()));
+            Assertions.assertTrue(body.handlers().stream().anyMatch(handler ->
+                handler.channel().equals("Telegram")
+                    && handler.order() == -5));
+            Assertions.assertTrue(body.handlers().stream().anyMatch(handler ->
+                handler.channel().equals("Basecamp")
+                    && handler.order() == 10));
+            Assertions.assertFalse(body.toString().contains(TELEGRAM_SECRET));
+            Assertions.assertFalse(body.toString().contains(BOT_API_TOKEN));
+            Assertions.assertTrue(body.setupHints().stream().anyMatch(hint -> hint.command().contains("<BOT_API_TOKEN>")));
+            Assertions.assertFalse(SupportTelegramHandler.canHandleCalled.get());
+            Assertions.assertFalse(SupportTelegramHandler.handleCalled.get());
+        }
+    }
+
+    @Test
+    void disabledPanelDoesNotRegister() {
+        Map<String, Object> properties = properties();
+        properties.put("micronaut.control-panel.panels.chatbots.enabled", false);
+        try (ApplicationContext context = ApplicationContext.run(properties)) {
+            Assertions.assertFalse(context.containsBean(ChatbotsControlPanel.class));
+        }
+    }
+
+    @Test
+    void webhookLookupIsOptInAndDegradesPerBot() throws IOException {
+        HttpServer server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/bot" + BOT_API_TOKEN + "/getWebhookInfo", exchange -> {
+            byte[] bytes = """
+                {"ok":true,"result":{"url":"https://dev.example.test/custom-telegram","pending_update_count":0,"max_connections":40,"allowed_updates":["message"],"has_custom_certificate":false}}
+                """.getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, bytes.length);
+            try (OutputStream out = exchange.getResponseBody()) {
+                out.write(bytes);
+            }
+        });
+        server.start();
+        try {
+            Map<String, Object> properties = properties();
+            properties.put("micronaut.control-panel.chatbots.telegram.webhook-status.enabled", true);
+            properties.put("micronaut.control-panel.chatbots.telegram.webhook-status.base-url", "http://localhost:" + server.getAddress().getPort());
+            properties.put("micronaut.control-panel.chatbots.telegram.webhook-status.api-tokens.support", BOT_API_TOKEN);
+            try (ApplicationContext context = ApplicationContext.run(properties)) {
+                ChatbotsControlPanel.Body body = context.getBean(ChatbotsControlPanel.class).getBody();
+                Optional<ChatbotsControlPanel.WebhookRow> webhook = body.webhooks().stream()
+                    .filter(row -> row.botName().equals("support"))
+                    .findFirst();
+
+                Assertions.assertTrue(webhook.isPresent());
+                Assertions.assertTrue(webhook.get().available(), webhook.get()::toString);
+                Assertions.assertEquals("matches expected URL", webhook.get().matchStatus());
+                Assertions.assertEquals("0", webhook.get().pendingUpdates());
+                Assertions.assertFalse(webhook.get().toString().contains(BOT_API_TOKEN));
+            }
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void webhookLookupFailureDoesNotFailPanel() throws IOException {
+        HttpServer server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/bot" + BOT_API_TOKEN + "/getWebhookInfo", exchange -> {
+            byte[] bytes = """
+                {"ok":false,"description":"Unauthorized"}
+                """.getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(401, bytes.length);
+            try (OutputStream out = exchange.getResponseBody()) {
+                out.write(bytes);
+            }
+        });
+        server.start();
+        try {
+            Map<String, Object> properties = properties();
+            properties.put("micronaut.control-panel.chatbots.telegram.webhook-status.enabled", true);
+            properties.put("micronaut.control-panel.chatbots.telegram.webhook-status.base-url", "http://localhost:" + server.getAddress().getPort());
+            properties.put("micronaut.control-panel.chatbots.telegram.webhook-status.api-tokens.support", BOT_API_TOKEN);
+            try (ApplicationContext context = ApplicationContext.run(properties)) {
+                ChatbotsControlPanel.Body body = context.getBean(ChatbotsControlPanel.class).getBody();
+                Optional<ChatbotsControlPanel.WebhookRow> webhook = body.webhooks().stream()
+                    .filter(row -> row.botName().equals("support"))
+                    .findFirst();
+
+                Assertions.assertTrue(webhook.isPresent());
+                Assertions.assertFalse(webhook.get().available(), webhook.get()::toString);
+                Assertions.assertEquals("invalid API token", webhook.get().state());
+                Assertions.assertEquals(2, body.summary().totalBots());
+                Assertions.assertFalse(body.toString().contains(BOT_API_TOKEN));
+            }
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void invalidWebhookLookupConfigurationDoesNotExposeToken() {
+        Map<String, Object> properties = properties();
+        properties.put("micronaut.control-panel.chatbots.telegram.webhook-status.enabled", true);
+        properties.put("micronaut.control-panel.chatbots.telegram.webhook-status.base-url", "http://[invalid");
+        properties.put("micronaut.control-panel.chatbots.telegram.webhook-status.api-tokens.support", BOT_API_TOKEN);
+        try (ApplicationContext context = ApplicationContext.run(properties)) {
+            ChatbotsControlPanel.Body body = context.getBean(ChatbotsControlPanel.class).getBody();
+            Optional<ChatbotsControlPanel.WebhookRow> webhook = body.webhooks().stream()
+                .filter(row -> row.botName().equals("support"))
+                .findFirst();
+
+            Assertions.assertTrue(webhook.isPresent());
+            Assertions.assertFalse(webhook.get().available(), webhook.get()::toString);
+            Assertions.assertEquals("lookup configuration error", webhook.get().state());
+            Assertions.assertEquals(2, body.summary().totalBots());
+            Assertions.assertFalse(body.toString().contains(BOT_API_TOKEN));
+        }
+    }
+
+    private static Map<String, Object> properties() {
+        return new LinkedHashMap<>(Map.ofEntries(
+            Map.entry("micronaut.application.name", "chatbots-test"),
+            Map.entry("micronaut.control-panel.chatbots.public-url", "https://dev.example.test"),
+            Map.entry("micronaut.chatbots.telegram.endpoint.path", "/custom-telegram"),
+            Map.entry("micronaut.chatbots.basecamp.endpoint.path", "/custom-basecamp"),
+            Map.entry("micronaut.chatbots.telegram.bots.support.token", TELEGRAM_SECRET),
+            Map.entry("micronaut.chatbots.telegram.bots.support.at-username", "@SupportExampleBot"),
+            Map.entry("micronaut.chatbots.telegram.bots.support.enabled", true),
+            Map.entry("micronaut.chatbots.basecamp.bots.ops.enabled", true)
+        ));
+    }
+
+    @Singleton
+    @Named("supportTelegramHandler")
+    static final class SupportTelegramHandler implements TelegramHandler<String> {
+        static final AtomicBoolean canHandleCalled = new AtomicBoolean();
+        static final AtomicBoolean handleCalled = new AtomicBoolean();
+
+        @Override
+        public int getOrder() {
+            return -5;
+        }
+
+        @Override
+        public boolean canHandle(TelegramBotConfiguration bot, Update input) {
+            canHandleCalled.set(true);
+            return false;
+        }
+
+        @Override
+        public Optional<String> handle(TelegramBotConfiguration bot, Update input) {
+            handleCalled.set(true);
+            return Optional.empty();
+        }
+    }
+
+    @Singleton
+    @Named("opsBasecampHandler")
+    static final class OpsBasecampHandler implements BasecampHandler {
+        @Override
+        public int getOrder() {
+            return 10;
+        }
+
+        @Override
+        public boolean canHandle(BasecampBotConfiguration bot, Query input) {
+            return false;
+        }
+
+        @Override
+        public Optional<String> handle(BasecampBotConfiguration bot, Query input) {
+            return Optional.empty();
+        }
+    }
+
+    @Singleton
+    @Named("genericChatbotsHandler")
+    static final class GenericChatbotsHandler implements Handler<BotConfiguration, Object, Object> {
+        @Override
+        public int getOrder() {
+            return Ordered.LOWEST_PRECEDENCE;
+        }
+
+        @Override
+        public boolean canHandle(BotConfiguration bot, Object input) {
+            return false;
+        }
+
+        @Override
+        public Optional<Object> handle(BotConfiguration bot, Object input) {
+            return Optional.empty();
+        }
+    }
+}

--- a/control-panel-chatbots/src/test/java/io/micronaut/controlpanel/panels/chatbots/ChatbotsControlPanelTest.java
+++ b/control-panel-chatbots/src/test/java/io/micronaut/controlpanel/panels/chatbots/ChatbotsControlPanelTest.java
@@ -38,6 +38,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 final class ChatbotsControlPanelTest {
@@ -157,6 +158,53 @@ final class ChatbotsControlPanelTest {
             }
         } finally {
             server.stop(0);
+        }
+    }
+
+    @Test
+    void badgeDoesNotPerformWebhookLookup() throws IOException {
+        AtomicInteger requests = new AtomicInteger();
+        HttpServer server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+        server.createContext("/bot" + BOT_API_TOKEN + "/getWebhookInfo", exchange -> {
+            requests.incrementAndGet();
+            byte[] bytes = """
+                {"ok":true,"result":{"url":"https://dev.example.test/custom-telegram","pending_update_count":0}}
+                """.getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, bytes.length);
+            try (OutputStream out = exchange.getResponseBody()) {
+                out.write(bytes);
+            }
+        });
+        server.start();
+        try {
+            Map<String, Object> properties = properties();
+            properties.put("micronaut.control-panel.chatbots.telegram.webhook-status.enabled", true);
+            properties.put("micronaut.control-panel.chatbots.telegram.webhook-status.base-url", "http://localhost:" + server.getAddress().getPort());
+            properties.put("micronaut.control-panel.chatbots.telegram.webhook-status.api-tokens.support", BOT_API_TOKEN);
+            try (ApplicationContext context = ApplicationContext.run(properties)) {
+                ChatbotsControlPanel controlPanel = context.getBean(ChatbotsControlPanel.class);
+
+                Assertions.assertEquals("2 bots / 3 handlers", controlPanel.getBadge());
+                Assertions.assertEquals(0, requests.get());
+
+                controlPanel.getBody();
+                Assertions.assertEquals(1, requests.get());
+            }
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void setupHintUsesConfiguredEndpointPathWhenPublicUrlIsMissing() {
+        Map<String, Object> properties = properties();
+        properties.remove("micronaut.control-panel.chatbots.public-url");
+        try (ApplicationContext context = ApplicationContext.run(properties)) {
+            ChatbotsControlPanel.Body body = context.getBean(ChatbotsControlPanel.class).getBody();
+
+            Assertions.assertTrue(body.setupHints().stream()
+                .filter(hint -> hint.label().equals("setWebhook for support"))
+                .anyMatch(hint -> hint.command().contains("https://example.test/custom-telegram")));
         }
     }
 

--- a/control-panel-core/build.gradle.kts
+++ b/control-panel-core/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
 
 dependencies {
     api(mn.micronaut.router)
-    implementation(mn.micronaut.discovery.core)
     implementation(mn.micronaut.http.server)
     implementation(mn.micronaut.json.core)
     compileOnly(libs.micronaut.security)

--- a/control-panel-core/src/main/java/io/micronaut/controlpanel/core/ControlPanelUrlLogger.java
+++ b/control-panel-core/src/main/java/io/micronaut/controlpanel/core/ControlPanelUrlLogger.java
@@ -19,10 +19,10 @@ import io.micronaut.context.annotation.Requires;
 import io.micronaut.controlpanel.core.config.ControlPanelModuleConfiguration;
 import io.micronaut.controlpanel.util.ControlPanelUtils;
 import io.micronaut.core.util.StringUtils;
-import io.micronaut.discovery.event.ServiceReadyEvent;
 import io.micronaut.http.server.HttpServerConfiguration;
 import io.micronaut.runtime.ApplicationConfiguration;
 import io.micronaut.runtime.event.annotation.EventListener;
+import io.micronaut.runtime.server.event.ServerStartupEvent;
 import jakarta.inject.Singleton;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,12 +51,12 @@ public class ControlPanelUrlLogger {
     }
 
     /**
-     * Logs the Control Panel URL when the ServiceReadyEvent is triggered.
+     * Logs the Control Panel URL when the server startup event is triggered.
      *
-     * @param event the ServiceReadyEvent that triggered this method call
+     * @param event the server startup event that triggered this method call
      */
     @EventListener
-    public void logUrl(ServiceReadyEvent event) {
+    public void logUrl(ServerStartupEvent event) {
         var baseUrl = event.getSource().getURI().toString();
         var controlPanelUrl = baseUrl + ControlPanelUtils.computeControlPanelPath(applicationPath, controlPanelPath);
         var prefix = applicationName.map("[%s]"::formatted).orElse("");

--- a/doc-examples/example-java/build.gradle.kts
+++ b/doc-examples/example-java/build.gradle.kts
@@ -50,6 +50,11 @@ dependencies {
     implementation(libs.avro)
     implementation(libs.avro.serde)
 
+    // Chatbots
+    implementation(projects.micronautControlPanelChatbots)
+    implementation(mnChatbots.micronaut.chatbots.telegram.http)
+    implementation(mnChatbots.micronaut.chatbots.basecamp.http)
+
     // OpenAPI + Swagger UI (views generated at compile-time)
     annotationProcessor(mnOpenapi.micronaut.openapi)
     testAnnotationProcessor(mnOpenapi.micronaut.openapi)

--- a/doc-examples/example-java/src/main/java/example/OpsBasecampHandler.java
+++ b/doc-examples/example-java/src/main/java/example/OpsBasecampHandler.java
@@ -1,0 +1,27 @@
+package example;
+
+import io.micronaut.chatbots.basecamp.api.Query;
+import io.micronaut.chatbots.basecamp.core.BasecampBotConfiguration;
+import io.micronaut.chatbots.basecamp.core.BasecampHandler;
+import jakarta.inject.Singleton;
+
+import java.util.Optional;
+
+@Singleton
+final class OpsBasecampHandler implements BasecampHandler {
+
+    @Override
+    public int getOrder() {
+        return 10;
+    }
+
+    @Override
+    public boolean canHandle(BasecampBotConfiguration bot, Query input) {
+        return false;
+    }
+
+    @Override
+    public Optional<String> handle(BasecampBotConfiguration bot, Query input) {
+        return Optional.empty();
+    }
+}

--- a/doc-examples/example-java/src/main/java/example/SupportTelegramHandler.java
+++ b/doc-examples/example-java/src/main/java/example/SupportTelegramHandler.java
@@ -1,0 +1,27 @@
+package example;
+
+import io.micronaut.chatbots.telegram.api.Update;
+import io.micronaut.chatbots.telegram.core.TelegramBotConfiguration;
+import io.micronaut.chatbots.telegram.core.TelegramHandler;
+import jakarta.inject.Singleton;
+
+import java.util.Optional;
+
+@Singleton
+final class SupportTelegramHandler implements TelegramHandler<String> {
+
+    @Override
+    public int getOrder() {
+        return 0;
+    }
+
+    @Override
+    public boolean canHandle(TelegramBotConfiguration bot, Update input) {
+        return false;
+    }
+
+    @Override
+    public Optional<String> handle(TelegramBotConfiguration bot, Update input) {
+        return Optional.empty();
+    }
+}

--- a/doc-examples/example-java/src/main/resources/application.yml
+++ b/doc-examples/example-java/src/main/resources/application.yml
@@ -11,6 +11,8 @@ micronaut:
 #end::control-panel[]
     env:
       show-values: true
+    chatbots:
+      public-url: https://example.test
   router:
     static-resources:
       swagger:
@@ -28,6 +30,21 @@ micronaut:
       initial-capacity: 2
   application:
     name: myApplication
+  chatbots:
+    telegram:
+      endpoint:
+        path: /telegram
+      bots:
+        support:
+          token: sample-telegram-webhook-secret
+          at-username: "@SupportExampleBot"
+          enabled: true
+    basecamp:
+      endpoint:
+        path: /basecamp
+      bots:
+        ops:
+          enabled: true
 
 info:
   demo:

--- a/doc-examples/example-java/src/test/java/example/ControlPanelRenderingTest.java
+++ b/doc-examples/example-java/src/test/java/example/ControlPanelRenderingTest.java
@@ -32,6 +32,7 @@ class ControlPanelRenderingTest {
         assertTrue(body.contains("configured"));
         assertTrue(body.contains("ops"));
         assertTrue(body.contains("SupportTelegramHandler"));
+        assertTrue(body.contains("data-tabs-panel=\"handlers\""));
         assertTrue(body.contains("lookup configuration error"));
         assertTrue(!body.contains("sample-telegram-webhook-secret"));
         assertTrue(!body.contains("123456:bot-api-token-value"));

--- a/doc-examples/example-java/src/test/java/example/ControlPanelRenderingTest.java
+++ b/doc-examples/example-java/src/test/java/example/ControlPanelRenderingTest.java
@@ -1,5 +1,6 @@
 package example;
 
+import io.micronaut.context.annotation.Property;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.client.HttpClient;
 import io.micronaut.http.client.annotation.Client;
@@ -9,6 +10,9 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @MicronautTest
+@Property(name = "micronaut.control-panel.chatbots.telegram.webhook-status.enabled", value = "true")
+@Property(name = "micronaut.control-panel.chatbots.telegram.webhook-status.base-url", value = "http://[invalid")
+@Property(name = "micronaut.control-panel.chatbots.telegram.webhook-status.api-tokens.support", value = "123456:bot-api-token-value")
 class ControlPanelRenderingTest {
 
     @Test
@@ -17,5 +21,20 @@ class ControlPanelRenderingTest {
 
         assertTrue(body.contains("my-local"));
         assertTrue(body.contains("files stored."));
+    }
+
+    @Test
+    void rendersChatbotsCategory(@Client("/") HttpClient client) {
+        var body = client.toBlocking().retrieve(HttpRequest.GET("/control-panel/chatbots"));
+
+        assertTrue(body.contains("Chatbots"));
+        assertTrue(body.contains("support"));
+        assertTrue(body.contains("configured"));
+        assertTrue(body.contains("ops"));
+        assertTrue(body.contains("SupportTelegramHandler"));
+        assertTrue(body.contains("lookup configuration error"));
+        assertTrue(!body.contains("sample-telegram-webhook-secret"));
+        assertTrue(!body.contains("123456:bot-api-token-value"));
+        assertTrue(!body.contains("http://[invalid"));
     }
 }

--- a/doc-examples/example-java/src/test/java/example/e2e/ControlPanelE2ETest.java
+++ b/doc-examples/example-java/src/test/java/example/e2e/ControlPanelE2ETest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.condition.DisabledInNativeImage;
 
+import java.nio.file.Paths;
 import java.util.regex.Pattern;
 
 import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
@@ -240,6 +241,30 @@ class ControlPanelE2ETest extends AbstractE2ETest {
         page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Details")).click();
 
         assertThat(page.getByRole(AriaRole.DEFINITION)).containsText("/tmp/foo");
+    }
+
+    @Test
+    void testChatbots(Page page) {
+        page.setViewportSize(1440, 900);
+        page.navigate(baseUrl() + "/chatbots");
+
+        assertThat(body(page)).containsText("Chatbots");
+        assertThat(body(page)).containsText("support");
+        assertThat(body(page)).containsText("ops");
+        assertThat(body(page)).containsText("SupportTelegramHandler");
+        assertThat(body(page)).containsText("lookup disabled");
+        assertThat(body(page)).not().containsText("sample-telegram-webhook-secret");
+        page.screenshot(new Page.ScreenshotOptions()
+            .setPath(Paths.get("output/playwright/DEV-479-chatbots-1440x900.png"))
+            .setFullPage(true));
+
+        page.setViewportSize(390, 844);
+        page.navigate(baseUrl() + "/chatbots");
+        assertThat(body(page)).containsText("Chatbots");
+        assertThat(body(page)).not().containsText("sample-telegram-webhook-secret");
+        page.screenshot(new Page.ScreenshotOptions()
+            .setPath(Paths.get("output/playwright/DEV-479-chatbots-390x844.png"))
+            .setFullPage(true));
     }
 
     @Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ micronaut-testresources = "4.0.0"
 micronaut-gradle-plugin = "5.0.0-M1"
 micronaut-openapi = "7.0.0"
 micronaut-kafka = "6.0.0"
+micronaut-chatbots = "2.0.0-RC2"
 kotlin-gradle-plugin = "2.3.21"
 micronaut-shared-settings = "8.0.0"
 playwright = "1.59.0"
@@ -58,6 +59,7 @@ micronaut-sql = { module = "io.micronaut.sql:micronaut-sql-bom", version.ref = "
 micronaut-data = { module = "io.micronaut.data:micronaut-data-bom", version.ref = "micronaut-data" }
 micronaut-testresources = { module = 'io.micronaut.testresources:micronaut-test-resources-bom', version.ref = "micronaut-testresources" }
 micronaut-kafka = { module = "io.micronaut.kafka:micronaut-kafka-bom", version.ref = "micronaut-kafka" }
+micronaut-chatbots = { module = "io.micronaut.chatbots:micronaut-chatbots-bom", version.ref = "micronaut-chatbots" }
 avro = { module = "org.apache.avro:avro", version.ref = "avro" }
 avro-serde = { module = "io.confluent:kafka-streams-avro-serde", version.ref = "avro-serde" }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,6 +22,7 @@ include("control-panel-datasource")
 include("control-panel-hibernate")
 include("control-panel-ui")
 include("control-panel-kafka")
+include("control-panel-chatbots")
 
 include("doc-examples:example-java")
 
@@ -42,4 +43,5 @@ configure<MicronautBuildSettingsExtension> {
     importMicronautCatalog("micronaut-testresources")
     importMicronautCatalog("micronaut-openapi")
     importMicronautCatalog("micronaut-kafka")
+    importMicronautCatalog("micronaut-chatbots")
 }

--- a/src/main/docs/guide/controlPanels/chatbots.adoc
+++ b/src/main/docs/guide/controlPanels/chatbots.adoc
@@ -1,0 +1,74 @@
+The Chatbots control panel provides development-time diagnostics for applications that use Micronaut Chatbots Telegram and Basecamp webhook integrations.
+
+dependency:io.micronaut.controlpanel:micronaut-control-panel-chatbots[scope=developmentOnly]
+
+Add the Micronaut Chatbots HTTP modules used by your application, for example `micronaut-chatbots-telegram-http` and/or `micronaut-chatbots-basecamp-http`.
+
+The panel shows:
+
+* configured Telegram and Basecamp bot names
+* Telegram usernames
+* enabled or disabled bot state
+* token presence only, never token values
+* Telegram and Basecamp endpoint path and route registration state
+* registered `Handler`, `TelegramHandler`, and `BasecampHandler` beans with bean name, implementation class, channel, output type, and order
+* optional read-only Telegram `getWebhookInfo` diagnostics
+* setup hints that use placeholders instead of secrets
+
+The panel does not call handler `canHandle` or `handle` methods and does not change Chatbots dispatch behavior, endpoint routing, token validation, or webhook registration.
+
+== Disabling the panel
+
+To disable only this panel:
+
+[configuration]
+----
+micronaut:
+  control-panel:
+    panels:
+      chatbots:
+        enabled: false
+----
+
+== Secret handling
+
+The panel redacts sensitive values. It does not render Telegram webhook secret tokens, Telegram Bot API tokens, Basecamp OAuth or access tokens, authorization headers, or generated command secrets.
+
+Generated Telegram setup hints use placeholders such as `<BOT_API_TOKEN>` and `<SECRET_TOKEN>`.
+
+== Public URL and webhook status lookup
+
+By default, the panel does not make external network calls. Telegram webhook status lookup is read-only and opt-in.
+
+[configuration]
+----
+micronaut:
+  control-panel:
+    chatbots:
+      public-url: https://dev.example.test
+      telegram:
+        webhook-status:
+          enabled: true
+          api-tokens:
+            support: <BOT_API_TOKEN>
+----
+
+The `public-url` value is combined with the configured Telegram endpoint path to show the expected webhook URL. If no public URL is configured, the panel reports that the expected URL is not configured and uses placeholder setup hints.
+
+The Bot API token configured under `api-tokens` is used only for Telegram `getWebhookInfo`. It is separate from the Telegram webhook secret token configured for Micronaut Chatbots and must not be the value used for `X-Telegram-Bot-Api-Secret-Token` validation.
+
+== Interpreting states
+
+`not configured` means the relevant value is absent, for example no public URL or no Telegram returned webhook URL.
+
+`configured disabled` means configuration explicitly disables the endpoint.
+
+`configured enabled but route not registered` means the endpoint setting is enabled, but the HTTP route is not available in the running application. Check that the corresponding Chatbots HTTP module is on the classpath.
+
+`HTTP module absent` means the Telegram or Basecamp HTTP integration is not present.
+
+`lookup disabled` means Telegram webhook status lookup is not enabled. `API token not configured` means lookup is enabled but there is no per-bot Bot API token. Lookup failures are shown per bot and do not prevent the rest of the panel from rendering.
+
+== Local verification
+
+Run an application with `micronaut-control-panel-ui`, this module, and sample Telegram or Basecamp bot configuration. Open the Control Panel and select the Chatbots category. Verify that configured bots, endpoint state, handler order, and setup hints are visible and that token values do not appear in the UI.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -10,6 +10,7 @@ controlPanels:
   datasource: Datasource
   hibernate: Hibernate
   kafka: Kafka
+  chatbots: Chatbots
 
 custom: Creating Custom Control Panels
 repository: Repository


### PR DESCRIPTION
## Summary

- Add `micronaut-control-panel-chatbots`, an optional Chatbots diagnostics panel for Telegram and Basecamp webhook integrations.
- Show configured bots, endpoint/route state, handler bean order, redacted setup hints, and opt-in read-only Telegram `getWebhookInfo` status.
- Wire the module through the BOM/catalog settings, example app, focused rendering/E2E coverage, and user guide navigation.

## Issue Linkage

Closes DEV-479.

No linked GitHub issue is present for this Paperclip-originated work item, so there is no GitHub issue creator to request as a reviewer.

## Screenshots

Desktop 1440x900:

![Desktop screenshot](https://raw.githubusercontent.com/micronaut-projects/micronaut-control-panel/3e0ce724b19c761473742302d11d1f71c1746bdd/assets/pr-570/a977f16ead10/DEV-479-chatbots-1440x900.png)

Mobile 390x844:

![Mobile screenshot](https://raw.githubusercontent.com/micronaut-projects/micronaut-control-panel/3d184935ec435513876dbf0e168b0b4ec133b6c9/assets/pr-570/a977f16ead10/DEV-479-chatbots-390x844.png)

## Verification

- `./gradlew :micronaut-control-panel-chatbots:checkstyleMain`
- `./gradlew :micronaut-control-panel-chatbots:check`
- `./gradlew :micronaut-control-panel-chatbots:test :micronaut-doc-examples:micronaut-example-java:test --tests example.ControlPanelRenderingTest`
- `./gradlew spotlessCheck`
- `git diff --check`
- `./gradlew docs`
- `CI=true ./gradlew :micronaut-doc-examples:micronaut-example-java:test --tests example.e2e.ControlPanelE2ETest.testChatbots --rerun-tasks`
- 2026-05-21 retarget follow-through after rebasing onto `2.1.x`: `./gradlew :micronaut-control-panel-chatbots:check :micronaut-doc-examples:micronaut-example-java:test --tests example.ControlPanelRenderingTest`
- 2026-05-21 retarget follow-through: `git diff --check`

## Project Targeting

This PR is currently based on `2.1.x` and linked to the live `5.1.0 Release` project. The branch was rebased onto the current `2.1.x` tip after retargeting, preserving the Chatbots feature diff while incorporating the upstream Kafka control panel changes.

## Review Follow-Up

Addressed automated review feedback in follow-up commit `a977f16` by avoiding webhook lookup from badge rendering, reusing the Telegram status HTTP client, preserving custom endpoint paths in placeholder setup hints, and switching the Chatbots tabs to the project's `data-tabs-panel` markup with ARIA linkage.

Addressed the CI Checkstyle failure in follow-up commit `dc2ed47` by adding required record-component Javadocs to the new Chatbots view models and fixing diagnostics field declaration order.

Addressed `2.0.x`/`2.1.x` follow-through in later commits by moving the Control Panel URL logger to `ServerStartupEvent`, avoiding stale published Control Panel artifacts in the example Test Resources setup, rebasing over the latest `2.1.x`, and aligning the new Chatbots module with the current Error Prone/NullAway and binary compatibility checks.

---
###### ✨ This message was AI-generated using gpt-5