### PR TITLE
Add GraalPy diagnostics control panel

### DIFF
--- a/control-panel-core/build.gradle.kts
+++ b/control-panel-core/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
 
 dependencies {
     api(mn.micronaut.router)
-    implementation(mn.micronaut.discovery.core)
     implementation(mn.micronaut.http.server)
     implementation(mn.micronaut.json.core)
     compileOnly(libs.micronaut.security)

--- a/control-panel-core/src/main/java/io/micronaut/controlpanel/core/ControlPanelUrlLogger.java
+++ b/control-panel-core/src/main/java/io/micronaut/controlpanel/core/ControlPanelUrlLogger.java
@@ -19,10 +19,10 @@ import io.micronaut.context.annotation.Requires;
 import io.micronaut.controlpanel.core.config.ControlPanelModuleConfiguration;
 import io.micronaut.controlpanel.util.ControlPanelUtils;
 import io.micronaut.core.util.StringUtils;
-import io.micronaut.discovery.event.ServiceReadyEvent;
 import io.micronaut.http.server.HttpServerConfiguration;
 import io.micronaut.runtime.ApplicationConfiguration;
 import io.micronaut.runtime.event.annotation.EventListener;
+import io.micronaut.runtime.server.event.ServerStartupEvent;
 import jakarta.inject.Singleton;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,12 +51,12 @@ public class ControlPanelUrlLogger {
     }
 
     /**
-     * Logs the Control Panel URL when the ServiceReadyEvent is triggered.
+     * Logs the Control Panel URL when the ServerStartupEvent is triggered.
      *
-     * @param event the ServiceReadyEvent that triggered this method call
+     * @param event the ServerStartupEvent that triggered this method call
      */
     @EventListener
-    public void logUrl(ServiceReadyEvent event) {
+    public void logUrl(ServerStartupEvent event) {
         var baseUrl = event.getSource().getURI().toString();
         var controlPanelUrl = baseUrl + ControlPanelUtils.computeControlPanelPath(applicationPath, controlPanelPath);
         var prefix = applicationName.map("[%s]"::formatted).orElse("");

--- a/control-panel-graalpy/build.gradle.kts
+++ b/control-panel-graalpy/build.gradle.kts
@@ -1,0 +1,20 @@
+plugins {
+    io.micronaut.build.internal.`control-panel-module`
+}
+
+dependencies {
+    api(projects.micronautControlPanelCore)
+
+    compileOnly(libs.micronaut.graalpy)
+
+    testAnnotationProcessor(mn.micronaut.inject.java)
+    testImplementation(mnTest.micronaut.test.junit5)
+    testImplementation(mnTest.mockito.junit.jupiter)
+    testImplementation(libs.micronaut.graalpy)
+    testImplementation(mn.micronaut.http.server.netty)
+    testRuntimeOnly(mnTest.junit.jupiter.engine)
+}
+
+micronautBuild {
+    binaryCompatibility.enabledAfter("2.0.0")
+}

--- a/control-panel-graalpy/build.gradle.kts
+++ b/control-panel-graalpy/build.gradle.kts
@@ -16,5 +16,5 @@ dependencies {
 }
 
 micronautBuild {
-    binaryCompatibility.enabledAfter("2.0.0")
+    binaryCompatibility.enabledAfter("2.0.1")
 }

--- a/control-panel-graalpy/src/main/java/io/micronaut/controlpanel/panels/graalpy/GraalPyControlPanel.java
+++ b/control-panel-graalpy/src/main/java/io/micronaut/controlpanel/panels/graalpy/GraalPyControlPanel.java
@@ -1,0 +1,310 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.graalpy;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.Qualifier;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.controlpanel.core.AbstractControlPanel;
+import io.micronaut.controlpanel.core.ControlPanel;
+import io.micronaut.controlpanel.core.config.ControlPanelConfiguration;
+import io.micronaut.core.annotation.ReflectiveAccess;
+import io.micronaut.core.type.Argument;
+import io.micronaut.graal.graalpy.GraalPyContextBuilderFactory;
+import io.micronaut.graal.graalpy.annotations.GraalPyModule;
+import io.micronaut.inject.BeanDefinition;
+import io.micronaut.inject.ExecutableMethod;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Read-only diagnostics for Micronaut GraalPy module definitions.
+ */
+@Singleton
+@Requires(classes = GraalPyModule.class)
+public class GraalPyControlPanel extends AbstractControlPanel<GraalPyControlPanel.Body> {
+
+    /**
+     * Panel name.
+     */
+    public static final String NAME = "graalpy";
+    /**
+     * Property that enables or disables the GraalPy panel.
+     */
+    public static final String ENABLED_PROPERTY = ControlPanelConfiguration.PREFIX + "." + NAME + ".enabled";
+    /**
+     * GraalPy category used by the sidebar.
+     */
+    public static final ControlPanel.Category CATEGORY = new ControlPanel.Category("graalpy", "GraalPy", "fa-brands fa-python");
+
+    private static final String GRAALPY_CONTEXT_CLASS_NAME = "io.micronaut.graal.graalpy.GraalPyContext";
+
+    private final BeanContext beanContext;
+    private final GraalPyVfsMetadataReader vfsMetadataReader;
+
+    /**
+     * Constructor.
+     *
+     * @param beanContext the bean context to inspect
+     * @param vfsMetadataReader the VFS metadata reader
+     * @param configuration panel configuration
+     */
+    public GraalPyControlPanel(BeanContext beanContext,
+                               GraalPyVfsMetadataReader vfsMetadataReader,
+                               @Named(NAME) ControlPanelConfiguration configuration) {
+        super(NAME, configuration);
+        this.beanContext = beanContext;
+        this.vfsMetadataReader = vfsMetadataReader;
+    }
+
+    @Override
+    public Body getBody() {
+        List<ModuleInterface> modules = discoverModules();
+        RuntimeMetadata runtime = discoverRuntimeMetadata();
+        GraalPyVfsMetadataReader.GraalPyVfsMetadata vfs = vfsMetadataReader.read();
+        return new Body(modules, runtime, vfs);
+    }
+
+    @Override
+    public String getBadge() {
+        return String.valueOf(discoverModules().size());
+    }
+
+    @Override
+    public ControlPanel.Category getCategory() {
+        return CATEGORY;
+    }
+
+    private List<ModuleInterface> discoverModules() {
+        return beanContext.getAllBeanDefinitions()
+            .stream()
+            .filter(definition -> definition.hasStereotype(GraalPyModule.class) || definition.hasDeclaredStereotype(GraalPyModule.class))
+            .map(this::moduleInterface)
+            .sorted(Comparator.comparing(ModuleInterface::javaType).thenComparing(ModuleInterface::beanName))
+            .toList();
+    }
+
+    private ModuleInterface moduleInterface(BeanDefinition<?> definition) {
+        String moduleName = definition.stringValue(GraalPyModule.class).orElse("");
+        List<MethodSignature> methods = methodSignatures(definition);
+        return new ModuleInterface(
+            definition.getName(),
+            definition.getBeanType().getName(),
+            moduleName,
+            definition.getScopeName().orElse("Unknown"),
+            qualifierName(definition),
+            "Unknown",
+            methods
+        );
+    }
+
+    private static String qualifierName(BeanDefinition<?> definition) {
+        Qualifier<?> qualifier = definition.getDeclaredQualifier();
+        return qualifier == null ? "Default" : qualifier.toString();
+    }
+
+    private static List<MethodSignature> methodSignatures(BeanDefinition<?> definition) {
+        Collection<ExecutableMethod<?, ?>> executableMethods = new ArrayList<>(definition.getExecutableMethods());
+        if (!executableMethods.isEmpty()) {
+            return executableMethods.stream()
+                .filter(GraalPyControlPanel::isUserMethod)
+                .map(GraalPyControlPanel::methodSignature)
+                .sorted(Comparator.comparing(MethodSignature::name).thenComparing(MethodSignature::signature))
+                .toList();
+        }
+        return Arrays.stream(definition.getBeanType().getMethods())
+            .filter(GraalPyControlPanel::isUserMethod)
+            .map(GraalPyControlPanel::methodSignature)
+            .sorted(Comparator.comparing(MethodSignature::name).thenComparing(MethodSignature::signature))
+            .toList();
+    }
+
+    private static boolean isUserMethod(ExecutableMethod<?, ?> method) {
+        Method targetMethod = method.getTargetMethod();
+        return isUserMethod(targetMethod);
+    }
+
+    private static boolean isUserMethod(Method method) {
+        return method.getDeclaringClass() != Object.class
+            && !method.isSynthetic()
+            && !method.isBridge()
+            && !Modifier.isStatic(method.getModifiers());
+    }
+
+    private static MethodSignature methodSignature(ExecutableMethod<?, ?> method) {
+        String name = method.getMethodName();
+        String returnType = displayType(method.getReturnType().asArgument());
+        String parameters = Arrays.stream(method.getArguments())
+            .map(GraalPyControlPanel::displayParameter)
+            .collect(Collectors.joining(", "));
+        return new MethodSignature(name, returnType, parameters, returnType + " " + name + "(" + parameters + ")");
+    }
+
+    private static MethodSignature methodSignature(Method method) {
+        String name = method.getName();
+        String returnType = displayType(method.getGenericReturnType());
+        String parameters = Arrays.stream(method.getGenericParameterTypes())
+            .map(GraalPyControlPanel::displayType)
+            .collect(Collectors.joining(", "));
+        return new MethodSignature(name, returnType, parameters, returnType + " " + name + "(" + parameters + ")");
+    }
+
+    private static String displayParameter(Argument<?> argument) {
+        return displayType(argument) + " " + argument.getName();
+    }
+
+    private static String displayType(Argument<?> argument) {
+        return argument.getTypeString(false);
+    }
+
+    private static String displayType(Type type) {
+        return type.getTypeName()
+            .replace("java.lang.", "")
+            .replace("java.util.", "");
+    }
+
+    private RuntimeMetadata discoverRuntimeMetadata() {
+        List<String> factoryCandidates = beanContext.getBeanDefinitions(GraalPyContextBuilderFactory.class)
+            .stream()
+            .map(definition -> definition.getBeanType().getName())
+            .sorted()
+            .toList();
+        String factoryStatus = factoryCandidates.isEmpty() ? "Unavailable" : factoryCandidates.size() == 1 ? "Available" : "Ambiguous";
+        String activeFactoryClass = factoryCandidates.size() == 1 ? factoryCandidates.get(0) : "";
+        boolean sharedContextPresent = beanContext.getAllBeanDefinitions()
+            .stream()
+            .map(BeanDefinition::getBeanType)
+            .map(Class::getName)
+            .anyMatch(GRAALPY_CONTEXT_CLASS_NAME::equals);
+        return new RuntimeMetadata(factoryStatus, activeFactoryClass, factoryCandidates, sharedContextPresent);
+    }
+
+    /**
+     * Detail body for the GraalPy panel.
+     *
+     * @param modules discovered module interfaces
+     * @param runtime runtime metadata
+     * @param vfs VFS metadata
+     */
+    @ReflectiveAccess
+    public record Body(
+        List<ModuleInterface> modules,
+        RuntimeMetadata runtime,
+        GraalPyVfsMetadataReader.GraalPyVfsMetadata vfs) {
+
+        /**
+         * @return whether at least one GraalPy module interface was detected
+         */
+        public boolean hasModules() {
+            return !modules.isEmpty();
+        }
+
+        /**
+         * @return number of detected GraalPy module interfaces
+         */
+        public int moduleCount() {
+            return modules.size();
+        }
+    }
+
+    /**
+     * Description of a bean definition annotated with {@link GraalPyModule}.
+     *
+     * @param beanName bean name
+     * @param javaType Java interface type
+     * @param pythonModule Python module name
+     * @param scope scope metadata
+     * @param qualifier qualifier metadata
+     * @param instantiated safe instantiation state
+     * @param methods Java method signatures
+     */
+    @ReflectiveAccess
+    public record ModuleInterface(
+        String beanName,
+        String javaType,
+        String pythonModule,
+        String scope,
+        String qualifier,
+        String instantiated,
+        List<MethodSignature> methods) {
+
+        /**
+         * @return whether method signatures are available
+         */
+        public boolean hasMethods() {
+            return !methods.isEmpty();
+        }
+
+        /**
+         * @return method signature count
+         */
+        public int methodCount() {
+            return methods.size();
+        }
+    }
+
+    /**
+     * Java method signature expected to map to a Python function.
+     *
+     * @param name method name
+     * @param returnType return type
+     * @param parameters parameter list
+     * @param signature display signature
+     */
+    @ReflectiveAccess
+    public record MethodSignature(String name, String returnType, String parameters, String signature) {
+    }
+
+    /**
+     * Runtime metadata that can be discovered without creating GraalPy contexts.
+     *
+     * @param factoryStatus factory candidate state
+     * @param activeFactoryClass single factory class when unambiguous
+     * @param factoryCandidates factory candidate classes
+     * @param sharedContextPresent whether the shared context bean definition is present
+     */
+    @ReflectiveAccess
+    public record RuntimeMetadata(
+        String factoryStatus,
+        String activeFactoryClass,
+        List<String> factoryCandidates,
+        boolean sharedContextPresent) {
+
+        /**
+         * @return whether a single factory candidate was found
+         */
+        public boolean hasActiveFactory() {
+            return !activeFactoryClass.isBlank();
+        }
+
+        /**
+         * @return whether any factory candidates were found
+         */
+        public boolean hasFactoryCandidates() {
+            return !factoryCandidates.isEmpty();
+        }
+    }
+}

--- a/control-panel-graalpy/src/main/java/io/micronaut/controlpanel/panels/graalpy/GraalPyControlPanel.java
+++ b/control-panel-graalpy/src/main/java/io/micronaut/controlpanel/panels/graalpy/GraalPyControlPanel.java
@@ -90,7 +90,7 @@ public class GraalPyControlPanel extends AbstractControlPanel<GraalPyControlPane
 
     @Override
     public String getBadge() {
-        return String.valueOf(discoverModules().size());
+        return String.valueOf(countModules());
     }
 
     @Override
@@ -101,10 +101,21 @@ public class GraalPyControlPanel extends AbstractControlPanel<GraalPyControlPane
     private List<ModuleInterface> discoverModules() {
         return beanContext.getAllBeanDefinitions()
             .stream()
-            .filter(definition -> definition.hasStereotype(GraalPyModule.class) || definition.hasDeclaredStereotype(GraalPyModule.class))
+            .filter(GraalPyControlPanel::isGraalPyModule)
             .map(this::moduleInterface)
             .sorted(Comparator.comparing(ModuleInterface::javaType).thenComparing(ModuleInterface::beanName))
             .toList();
+    }
+
+    private long countModules() {
+        return beanContext.getAllBeanDefinitions()
+            .stream()
+            .filter(GraalPyControlPanel::isGraalPyModule)
+            .count();
+    }
+
+    private static boolean isGraalPyModule(BeanDefinition<?> definition) {
+        return definition.hasStereotype(GraalPyModule.class) || definition.hasDeclaredStereotype(GraalPyModule.class);
     }
 
     private ModuleInterface moduleInterface(BeanDefinition<?> definition) {
@@ -182,8 +193,7 @@ public class GraalPyControlPanel extends AbstractControlPanel<GraalPyControlPane
 
     private static String displayType(Type type) {
         return type.getTypeName()
-            .replace("java.lang.", "")
-            .replace("java.util.", "");
+            .replace("java.lang.", "");
     }
 
     private RuntimeMetadata discoverRuntimeMetadata() {

--- a/control-panel-graalpy/src/main/java/io/micronaut/controlpanel/panels/graalpy/GraalPyControlPanel.java
+++ b/control-panel-graalpy/src/main/java/io/micronaut/controlpanel/panels/graalpy/GraalPyControlPanel.java
@@ -58,7 +58,7 @@ public class GraalPyControlPanel extends AbstractControlPanel<GraalPyControlPane
     /**
      * GraalPy category used by the sidebar.
      */
-    public static final ControlPanel.Category CATEGORY = new ControlPanel.Category("graalpy", "GraalPy", "fa-brands fa-python");
+    public static final ControlPanel.Category CATEGORY = new ControlPanel.Category(NAME, "GraalPy", "fa-brands fa-python");
 
     private static final String GRAALPY_CONTEXT_CLASS_NAME = "io.micronaut.graal.graalpy.GraalPyContext";
 
@@ -202,7 +202,7 @@ public class GraalPyControlPanel extends AbstractControlPanel<GraalPyControlPane
             .map(definition -> definition.getBeanType().getName())
             .sorted()
             .toList();
-        String factoryStatus = factoryCandidates.isEmpty() ? "Unavailable" : factoryCandidates.size() == 1 ? "Available" : "Ambiguous";
+        String factoryStatus = factoryStatus(factoryCandidates);
         String activeFactoryClass = factoryCandidates.size() == 1 ? factoryCandidates.get(0) : "";
         boolean sharedContextPresent = beanContext.getAllBeanDefinitions()
             .stream()
@@ -210,6 +210,16 @@ public class GraalPyControlPanel extends AbstractControlPanel<GraalPyControlPane
             .map(Class::getName)
             .anyMatch(GRAALPY_CONTEXT_CLASS_NAME::equals);
         return new RuntimeMetadata(factoryStatus, activeFactoryClass, factoryCandidates, sharedContextPresent);
+    }
+
+    private static String factoryStatus(List<String> factoryCandidates) {
+        if (factoryCandidates.isEmpty()) {
+            return "Unavailable";
+        }
+        if (factoryCandidates.size() == 1) {
+            return "Available";
+        }
+        return "Ambiguous";
     }
 
     /**

--- a/control-panel-graalpy/src/main/java/io/micronaut/controlpanel/panels/graalpy/GraalPyVfsMetadataReader.java
+++ b/control-panel-graalpy/src/main/java/io/micronaut/controlpanel/panels/graalpy/GraalPyVfsMetadataReader.java
@@ -19,15 +19,22 @@ import io.micronaut.core.annotation.ReflectiveAccess;
 import jakarta.inject.Singleton;
 
 import java.io.BufferedReader;
+import java.io.FilterInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.Reader;
+import java.net.URI;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.jar.JarFile;
 
 /**
  * Reads GraalPy virtual filesystem metadata without opening any listed Python files.
@@ -92,41 +99,152 @@ public class GraalPyVfsMetadataReader {
         int omittedEntries = 0;
         GraalPyVfsResource resource = new GraalPyVfsResource(resourceLabel(resourceIndex, url), protocolLabel(url), 0, false);
 
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(url.openStream(), StandardCharsets.UTF_8.newDecoder()
+        if (!isLocalClasspathResource(url)) {
+            warnings.add("Skipped non-local GraalPy VFS metadata in " + resource.label() + ".");
+            resource = new GraalPyVfsResource(resource.label(), resource.kind(), 0, true);
+            return new ResourceRead(resource, entries, warnings, truncated, omittedEntries);
+        }
+
+        try (Reader reader = new BufferedReader(new InputStreamReader(openLocalStream(url), StandardCharsets.UTF_8.newDecoder()
             .onMalformedInput(CodingErrorAction.REPORT)
             .onUnmappableCharacter(CodingErrorAction.REPORT)))) {
-            String line;
-            int lineNumber = 0;
-            int metadataChars = 0;
-            while ((line = reader.readLine()) != null) {
-                lineNumber++;
-                metadataChars += line.length();
-                if (metadataChars > MAX_METADATA_CHARS) {
-                    warnings.add("Stopped reading over-sized VFS metadata in " + resource.label() + ".");
-                    truncated = true;
-                    break;
-                }
-                if (line.length() > MAX_LINE_CHARS) {
-                    warnings.add("Skipped an over-sized VFS metadata line in " + resource.label() + ".");
-                    continue;
-                }
-                String path = sanitizePath(line);
-                if (path.isBlank()) {
-                    continue;
-                }
-                if (entries.size() < remainingCapacity) {
-                    entries.add(new GraalPyVfsEntry(path, group(path), resource.label()));
-                } else {
-                    truncated = true;
-                    omittedEntries++;
-                }
-            }
-            resource = new GraalPyVfsResource(resource.label(), resource.kind(), lineNumber, false);
+            ParseResult result = parseMetadata(reader, resource, entries, warnings, truncated, remainingCapacity);
+            resource = new GraalPyVfsResource(resource.label(), resource.kind(), result.lineCount(), false);
+            truncated = result.truncated();
+            omittedEntries = result.omittedEntries();
         } catch (IOException e) {
             warnings.add("Unable to read " + resource.label() + "; partial GraalPy VFS metadata is shown when available.");
             resource = new GraalPyVfsResource(resource.label(), resource.kind(), 0, true);
         }
         return new ResourceRead(resource, entries, warnings, truncated, omittedEntries);
+    }
+
+    private static InputStream openLocalStream(URL url) throws IOException {
+        try {
+            if ("file".equals(url.getProtocol())) {
+                return Files.newInputStream(Path.of(URI.create(url.toExternalForm())));
+            }
+            return openLocalJarStream(url);
+        } catch (IllegalArgumentException e) {
+            throw new IOException("Invalid local resource URL", e);
+        }
+    }
+
+    private static InputStream openLocalJarStream(URL url) throws IOException {
+        String file = url.getFile();
+        int separator = file.indexOf("!/");
+        Path jarPath = Path.of(URI.create(file.substring(0, separator)));
+        String entryPath = file.substring(separator + 2);
+        JarFile jarFile = new JarFile(jarPath.toFile());
+        var entry = jarFile.getJarEntry(entryPath);
+        if (entry == null) {
+            jarFile.close();
+            throw new IOException("Missing jar entry");
+        }
+        InputStream entryStream = jarFile.getInputStream(entry);
+        return new FilterInputStream(entryStream) {
+            @Override
+            public void close() throws IOException {
+                try {
+                    super.close();
+                } finally {
+                    jarFile.close();
+                }
+            }
+        };
+    }
+
+    private static ParseResult parseMetadata(Reader reader,
+                                             GraalPyVfsResource resource,
+                                             List<GraalPyVfsEntry> entries,
+                                             List<String> warnings,
+                                             boolean truncated,
+                                             int remainingCapacity) throws IOException {
+        char[] buffer = new char[8192];
+        StringBuilder line = new StringBuilder(Math.min(MAX_LINE_CHARS, 256));
+        boolean lineOversized = false;
+        int lineNumber = 0;
+        int metadataChars = 0;
+        int omittedEntries = 0;
+
+        int read;
+        while ((read = reader.read(buffer)) != -1) {
+            for (int i = 0; i < read; i++) {
+                metadataChars++;
+                if (metadataChars > MAX_METADATA_CHARS) {
+                    warnings.add("Stopped reading over-sized VFS metadata in " + resource.label() + ".");
+                    return new ParseResult(lineNumber, true, omittedEntries);
+                }
+                char character = buffer[i];
+                if (character == '\n') {
+                    lineNumber++;
+                    LineResult result = processLine(line, lineOversized, resource, entries, warnings, truncated, remainingCapacity, omittedEntries);
+                    truncated = result.truncated();
+                    omittedEntries = result.omittedEntries();
+                    line.setLength(0);
+                    lineOversized = false;
+                } else if (character != '\r') {
+                    if (line.length() < MAX_LINE_CHARS) {
+                        line.append(character);
+                    } else {
+                        lineOversized = true;
+                    }
+                }
+            }
+        }
+        if (!line.isEmpty() || lineOversized) {
+            lineNumber++;
+            LineResult result = processLine(line, lineOversized, resource, entries, warnings, truncated, remainingCapacity, omittedEntries);
+            truncated = result.truncated();
+            omittedEntries = result.omittedEntries();
+        }
+        return new ParseResult(lineNumber, truncated, omittedEntries);
+    }
+
+    private static LineResult processLine(StringBuilder line,
+                                          boolean lineOversized,
+                                          GraalPyVfsResource resource,
+                                          List<GraalPyVfsEntry> entries,
+                                          List<String> warnings,
+                                          boolean truncated,
+                                          int remainingCapacity,
+                                          int omittedEntries) {
+        if (lineOversized) {
+            warnings.add("Skipped an over-sized VFS metadata line in " + resource.label() + ".");
+            return new LineResult(truncated, omittedEntries);
+        }
+        String path = sanitizePath(line.toString());
+        if (path.isBlank()) {
+            return new LineResult(truncated, omittedEntries);
+        }
+        if (entries.size() < remainingCapacity) {
+            entries.add(new GraalPyVfsEntry(path, group(path), resource.label()));
+        } else {
+            truncated = true;
+            omittedEntries++;
+        }
+        return new LineResult(truncated, omittedEntries);
+    }
+
+    private static boolean isLocalClasspathResource(URL url) {
+        return switch (url.getProtocol()) {
+            case "file" -> true;
+            case "jar" -> isLocalJarResource(url);
+            default -> false;
+        };
+    }
+
+    private static boolean isLocalJarResource(URL url) {
+        String file = url.getFile();
+        int separator = file.indexOf("!/");
+        if (separator < 0) {
+            return false;
+        }
+        try {
+            return "file".equals(URI.create(file.substring(0, separator)).getScheme());
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
     }
 
     private static String sanitizePath(String line) {
@@ -166,6 +284,12 @@ public class GraalPyVfsMetadataReader {
         List<String> warnings,
         boolean truncated,
         int omittedEntries) {
+    }
+
+    private record ParseResult(int lineCount, boolean truncated, int omittedEntries) {
+    }
+
+    private record LineResult(boolean truncated, int omittedEntries) {
     }
 
     /**

--- a/control-panel-graalpy/src/main/java/io/micronaut/controlpanel/panels/graalpy/GraalPyVfsMetadataReader.java
+++ b/control-panel-graalpy/src/main/java/io/micronaut/controlpanel/panels/graalpy/GraalPyVfsMetadataReader.java
@@ -40,7 +40,7 @@ import java.util.jar.JarFile;
  * Reads GraalPy virtual filesystem metadata without opening any listed Python files.
  */
 @Singleton
-public class GraalPyVfsMetadataReader {
+public final class GraalPyVfsMetadataReader {
 
     static final String RESOURCE_PATH = "org.graalvm.python.vfs/fileslist.txt";
     static final int MAX_ENTRIES = 500;
@@ -81,7 +81,10 @@ public class GraalPyVfsMetadataReader {
                 truncated = truncated || read.truncated();
                 omittedEntries += read.omittedEntries();
                 if (entries.size() >= MAX_ENTRIES) {
-                    truncated = true;
+                    if (resourceUrls.hasMoreElements()) {
+                        truncated = true;
+                    }
+                    break;
                 }
             }
         } catch (IOException e) {
@@ -141,7 +144,13 @@ public class GraalPyVfsMetadataReader {
             jarFile.close();
             throw new IOException("Missing jar entry");
         }
-        InputStream entryStream = jarFile.getInputStream(entry);
+        InputStream entryStream;
+        try {
+            entryStream = jarFile.getInputStream(entry);
+        } catch (IOException e) {
+            jarFile.close();
+            throw e;
+        }
         return new FilterInputStream(entryStream) {
             @Override
             public void close() throws IOException {

--- a/control-panel-graalpy/src/main/java/io/micronaut/controlpanel/panels/graalpy/GraalPyVfsMetadataReader.java
+++ b/control-panel-graalpy/src/main/java/io/micronaut/controlpanel/panels/graalpy/GraalPyVfsMetadataReader.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.graalpy;
+
+import io.micronaut.core.annotation.ReflectiveAccess;
+import jakarta.inject.Singleton;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Enumeration;
+import java.util.List;
+
+/**
+ * Reads GraalPy virtual filesystem metadata without opening any listed Python files.
+ */
+@Singleton
+public class GraalPyVfsMetadataReader {
+
+    static final String RESOURCE_PATH = "org.graalvm.python.vfs/fileslist.txt";
+    static final int MAX_ENTRIES = 500;
+    private static final int MAX_LINE_CHARS = 4096;
+    private static final int MAX_METADATA_CHARS = 1_000_000;
+
+    /**
+     * Constructor.
+     */
+    public GraalPyVfsMetadataReader() {
+    }
+
+    GraalPyVfsMetadata read() {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        if (classLoader == null) {
+            classLoader = GraalPyVfsMetadataReader.class.getClassLoader();
+        }
+        return read(classLoader);
+    }
+
+    GraalPyVfsMetadata read(ClassLoader classLoader) {
+        List<GraalPyVfsResource> resources = new ArrayList<>();
+        List<GraalPyVfsEntry> entries = new ArrayList<>();
+        List<String> warnings = new ArrayList<>();
+        boolean truncated = false;
+        int omittedEntries = 0;
+
+        try {
+            Enumeration<URL> resourceUrls = classLoader.getResources(RESOURCE_PATH);
+            int resourceIndex = 0;
+            while (resourceUrls.hasMoreElements()) {
+                URL url = resourceUrls.nextElement();
+                resourceIndex++;
+                ResourceRead read = readResource(resourceIndex, url, MAX_ENTRIES - entries.size());
+                resources.add(read.resource());
+                entries.addAll(read.entries());
+                warnings.addAll(read.warnings());
+                truncated = truncated || read.truncated();
+                omittedEntries += read.omittedEntries();
+                if (entries.size() >= MAX_ENTRIES) {
+                    truncated = true;
+                }
+            }
+        } catch (IOException e) {
+            warnings.add("Unable to enumerate GraalPy VFS metadata resources.");
+        }
+
+        entries.sort(Comparator.comparing(GraalPyVfsEntry::path));
+        return new GraalPyVfsMetadata(resources, entries, warnings, truncated, omittedEntries);
+    }
+
+    private static ResourceRead readResource(int resourceIndex, URL url, int remainingCapacity) {
+        List<GraalPyVfsEntry> entries = new ArrayList<>();
+        List<String> warnings = new ArrayList<>();
+        boolean truncated = remainingCapacity <= 0;
+        int omittedEntries = 0;
+        GraalPyVfsResource resource = new GraalPyVfsResource(resourceLabel(resourceIndex, url), protocolLabel(url), 0, false);
+
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(url.openStream(), StandardCharsets.UTF_8.newDecoder()
+            .onMalformedInput(CodingErrorAction.REPORT)
+            .onUnmappableCharacter(CodingErrorAction.REPORT)))) {
+            String line;
+            int lineNumber = 0;
+            int metadataChars = 0;
+            while ((line = reader.readLine()) != null) {
+                lineNumber++;
+                metadataChars += line.length();
+                if (metadataChars > MAX_METADATA_CHARS) {
+                    warnings.add("Stopped reading over-sized VFS metadata in " + resource.label() + ".");
+                    truncated = true;
+                    break;
+                }
+                if (line.length() > MAX_LINE_CHARS) {
+                    warnings.add("Skipped an over-sized VFS metadata line in " + resource.label() + ".");
+                    continue;
+                }
+                String path = sanitizePath(line);
+                if (path.isBlank()) {
+                    continue;
+                }
+                if (entries.size() < remainingCapacity) {
+                    entries.add(new GraalPyVfsEntry(path, group(path), resource.label()));
+                } else {
+                    truncated = true;
+                    omittedEntries++;
+                }
+            }
+            resource = new GraalPyVfsResource(resource.label(), resource.kind(), lineNumber, false);
+        } catch (IOException e) {
+            warnings.add("Unable to read " + resource.label() + "; partial GraalPy VFS metadata is shown when available.");
+            resource = new GraalPyVfsResource(resource.label(), resource.kind(), 0, true);
+        }
+        return new ResourceRead(resource, entries, warnings, truncated, omittedEntries);
+    }
+
+    private static String sanitizePath(String line) {
+        String path = line.strip();
+        while (path.startsWith("/")) {
+            path = path.substring(1);
+        }
+        return path;
+    }
+
+    private static String group(String path) {
+        if (path.startsWith("src/")) {
+            return "src";
+        }
+        if (path.contains("/site-packages/")) {
+            return "site-packages";
+        }
+        if (path.startsWith("venv/")) {
+            return "venv";
+        }
+        int slash = path.indexOf('/');
+        return slash > 0 ? path.substring(0, slash) : "other";
+    }
+
+    private static String protocolLabel(URL url) {
+        String protocol = url.getProtocol();
+        return protocol == null || protocol.isBlank() ? "resource" : protocol;
+    }
+
+    private static String resourceLabel(int resourceIndex, URL url) {
+        return "classpath resource #" + resourceIndex + " (" + protocolLabel(url) + ")";
+    }
+
+    private record ResourceRead(
+        GraalPyVfsResource resource,
+        List<GraalPyVfsEntry> entries,
+        List<String> warnings,
+        boolean truncated,
+        int omittedEntries) {
+    }
+
+    /**
+     * GraalPy VFS metadata discovered from classpath resources.
+     *
+     * @param resources metadata resources
+     * @param entries VFS file entries
+     * @param warnings safe warnings for partial metadata
+     * @param truncated whether displayed metadata was truncated
+     * @param omittedEntries entries omitted after the display cap
+     */
+    @ReflectiveAccess
+    public record GraalPyVfsMetadata(
+        List<GraalPyVfsResource> resources,
+        List<GraalPyVfsEntry> entries,
+        List<String> warnings,
+        boolean truncated,
+        int omittedEntries) {
+
+        /**
+         * @return whether metadata resources were found
+         */
+        public boolean hasResources() {
+            return !resources.isEmpty();
+        }
+
+        /**
+         * @return whether any VFS entries were read
+         */
+        public boolean hasEntries() {
+            return !entries.isEmpty();
+        }
+
+        /**
+         * @return whether partial-data warnings are available
+         */
+        public boolean hasWarnings() {
+            return !warnings.isEmpty();
+        }
+
+        /**
+         * @return number of metadata resources
+         */
+        public int resourceCount() {
+            return resources.size();
+        }
+
+        /**
+         * @return number of displayed VFS entries
+         */
+        public int entryCount() {
+            return entries.size();
+        }
+    }
+
+    /**
+     * Sanitized metadata resource description.
+     *
+     * @param label display label
+     * @param kind resource protocol kind
+     * @param lineCount line count read
+     * @param unreadable whether the resource could not be read
+     */
+    @ReflectiveAccess
+    public record GraalPyVfsResource(String label, String kind, int lineCount, boolean unreadable) {
+    }
+
+    /**
+     * Packaged VFS path entry.
+     *
+     * @param path relative VFS path
+     * @param group display group
+     * @param resource sanitized source resource label
+     */
+    @ReflectiveAccess
+    public record GraalPyVfsEntry(String path, String group, String resource) {
+    }
+}

--- a/control-panel-graalpy/src/main/java/io/micronaut/controlpanel/panels/graalpy/GraalPyVfsMetadataReader.java
+++ b/control-panel-graalpy/src/main/java/io/micronaut/controlpanel/panels/graalpy/GraalPyVfsMetadataReader.java
@@ -19,7 +19,6 @@ import io.micronaut.core.annotation.ReflectiveAccess;
 import jakarta.inject.Singleton;
 
 import java.io.BufferedReader;
-import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -46,12 +45,6 @@ public final class GraalPyVfsMetadataReader {
     static final int MAX_ENTRIES = 500;
     private static final int MAX_LINE_CHARS = 4096;
     private static final int MAX_METADATA_CHARS = 1_000_000;
-
-    /**
-     * Constructor.
-     */
-    public GraalPyVfsMetadataReader() {
-    }
 
     GraalPyVfsMetadata read() {
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
@@ -87,7 +80,7 @@ public final class GraalPyVfsMetadataReader {
                     break;
                 }
             }
-        } catch (IOException e) {
+        } catch (IOException _) {
             warnings.add("Unable to enumerate GraalPy VFS metadata resources.");
         }
 
@@ -108,59 +101,61 @@ public final class GraalPyVfsMetadataReader {
             return new ResourceRead(resource, entries, warnings, truncated, omittedEntries);
         }
 
-        try (Reader reader = new BufferedReader(new InputStreamReader(openLocalStream(url), StandardCharsets.UTF_8.newDecoder()
-            .onMalformedInput(CodingErrorAction.REPORT)
-            .onUnmappableCharacter(CodingErrorAction.REPORT)))) {
-            ParseResult result = parseMetadata(reader, resource, entries, warnings, truncated, remainingCapacity);
+        try {
+            ParseResult result = parseLocalResource(url, resource, entries, warnings, truncated, remainingCapacity);
             resource = new GraalPyVfsResource(resource.label(), resource.kind(), result.lineCount(), false);
             truncated = result.truncated();
             omittedEntries = result.omittedEntries();
-        } catch (IOException e) {
+        } catch (IOException _) {
             warnings.add("Unable to read " + resource.label() + "; partial GraalPy VFS metadata is shown when available.");
             resource = new GraalPyVfsResource(resource.label(), resource.kind(), 0, true);
         }
         return new ResourceRead(resource, entries, warnings, truncated, omittedEntries);
     }
 
-    private static InputStream openLocalStream(URL url) throws IOException {
+    private static ParseResult parseLocalResource(URL url,
+                                                  GraalPyVfsResource resource,
+                                                  List<GraalPyVfsEntry> entries,
+                                                  List<String> warnings,
+                                                  boolean truncated,
+                                                  int remainingCapacity) throws IOException {
         try {
             if ("file".equals(url.getProtocol())) {
-                return Files.newInputStream(Path.of(URI.create(url.toExternalForm())));
+                try (Reader reader = newReader(Files.newInputStream(Path.of(URI.create(url.toExternalForm()))))) {
+                    return parseMetadata(reader, resource, entries, warnings, truncated, remainingCapacity);
+                }
             }
-            return openLocalJarStream(url);
+            return parseLocalJarResource(url, resource, entries, warnings, truncated, remainingCapacity);
         } catch (IllegalArgumentException e) {
             throw new IOException("Invalid local resource URL", e);
         }
     }
 
-    private static InputStream openLocalJarStream(URL url) throws IOException {
+    private static ParseResult parseLocalJarResource(URL url,
+                                                     GraalPyVfsResource resource,
+                                                     List<GraalPyVfsEntry> entries,
+                                                     List<String> warnings,
+                                                     boolean truncated,
+                                                     int remainingCapacity) throws IOException {
         String file = url.getFile();
         int separator = file.indexOf("!/");
         Path jarPath = Path.of(URI.create(file.substring(0, separator)));
         String entryPath = file.substring(separator + 2);
-        JarFile jarFile = new JarFile(jarPath.toFile());
-        var entry = jarFile.getJarEntry(entryPath);
-        if (entry == null) {
-            jarFile.close();
-            throw new IOException("Missing jar entry");
-        }
-        InputStream entryStream;
-        try {
-            entryStream = jarFile.getInputStream(entry);
-        } catch (IOException e) {
-            jarFile.close();
-            throw e;
-        }
-        return new FilterInputStream(entryStream) {
-            @Override
-            public void close() throws IOException {
-                try {
-                    super.close();
-                } finally {
-                    jarFile.close();
-                }
+        try (JarFile jarFile = new JarFile(jarPath.toFile())) {
+            var entry = jarFile.getJarEntry(entryPath);
+            if (entry == null) {
+                throw new IOException("Missing jar entry");
             }
-        };
+            try (Reader reader = newReader(jarFile.getInputStream(entry))) {
+                return parseMetadata(reader, resource, entries, warnings, truncated, remainingCapacity);
+            }
+        }
+    }
+
+    private static Reader newReader(InputStream inputStream) {
+        return new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8.newDecoder()
+            .onMalformedInput(CodingErrorAction.REPORT)
+            .onUnmappableCharacter(CodingErrorAction.REPORT)));
     }
 
     private static ParseResult parseMetadata(Reader reader,
@@ -169,70 +164,7 @@ public final class GraalPyVfsMetadataReader {
                                              List<String> warnings,
                                              boolean truncated,
                                              int remainingCapacity) throws IOException {
-        char[] buffer = new char[8192];
-        StringBuilder line = new StringBuilder(Math.min(MAX_LINE_CHARS, 256));
-        boolean lineOversized = false;
-        int lineNumber = 0;
-        int metadataChars = 0;
-        int omittedEntries = 0;
-
-        int read;
-        while ((read = reader.read(buffer)) != -1) {
-            for (int i = 0; i < read; i++) {
-                metadataChars++;
-                if (metadataChars > MAX_METADATA_CHARS) {
-                    warnings.add("Stopped reading over-sized VFS metadata in " + resource.label() + ".");
-                    return new ParseResult(lineNumber, true, omittedEntries);
-                }
-                char character = buffer[i];
-                if (character == '\n') {
-                    lineNumber++;
-                    LineResult result = processLine(line, lineOversized, resource, entries, warnings, truncated, remainingCapacity, omittedEntries);
-                    truncated = result.truncated();
-                    omittedEntries = result.omittedEntries();
-                    line.setLength(0);
-                    lineOversized = false;
-                } else if (character != '\r') {
-                    if (line.length() < MAX_LINE_CHARS) {
-                        line.append(character);
-                    } else {
-                        lineOversized = true;
-                    }
-                }
-            }
-        }
-        if (!line.isEmpty() || lineOversized) {
-            lineNumber++;
-            LineResult result = processLine(line, lineOversized, resource, entries, warnings, truncated, remainingCapacity, omittedEntries);
-            truncated = result.truncated();
-            omittedEntries = result.omittedEntries();
-        }
-        return new ParseResult(lineNumber, truncated, omittedEntries);
-    }
-
-    private static LineResult processLine(StringBuilder line,
-                                          boolean lineOversized,
-                                          GraalPyVfsResource resource,
-                                          List<GraalPyVfsEntry> entries,
-                                          List<String> warnings,
-                                          boolean truncated,
-                                          int remainingCapacity,
-                                          int omittedEntries) {
-        if (lineOversized) {
-            warnings.add("Skipped an over-sized VFS metadata line in " + resource.label() + ".");
-            return new LineResult(truncated, omittedEntries);
-        }
-        String path = sanitizePath(line.toString());
-        if (path.isBlank()) {
-            return new LineResult(truncated, omittedEntries);
-        }
-        if (entries.size() < remainingCapacity) {
-            entries.add(new GraalPyVfsEntry(path, group(path), resource.label()));
-        } else {
-            truncated = true;
-            omittedEntries++;
-        }
-        return new LineResult(truncated, omittedEntries);
+        return new MetadataParser(reader, resource, entries, warnings, truncated, remainingCapacity).parse();
     }
 
     private static boolean isLocalClasspathResource(URL url) {
@@ -251,7 +183,7 @@ public final class GraalPyVfsMetadataReader {
         }
         try {
             return "file".equals(URI.create(file.substring(0, separator)).getScheme());
-        } catch (IllegalArgumentException e) {
+        } catch (IllegalArgumentException _) {
             return false;
         }
     }
@@ -296,9 +228,6 @@ public final class GraalPyVfsMetadataReader {
     }
 
     private record ParseResult(int lineCount, boolean truncated, int omittedEntries) {
-    }
-
-    private record LineResult(boolean truncated, int omittedEntries) {
     }
 
     /**
@@ -375,5 +304,99 @@ public final class GraalPyVfsMetadataReader {
      */
     @ReflectiveAccess
     public record GraalPyVfsEntry(String path, String group, String resource) {
+    }
+
+    private static final class MetadataParser {
+        private final Reader reader;
+        private final GraalPyVfsResource resource;
+        private final List<GraalPyVfsEntry> entries;
+        private final List<String> warnings;
+        private final int remainingCapacity;
+        private final StringBuilder line = new StringBuilder(Math.min(MAX_LINE_CHARS, 256));
+        private boolean truncated;
+        private boolean lineOversized;
+        private int lineNumber;
+        private int metadataChars;
+        private int omittedEntries;
+
+        private MetadataParser(Reader reader,
+                               GraalPyVfsResource resource,
+                               List<GraalPyVfsEntry> entries,
+                               List<String> warnings,
+                               boolean truncated,
+                               int remainingCapacity) {
+            this.reader = reader;
+            this.resource = resource;
+            this.entries = entries;
+            this.warnings = warnings;
+            this.truncated = truncated;
+            this.remainingCapacity = remainingCapacity;
+        }
+
+        private ParseResult parse() throws IOException {
+            char[] buffer = new char[8192];
+            int read;
+            while ((read = reader.read(buffer)) != -1) {
+                for (int i = 0; i < read; i++) {
+                    if (processCharacter(buffer[i])) {
+                        return result(true);
+                    }
+                }
+            }
+            if (!line.isEmpty() || lineOversized) {
+                lineNumber++;
+                processLine();
+            }
+            return result(truncated);
+        }
+
+        private boolean processCharacter(char character) {
+            metadataChars++;
+            if (metadataChars > MAX_METADATA_CHARS) {
+                warnings.add("Stopped reading over-sized VFS metadata in " + resource.label() + ".");
+                return true;
+            }
+            if (character == '\n') {
+                lineNumber++;
+                processLine();
+            } else if (character != '\r') {
+                appendCharacter(character);
+            }
+            return false;
+        }
+
+        private void appendCharacter(char character) {
+            if (line.length() < MAX_LINE_CHARS) {
+                line.append(character);
+            } else {
+                lineOversized = true;
+            }
+        }
+
+        private void processLine() {
+            if (lineOversized) {
+                warnings.add("Skipped an over-sized VFS metadata line in " + resource.label() + ".");
+            } else {
+                addPath(sanitizePath(line.toString()));
+            }
+            line.setLength(0);
+            lineOversized = false;
+        }
+
+        private void addPath(String path) {
+            if (path.isBlank()) {
+                return;
+            }
+            if (entries.size() < remainingCapacity) {
+                entries.add(new GraalPyVfsEntry(path, group(path), resource.label()));
+            } else {
+                truncated = true;
+                omittedEntries++;
+            }
+        }
+
+        private ParseResult result(boolean truncated) {
+            return new ParseResult(lineNumber, truncated, omittedEntries);
+        }
     }
 }

--- a/control-panel-graalpy/src/main/java/io/micronaut/controlpanel/panels/graalpy/package-info.java
+++ b/control-panel-graalpy/src/main/java/io/micronaut/controlpanel/panels/graalpy/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * GraalPy Control Panel classes.
+ */
+@Configuration
+@Requires(condition = ControlPanelEnabledCondition.class)
+@Requires(property = GraalPyControlPanel.ENABLED_PROPERTY, notEquals = StringUtils.FALSE)
+package io.micronaut.controlpanel.panels.graalpy;
+
+import io.micronaut.context.annotation.Configuration;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.controlpanel.core.config.ControlPanelEnabledCondition;
+import io.micronaut.core.util.StringUtils;

--- a/control-panel-graalpy/src/main/resources/micronaut-control-panel/micronaut-control-panel.properties
+++ b/control-panel-graalpy/src/main/resources/micronaut-control-panel/micronaut-control-panel.properties
@@ -1,0 +1,4 @@
+micronaut.control-panel.panels.graalpy.enabled = true
+micronaut.control-panel.panels.graalpy.title = GraalPy
+micronaut.control-panel.panels.graalpy.icon = fa-brands fa-python
+micronaut.control-panel.panels.graalpy.order = 20

--- a/control-panel-graalpy/src/main/resources/views/graalpy/body.hbs
+++ b/control-panel-graalpy/src/main/resources/views/graalpy/body.hbs
@@ -1,0 +1,29 @@
+{{#with body}}
+    <p class="card-text">
+        <strong>{{moduleCount}}</strong> GraalPy module interfaces detected.
+    </p>
+    <p class="card-text">
+        <strong>VFS metadata</strong>:
+        {{#if vfs.hasEntries}}
+            <span class="badge badge-secondary">{{vfs.entryCount}} entries</span>
+        {{else}}
+            <span class="badge badge-secondary">Not found</span>
+        {{/if}}
+    </p>
+    <p class="card-text">
+        <strong>Context</strong>:
+        {{#if runtime.sharedContextPresent}}
+            <span class="badge badge-secondary">shared</span>
+        {{else}}
+            <span class="badge badge-secondary">not detected</span>
+        {{/if}}
+    </p>
+    <p class="card-text">
+        <strong>Factory</strong>:
+        {{#if runtime.hasActiveFactory}}
+            <code title="{{runtime.activeFactoryClass}}">{{abbreviate runtime.activeFactoryClass 56}}</code>
+        {{else}}
+            <span>{{runtime.factoryStatus}}</span>
+        {{/if}}
+    </p>
+{{/with}}

--- a/control-panel-graalpy/src/main/resources/views/graalpy/detail.hbs
+++ b/control-panel-graalpy/src/main/resources/views/graalpy/detail.hbs
@@ -1,0 +1,258 @@
+{{#with controlPanel.body}}
+    <div class="row">
+        <div class="col-md-3">
+            <div class="card">
+                <div class="card-body">
+                    <h5 class="card-title">Modules</h5>
+                    <p class="card-text"><strong>{{moduleCount}}</strong> interfaces</p>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-3">
+            <div class="card">
+                <div class="card-body">
+                    <h5 class="card-title">Python VFS</h5>
+                    <p class="card-text"><strong>{{vfs.entryCount}}</strong> entries</p>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-3">
+            <div class="card">
+                <div class="card-body">
+                    <h5 class="card-title">Shared Context</h5>
+                    <p class="card-text">
+                        {{#if runtime.sharedContextPresent}}
+                            <span class="badge badge-secondary">Present</span>
+                        {{else}}
+                            <span class="badge badge-secondary">Not detected</span>
+                        {{/if}}
+                    </p>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-3">
+            <div class="card">
+                <div class="card-body">
+                    <h5 class="card-title">Factory</h5>
+                    <p class="card-text">
+                        {{#if runtime.hasActiveFactory}}
+                            <code title="{{runtime.activeFactoryClass}}">{{abbreviate runtime.activeFactoryClass 42}}</code>
+                        {{else}}
+                            <span>{{runtime.factoryStatus}}</span>
+                        {{/if}}
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="tabs mt-4" data-tabs>
+        <div class="tabs-list" role="tablist" aria-label="GraalPy diagnostics">
+            <button type="button" class="tabs-trigger active" data-tab-target="graalpy-modules" role="tab" aria-selected="true">Module Interfaces</button>
+            <button type="button" class="tabs-trigger" data-tab-target="graalpy-vfs" role="tab" aria-selected="false">Python VFS</button>
+            <button type="button" class="tabs-trigger" data-tab-target="graalpy-runtime" role="tab" aria-selected="false">Runtime Notes</button>
+        </div>
+
+        <div id="graalpy-modules" class="tabs-panel active" role="tabpanel">
+            {{#if hasModules}}
+                <div class="cp-data-table cp-data-table-paged" data-filter-table data-filter-table-page-size="12" data-filter-table-label="module interface" data-filter-table-label-plural="module interfaces">
+                    <div class="cp-data-table-toolbar">
+                        <div class="cp-data-table-summary" data-filter-table-summary>{{moduleCount}} module interfaces</div>
+                        <div class="cp-data-table-search">
+                            <input type="search" class="form-control" data-filter-table-search placeholder="Search GraalPy modules" aria-label="Search GraalPy modules">
+                        </div>
+                    </div>
+                    <div class="cp-data-table-container">
+                        <table class="table cp-data-table-table cp-data-table-fixed">
+                            <thead>
+                            <tr>
+                                <th>Bean</th>
+                                <th>Python module</th>
+                                <th>Java type</th>
+                                <th>Methods</th>
+                                <th>Scope</th>
+                                <th>Instantiated</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            {{#each modules}}
+                                <tr data-filter-table-row>
+                                    <td><code class="cp-table-code" title="{{beanName}}">{{beanName}}</code></td>
+                                    <td><code class="cp-table-code" title="{{pythonModule}}">{{pythonModule}}</code></td>
+                                    <td><code class="cp-table-code" title="{{javaType}}">{{javaType}}</code></td>
+                                    <td>
+                                        {{#if hasMethods}}
+                                            <ul class="mb-0">
+                                                {{#each methods}}
+                                                    <li><code class="cp-table-code" title="{{signature}}">{{signature}}</code></li>
+                                                {{/each}}
+                                            </ul>
+                                        {{else}}
+                                            <span class="text-muted">No executable methods detected.</span>
+                                        {{/if}}
+                                    </td>
+                                    <td>
+                                        <span class="badge badge-secondary">{{scope}}</span>
+                                        <span class="text-muted">{{qualifier}}</span>
+                                    </td>
+                                    <td>{{instantiated}}</td>
+                                </tr>
+                            {{/each}}
+                            <tr data-filter-table-empty hidden>
+                                <td class="cp-data-table-empty-cell" colspan="6">No GraalPy module interfaces found.</td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="cp-data-table-footer">
+                        <label class="cp-data-table-page-size">
+                            Rows per page
+                            <select class="form-control" data-filter-table-page-size-select aria-label="GraalPy module interfaces per page">
+                                <option value="8">8</option>
+                                <option value="12" selected>12</option>
+                                <option value="20">20</option>
+                                <option value="50">50</option>
+                            </select>
+                        </label>
+                        <div class="cp-data-table-pagination">
+                            <span class="cp-data-table-page" data-filter-table-page>Page 1 of 1</span>
+                            <button type="button" class="btn btn-secondary btn-sm" data-filter-table-prev>Previous</button>
+                            <button type="button" class="btn btn-secondary btn-sm" data-filter-table-next>Next</button>
+                        </div>
+                    </div>
+                </div>
+            {{else}}
+                <div class="cp-data-table-empty">GraalPy is on the classpath, but no bean definitions annotated with <code>@GraalPyModule</code> were detected.</div>
+            {{/if}}
+        </div>
+
+        <div id="graalpy-vfs" class="tabs-panel" role="tabpanel" hidden>
+            {{#if vfs.hasWarnings}}
+                <div class="alert alert-warning" role="status">
+                    {{#each vfs.warnings}}
+                        <p>{{this}}</p>
+                    {{/each}}
+                </div>
+            {{/if}}
+            {{#if vfs.hasResources}}
+                <div class="cp-data-table-container cp-vertical-table">
+                    <table class="table cp-data-table-table">
+                        <tbody>
+                        {{#each vfs.resources}}
+                            <tr>
+                                <th scope="row">{{label}}</th>
+                                <td>
+                                    <span class="badge badge-secondary">{{kind}}</span>
+                                    {{lineCount}} metadata lines
+                                    {{#if unreadable}}<span class="badge badge-secondary">unreadable</span>{{/if}}
+                                </td>
+                            </tr>
+                        {{/each}}
+                        </tbody>
+                    </table>
+                </div>
+            {{/if}}
+            {{#if vfs.hasEntries}}
+                {{#if vfs.truncated}}
+                    <p class="text-muted">The displayed VFS metadata is capped at {{vfs.entryCount}} entries. {{vfs.omittedEntries}} additional entries were omitted after the cap.</p>
+                {{/if}}
+                <div class="cp-data-table cp-data-table-paged" data-filter-table data-filter-table-page-size="16" data-filter-table-label="VFS entry" data-filter-table-label-plural="VFS entries">
+                    <div class="cp-data-table-toolbar">
+                        <div class="cp-data-table-summary" data-filter-table-summary>{{vfs.entryCount}} VFS entries</div>
+                        <div class="cp-data-table-search">
+                            <input type="search" class="form-control" data-filter-table-search placeholder="Search VFS paths" aria-label="Search VFS paths">
+                        </div>
+                    </div>
+                    <div class="cp-data-table-container">
+                        <table class="table cp-data-table-table cp-data-table-fixed">
+                            <thead>
+                            <tr>
+                                <th>Group</th>
+                                <th>Path</th>
+                                <th>Resource</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            {{#each vfs.entries}}
+                                <tr data-filter-table-row>
+                                    <td><span class="badge badge-secondary">{{group}}</span></td>
+                                    <td><code class="cp-table-code" title="{{path}}">{{path}}</code></td>
+                                    <td>{{resource}}</td>
+                                </tr>
+                            {{/each}}
+                            <tr data-filter-table-empty hidden>
+                                <td class="cp-data-table-empty-cell" colspan="3">No VFS entries found.</td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="cp-data-table-footer">
+                        <label class="cp-data-table-page-size">
+                            Rows per page
+                            <select class="form-control" data-filter-table-page-size-select aria-label="VFS entries per page">
+                                <option value="8">8</option>
+                                <option value="16" selected>16</option>
+                                <option value="30">30</option>
+                                <option value="50">50</option>
+                            </select>
+                        </label>
+                        <div class="cp-data-table-pagination">
+                            <span class="cp-data-table-page" data-filter-table-page>Page 1 of 1</span>
+                            <button type="button" class="btn btn-secondary btn-sm" data-filter-table-prev>Previous</button>
+                            <button type="button" class="btn btn-secondary btn-sm" data-filter-table-next>Next</button>
+                        </div>
+                    </div>
+                </div>
+            {{else}}
+                <div class="cp-data-table-empty">No <code>org.graalvm.python.vfs/fileslist.txt</code> metadata was found. Check that the GraalPy build plugin packaged Python sources and dependencies into the application resources.</div>
+            {{/if}}
+        </div>
+
+        <div id="graalpy-runtime" class="tabs-panel" role="tabpanel" hidden>
+            <div class="cp-data-table-container cp-vertical-table">
+                <table class="table cp-data-table-table">
+                    <tbody>
+                    <tr>
+                        <th scope="row">Context builder factory</th>
+                        <td>
+                            {{#if runtime.hasActiveFactory}}
+                                <code>{{runtime.activeFactoryClass}}</code>
+                            {{else}}
+                                <span>{{runtime.factoryStatus}}</span>
+                            {{/if}}
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row">Factory candidates</th>
+                        <td>
+                            {{#if runtime.hasFactoryCandidates}}
+                                <ul>
+                                    {{#each runtime.factoryCandidates}}
+                                        <li><code>{{this}}</code></li>
+                                    {{/each}}
+                                </ul>
+                            {{else}}
+                                <span>No factory bean definitions were detected.</span>
+                            {{/if}}
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row">Shared context bean</th>
+                        <td>
+                            {{#if runtime.sharedContextPresent}}
+                                Present
+                            {{else}}
+                                Not detected
+                            {{/if}}
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+            <div class="alert alert-info" role="status">
+                <p>This panel is read-only. It inspects Micronaut bean definitions and GraalPy VFS metadata; it does not import Python modules, invoke Python functions, read listed Python files, or call package managers.</p>
+                <p>The default GraalPy introduction advice uses one shared polyglot context. Python execution can serialize on the global interpreter lock, so multi-context designs should use custom Context APIs outside this panel.</p>
+            </div>
+        </div>
+    </div>
+{{/with}}

--- a/control-panel-graalpy/src/main/resources/views/graalpy/detail.hbs
+++ b/control-panel-graalpy/src/main/resources/views/graalpy/detail.hbs
@@ -48,12 +48,12 @@
 
     <div class="tabs mt-4" data-tabs>
         <div class="tabs-list" role="tablist" aria-label="GraalPy diagnostics">
-            <button type="button" class="tabs-trigger active" data-tab-target="graalpy-modules" role="tab" aria-selected="true">Module Interfaces</button>
-            <button type="button" class="tabs-trigger" data-tab-target="graalpy-vfs" role="tab" aria-selected="false">Python VFS</button>
-            <button type="button" class="tabs-trigger" data-tab-target="graalpy-runtime" role="tab" aria-selected="false">Runtime Notes</button>
+            <button type="button" class="tabs-trigger active" id="tab-graalpy-modules" data-tabs-trigger="graalpy-modules" role="tab" aria-selected="true" aria-controls="panel-graalpy-modules">Module Interfaces</button>
+            <button type="button" class="tabs-trigger" id="tab-graalpy-vfs" data-tabs-trigger="graalpy-vfs" role="tab" aria-selected="false" aria-controls="panel-graalpy-vfs">Python VFS</button>
+            <button type="button" class="tabs-trigger" id="tab-graalpy-runtime" data-tabs-trigger="graalpy-runtime" role="tab" aria-selected="false" aria-controls="panel-graalpy-runtime">Runtime Notes</button>
         </div>
 
-        <div id="graalpy-modules" class="tabs-panel active" role="tabpanel">
+        <div id="panel-graalpy-modules" class="tabs-panel active" role="tabpanel" aria-labelledby="tab-graalpy-modules" data-tabs-panel="graalpy-modules">
             {{#if hasModules}}
                 <div class="cp-data-table cp-data-table-paged" data-filter-table data-filter-table-page-size="12" data-filter-table-label="module interface" data-filter-table-label-plural="module interfaces">
                     <div class="cp-data-table-toolbar">
@@ -126,7 +126,7 @@
             {{/if}}
         </div>
 
-        <div id="graalpy-vfs" class="tabs-panel" role="tabpanel" hidden>
+        <div id="panel-graalpy-vfs" class="tabs-panel" role="tabpanel" aria-labelledby="tab-graalpy-vfs" data-tabs-panel="graalpy-vfs" hidden>
             {{#if vfs.hasWarnings}}
                 <div class="alert alert-warning" role="status">
                     {{#each vfs.warnings}}
@@ -208,7 +208,7 @@
             {{/if}}
         </div>
 
-        <div id="graalpy-runtime" class="tabs-panel" role="tabpanel" hidden>
+        <div id="panel-graalpy-runtime" class="tabs-panel" role="tabpanel" aria-labelledby="tab-graalpy-runtime" data-tabs-panel="graalpy-runtime" hidden>
             <div class="cp-data-table-container cp-vertical-table">
                 <table class="table cp-data-table-table">
                     <tbody>

--- a/control-panel-graalpy/src/main/resources/views/graalpy/detail.hbs
+++ b/control-panel-graalpy/src/main/resources/views/graalpy/detail.hbs
@@ -46,7 +46,7 @@
         </div>
     </div>
 
-    <div class="tabs mt-4" data-tabs>
+    <div class="tabs mt-4 cp-graalpy-tabs" data-tabs>
         <div class="tabs-list" role="tablist" aria-label="GraalPy diagnostics">
             <button type="button" class="tabs-trigger active" id="tab-graalpy-modules" data-tabs-trigger="graalpy-modules" role="tab" aria-selected="true" aria-controls="panel-graalpy-modules">Module Interfaces</button>
             <button type="button" class="tabs-trigger" id="tab-graalpy-vfs" data-tabs-trigger="graalpy-vfs" role="tab" aria-selected="false" aria-controls="panel-graalpy-vfs">Python VFS</button>
@@ -63,7 +63,7 @@
                         </div>
                     </div>
                     <div class="cp-data-table-container">
-                        <table class="table cp-data-table-table cp-data-table-fixed">
+                        <table class="table cp-data-table-table cp-graalpy-module-table">
                             <thead>
                             <tr>
                                 <th>Bean</th>
@@ -82,9 +82,9 @@
                                     <td><code class="cp-table-code" title="{{javaType}}">{{javaType}}</code></td>
                                     <td>
                                         {{#if hasMethods}}
-                                            <ul class="mb-0">
+                                            <ul class="cp-data-table-list cp-graalpy-method-list">
                                                 {{#each methods}}
-                                                    <li><code class="cp-table-code" title="{{signature}}">{{signature}}</code></li>
+                                                    <li><code class="cp-table-code cp-graalpy-method-code" title="{{signature}}">{{signature}}</code></li>
                                                 {{/each}}
                                             </ul>
                                         {{else}}
@@ -164,7 +164,7 @@
                         </div>
                     </div>
                     <div class="cp-data-table-container">
-                        <table class="table cp-data-table-table cp-data-table-fixed">
+                        <table class="table cp-data-table-table cp-graalpy-vfs-table">
                             <thead>
                             <tr>
                                 <th>Group</th>

--- a/control-panel-graalpy/src/test/java/io/micronaut/controlpanel/panels/graalpy/GraalPyControlPanelTest.java
+++ b/control-panel-graalpy/src/test/java/io/micronaut/controlpanel/panels/graalpy/GraalPyControlPanelTest.java
@@ -78,6 +78,35 @@ class GraalPyControlPanelTest {
         assertEquals("Unavailable", body.runtime().factoryStatus());
     }
 
+    @Test
+    void badgeCountsModulesWithoutBuildingMethodSignatures() {
+        BeanContext beanContext = mock(BeanContext.class);
+        BeanDefinition<?> firstModule = moduleDefinition("dealerService", DealerService.class, "dealer");
+        BeanDefinition<?> secondModule = moduleDefinition("auditService", AuditService.class, "audit");
+        when(firstModule.getExecutableMethods()).thenThrow(new AssertionError("Badge should not build method signatures."));
+        when(secondModule.getExecutableMethods()).thenThrow(new AssertionError("Badge should not build method signatures."));
+        doReturn(List.of(firstModule, secondModule, beanDefinition(String.class))).when(beanContext).getAllBeanDefinitions();
+
+        String badge = new GraalPyControlPanel(beanContext, new GraalPyVfsMetadataReader(), configuration()).getBadge();
+
+        assertEquals("2", badge);
+    }
+
+    @Test
+    void reportsAmbiguousContextBuilderFactories() {
+        BeanContext beanContext = mock(BeanContext.class);
+        doReturn(List.of()).when(beanContext).getAllBeanDefinitions();
+        doReturn(List.of(beanDefinition(ExplodingFactory.class), beanDefinition(SecondFactory.class)))
+            .when(beanContext).getBeanDefinitions(GraalPyContextBuilderFactory.class);
+
+        GraalPyControlPanel.Body body = getBodyWithEmptyVfs(
+            new GraalPyControlPanel(beanContext, new GraalPyVfsMetadataReader(), configuration()));
+
+        assertEquals("Ambiguous", body.runtime().factoryStatus());
+        assertFalse(body.runtime().hasActiveFactory());
+        assertTrue(body.runtime().hasFactoryCandidates());
+    }
+
     private static GraalPyControlPanel.Body getBodyWithEmptyVfs(GraalPyControlPanel panel) {
         ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
         try {
@@ -126,12 +155,25 @@ class GraalPyControlPanelTest {
         CompletableFuture<String> dealAsync();
     }
 
+    @GraalPyModule("audit")
+    interface AuditService {
+        void record(String name);
+    }
+
     static final class ExplodingFactory implements GraalPyContextBuilderFactory {
         static final AtomicInteger createBuilderCalls = new AtomicInteger();
 
         @Override
         public Context.Builder createBuilder() {
             createBuilderCalls.incrementAndGet();
+            throw new AssertionError("Panel rendering must not create GraalPy Context builders.");
+        }
+    }
+
+    static final class SecondFactory implements GraalPyContextBuilderFactory {
+
+        @Override
+        public Context.Builder createBuilder() {
             throw new AssertionError("Panel rendering must not create GraalPy Context builders.");
         }
     }

--- a/control-panel-graalpy/src/test/java/io/micronaut/controlpanel/panels/graalpy/GraalPyControlPanelTest.java
+++ b/control-panel-graalpy/src/test/java/io/micronaut/controlpanel/panels/graalpy/GraalPyControlPanelTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.graalpy;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.controlpanel.core.config.ControlPanelConfiguration;
+import io.micronaut.graal.graalpy.GraalPyContextBuilderFactory;
+import io.micronaut.graal.graalpy.annotations.GraalPyModule;
+import io.micronaut.inject.BeanDefinition;
+import org.graalvm.polyglot.Context;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+class GraalPyControlPanelTest {
+
+    @Test
+    void discoversGraalPyModuleDefinitionsWithoutInstantiatingPythonModules() {
+        BeanContext beanContext = mock(BeanContext.class);
+        ControlPanelConfiguration configuration = configuration();
+        BeanDefinition<?> moduleDefinition = moduleDefinition("dealerService", DealerService.class, "dealer");
+        BeanDefinition<?> factoryDefinition = beanDefinition(ExplodingFactory.class);
+
+        doReturn(List.of(moduleDefinition)).when(beanContext).getAllBeanDefinitions();
+        doReturn(List.of(factoryDefinition)).when(beanContext).getBeanDefinitions(GraalPyContextBuilderFactory.class);
+
+        GraalPyControlPanel panel = new GraalPyControlPanel(beanContext, emptyVfsReader(), configuration);
+        GraalPyControlPanel.Body body = panel.getBody();
+
+        assertEquals(1, body.moduleCount());
+        GraalPyControlPanel.ModuleInterface module = body.modules().get(0);
+        assertEquals("dealerService", module.beanName());
+        assertEquals(DealerService.class.getName(), module.javaType());
+        assertEquals("dealer", module.pythonModule());
+        assertEquals("Unknown", module.instantiated());
+        assertTrue(module.methods().stream().anyMatch(method -> method.signature().startsWith("String deal(String, int)")));
+        assertEquals("Available", body.runtime().factoryStatus());
+        assertEquals(ExplodingFactory.class.getName(), body.runtime().activeFactoryClass());
+        assertEquals(0, ExplodingFactory.createBuilderCalls.get());
+    }
+
+    @Test
+    void reportsEmptyModulesWhenNoAnnotatedDefinitionsExist() {
+        BeanContext beanContext = mock(BeanContext.class);
+        doReturn(List.of(beanDefinition(String.class))).when(beanContext).getAllBeanDefinitions();
+        doReturn(List.of()).when(beanContext).getBeanDefinitions(GraalPyContextBuilderFactory.class);
+
+        GraalPyControlPanel.Body body = new GraalPyControlPanel(beanContext, emptyVfsReader(), configuration()).getBody();
+
+        assertFalse(body.hasModules());
+        assertEquals(0, body.moduleCount());
+        assertEquals("Unavailable", body.runtime().factoryStatus());
+    }
+
+    private static GraalPyVfsMetadataReader emptyVfsReader() {
+        ClassLoader emptyClassLoader = new ClassLoader(null) {
+        };
+        return new GraalPyVfsMetadataReader() {
+            @Override
+            GraalPyVfsMetadata read() {
+                return super.read(emptyClassLoader);
+            }
+        };
+    }
+
+    private static ControlPanelConfiguration configuration() {
+        ControlPanelConfiguration configuration = new ControlPanelConfiguration(GraalPyControlPanel.NAME);
+        configuration.setTitle("GraalPy");
+        configuration.setIcon("fa-brands fa-python");
+        return configuration;
+    }
+
+    private static BeanDefinition<?> moduleDefinition(String beanName, Class<?> beanType, String moduleName) {
+        BeanDefinition<?> definition = beanDefinition(beanType);
+        when(definition.getName()).thenReturn(beanName);
+        when(definition.hasStereotype(GraalPyModule.class)).thenReturn(true);
+        when(definition.hasDeclaredStereotype(GraalPyModule.class)).thenReturn(true);
+        when(definition.stringValue(GraalPyModule.class)).thenReturn(Optional.of(moduleName));
+        when(definition.getScopeName()).thenReturn(Optional.of("Singleton"));
+        when(definition.getExecutableMethods()).thenReturn(List.of());
+        return definition;
+    }
+
+    private static BeanDefinition<?> beanDefinition(Class<?> beanType) {
+        BeanDefinition<?> definition = mock(BeanDefinition.class);
+        when(definition.getBeanType()).then(invocation -> beanType);
+        when(definition.getName()).thenReturn(beanType.getSimpleName());
+        when(definition.hasStereotype(GraalPyModule.class)).thenReturn(false);
+        when(definition.hasDeclaredStereotype(GraalPyModule.class)).thenReturn(false);
+        when(definition.getScopeName()).thenReturn(Optional.empty());
+        when(definition.getDeclaredQualifier()).thenReturn(null);
+        when(definition.getExecutableMethods()).thenReturn(List.of());
+        return definition;
+    }
+
+    @GraalPyModule("dealer")
+    interface DealerService {
+        String deal(String name, int count);
+    }
+
+    static final class ExplodingFactory implements GraalPyContextBuilderFactory {
+        static final AtomicInteger createBuilderCalls = new AtomicInteger();
+
+        @Override
+        public Context.Builder createBuilder() {
+            createBuilderCalls.incrementAndGet();
+            throw new AssertionError("Panel rendering must not create GraalPy Context builders.");
+        }
+    }
+}

--- a/control-panel-graalpy/src/test/java/io/micronaut/controlpanel/panels/graalpy/GraalPyControlPanelTest.java
+++ b/control-panel-graalpy/src/test/java/io/micronaut/controlpanel/panels/graalpy/GraalPyControlPanelTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -46,8 +47,8 @@ class GraalPyControlPanelTest {
         doReturn(List.of(moduleDefinition)).when(beanContext).getAllBeanDefinitions();
         doReturn(List.of(factoryDefinition)).when(beanContext).getBeanDefinitions(GraalPyContextBuilderFactory.class);
 
-        GraalPyControlPanel panel = new GraalPyControlPanel(beanContext, emptyVfsReader(), configuration);
-        GraalPyControlPanel.Body body = panel.getBody();
+        GraalPyControlPanel panel = new GraalPyControlPanel(beanContext, new GraalPyVfsMetadataReader(), configuration);
+        GraalPyControlPanel.Body body = getBodyWithEmptyVfs(panel);
 
         assertEquals(1, body.moduleCount());
         GraalPyControlPanel.ModuleInterface module = body.modules().get(0);
@@ -56,6 +57,8 @@ class GraalPyControlPanelTest {
         assertEquals("dealer", module.pythonModule());
         assertEquals("Unknown", module.instantiated());
         assertTrue(module.methods().stream().anyMatch(method -> method.signature().startsWith("String deal(String, int)")));
+        assertTrue(module.methods().stream()
+            .anyMatch(method -> method.signature().startsWith("java.util.concurrent.CompletableFuture<String> dealAsync()")));
         assertEquals("Available", body.runtime().factoryStatus());
         assertEquals(ExplodingFactory.class.getName(), body.runtime().activeFactoryClass());
         assertEquals(0, ExplodingFactory.createBuilderCalls.get());
@@ -67,22 +70,23 @@ class GraalPyControlPanelTest {
         doReturn(List.of(beanDefinition(String.class))).when(beanContext).getAllBeanDefinitions();
         doReturn(List.of()).when(beanContext).getBeanDefinitions(GraalPyContextBuilderFactory.class);
 
-        GraalPyControlPanel.Body body = new GraalPyControlPanel(beanContext, emptyVfsReader(), configuration()).getBody();
+        GraalPyControlPanel.Body body = getBodyWithEmptyVfs(
+            new GraalPyControlPanel(beanContext, new GraalPyVfsMetadataReader(), configuration()));
 
         assertFalse(body.hasModules());
         assertEquals(0, body.moduleCount());
         assertEquals("Unavailable", body.runtime().factoryStatus());
     }
 
-    private static GraalPyVfsMetadataReader emptyVfsReader() {
-        ClassLoader emptyClassLoader = new ClassLoader(null) {
-        };
-        return new GraalPyVfsMetadataReader() {
-            @Override
-            GraalPyVfsMetadata read() {
-                return super.read(emptyClassLoader);
-            }
-        };
+    private static GraalPyControlPanel.Body getBodyWithEmptyVfs(GraalPyControlPanel panel) {
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(new ClassLoader(null) {
+            });
+            return panel.getBody();
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
     }
 
     private static ControlPanelConfiguration configuration() {
@@ -118,6 +122,8 @@ class GraalPyControlPanelTest {
     @GraalPyModule("dealer")
     interface DealerService {
         String deal(String name, int count);
+
+        CompletableFuture<String> dealAsync();
     }
 
     static final class ExplodingFactory implements GraalPyContextBuilderFactory {

--- a/control-panel-graalpy/src/test/java/io/micronaut/controlpanel/panels/graalpy/GraalPyVfsMetadataReaderTest.java
+++ b/control-panel-graalpy/src/test/java/io/micronaut/controlpanel/panels/graalpy/GraalPyVfsMetadataReaderTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.graalpy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GraalPyVfsMetadataReaderTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void readsPackagedFilesListMetadata() throws IOException {
+        writeFilesList("""
+            /src/dealer.py
+            venv/lib/python3.13/site-packages/termcolor/__init__.py
+            pyproject.toml
+            """);
+
+        var metadata = read();
+
+        assertTrue(metadata.hasResources());
+        assertEquals(1, metadata.resourceCount());
+        assertEquals(3, metadata.entryCount());
+        assertTrue(metadata.entries().stream().anyMatch(entry -> entry.path().equals("src/dealer.py")));
+        assertTrue(metadata.entries().stream().anyMatch(entry -> entry.group().equals("site-packages")));
+        assertFalse(metadata.truncated());
+    }
+
+    @Test
+    void missingFilesListIsAnEmptyState() {
+        var metadata = read();
+
+        assertFalse(metadata.hasResources());
+        assertFalse(metadata.hasEntries());
+        assertFalse(metadata.truncated());
+    }
+
+    @Test
+    void capsLargeFilesListMetadata() throws IOException {
+        writeFilesList(IntStream.range(0, GraalPyVfsMetadataReader.MAX_ENTRIES + 2)
+            .mapToObj(index -> "src/file" + index + ".py")
+            .collect(Collectors.joining("\n")));
+
+        var metadata = read();
+
+        assertEquals(GraalPyVfsMetadataReader.MAX_ENTRIES, metadata.entryCount());
+        assertTrue(metadata.truncated());
+        assertEquals(2, metadata.omittedEntries());
+    }
+
+    private GraalPyVfsMetadataReader.GraalPyVfsMetadata read() {
+        try (URLClassLoader classLoader = new URLClassLoader(new java.net.URL[] { tempDir.toUri().toURL() }, null)) {
+            return new GraalPyVfsMetadataReader().read(classLoader);
+        } catch (IOException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private void writeFilesList(String content) throws IOException {
+        Path filesList = tempDir.resolve(GraalPyVfsMetadataReader.RESOURCE_PATH);
+        Files.createDirectories(filesList.getParent());
+        Files.writeString(filesList, content);
+    }
+}

--- a/control-panel-graalpy/src/test/java/io/micronaut/controlpanel/panels/graalpy/GraalPyVfsMetadataReaderTest.java
+++ b/control-panel-graalpy/src/test/java/io/micronaut/controlpanel/panels/graalpy/GraalPyVfsMetadataReaderTest.java
@@ -36,6 +36,7 @@ import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class GraalPyVfsMetadataReaderTest {
@@ -48,6 +49,7 @@ class GraalPyVfsMetadataReaderTest {
         writeFilesList("""
             /src/dealer.py
             venv/lib/python3.13/site-packages/termcolor/__init__.py
+            venv/bin/python
             pyproject.toml
             """);
 
@@ -55,9 +57,10 @@ class GraalPyVfsMetadataReaderTest {
 
         assertTrue(metadata.hasResources());
         assertEquals(1, metadata.resourceCount());
-        assertEquals(3, metadata.entryCount());
+        assertEquals(4, metadata.entryCount());
         assertTrue(metadata.entries().stream().anyMatch(entry -> entry.path().equals("src/dealer.py")));
         assertTrue(metadata.entries().stream().anyMatch(entry -> entry.group().equals("site-packages")));
+        assertTrue(metadata.entries().stream().anyMatch(entry -> entry.group().equals("venv")));
         assertFalse(metadata.truncated());
     }
 
@@ -90,6 +93,22 @@ class GraalPyVfsMetadataReaderTest {
     }
 
     @Test
+    void readsMultipleFilesListResources() throws IOException {
+        Path first = tempDir.resolve("first");
+        Path second = tempDir.resolve("second");
+        writeFilesList(first, "src/dealer.py\n");
+        writeFilesList(second, "venv/bin/python\n");
+
+        try (URLClassLoader classLoader = new URLClassLoader(new java.net.URL[] { first.toUri().toURL(), second.toUri().toURL() }, null)) {
+            var metadata = new GraalPyVfsMetadataReader().read(classLoader);
+
+            assertEquals(2, metadata.resourceCount());
+            assertEquals(2, metadata.entryCount());
+            assertFalse(metadata.truncated());
+        }
+    }
+
+    @Test
     void capsLargeFilesListMetadata() throws IOException {
         writeFilesList(IntStream.range(0, GraalPyVfsMetadataReader.MAX_ENTRIES + 2)
             .mapToObj(index -> "src/file" + index + ".py")
@@ -113,6 +132,28 @@ class GraalPyVfsMetadataReaderTest {
         assertEquals(GraalPyVfsMetadataReader.MAX_ENTRIES, metadata.entryCount());
         assertFalse(metadata.truncated());
         assertEquals(0, metadata.omittedEntries());
+    }
+
+    @Test
+    void capsOversizedMetadataFiles() throws IOException {
+        writeFilesList("src/dealer.py\n".repeat(90_000));
+
+        var metadata = read();
+
+        assertTrue(metadata.truncated());
+        assertTrue(metadata.warnings().stream().anyMatch(warning -> warning.contains("Stopped reading over-sized VFS metadata")));
+    }
+
+    @Test
+    void fallsBackToDefaultClassLoaderWhenThreadContextClassLoaderIsNull() {
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(null);
+
+            assertNotNull(new GraalPyVfsMetadataReader().read());
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
     }
 
     @Test
@@ -164,7 +205,11 @@ class GraalPyVfsMetadataReaderTest {
     }
 
     private void writeFilesList(String content) throws IOException {
-        Path filesList = tempDir.resolve(GraalPyVfsMetadataReader.RESOURCE_PATH);
+        writeFilesList(tempDir, content);
+    }
+
+    private void writeFilesList(Path root, String content) throws IOException {
+        Path filesList = root.resolve(GraalPyVfsMetadataReader.RESOURCE_PATH);
         Files.createDirectories(filesList.getParent());
         Files.writeString(filesList, content);
     }

--- a/control-panel-graalpy/src/test/java/io/micronaut/controlpanel/panels/graalpy/GraalPyVfsMetadataReaderTest.java
+++ b/control-panel-graalpy/src/test/java/io/micronaut/controlpanel/panels/graalpy/GraalPyVfsMetadataReaderTest.java
@@ -19,9 +19,18 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.net.URL;
 import java.net.URLClassLoader;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -62,6 +71,25 @@ class GraalPyVfsMetadataReaderTest {
     }
 
     @Test
+    void readsLocalJarFilesListMetadata() throws IOException {
+        Path jar = tempDir.resolve("graalpy.jar");
+        try (JarOutputStream jarOutputStream = new JarOutputStream(Files.newOutputStream(jar))) {
+            jarOutputStream.putNextEntry(new JarEntry(GraalPyVfsMetadataReader.RESOURCE_PATH));
+            jarOutputStream.write("src/dealer.py\n".getBytes(StandardCharsets.UTF_8));
+            jarOutputStream.closeEntry();
+        }
+
+        try (URLClassLoader classLoader = new URLClassLoader(new java.net.URL[] { jar.toUri().toURL() }, null)) {
+            var metadata = new GraalPyVfsMetadataReader().read(classLoader);
+
+            assertTrue(metadata.hasResources());
+            assertEquals(1, metadata.entryCount());
+            assertEquals("jar", metadata.resources().get(0).kind());
+            assertEquals("src/dealer.py", metadata.entries().get(0).path());
+        }
+    }
+
+    @Test
     void capsLargeFilesListMetadata() throws IOException {
         writeFilesList(IntStream.range(0, GraalPyVfsMetadataReader.MAX_ENTRIES + 2)
             .mapToObj(index -> "src/file" + index + ".py")
@@ -72,6 +100,46 @@ class GraalPyVfsMetadataReaderTest {
         assertEquals(GraalPyVfsMetadataReader.MAX_ENTRIES, metadata.entryCount());
         assertTrue(metadata.truncated());
         assertEquals(2, metadata.omittedEntries());
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void skipsNonLocalMetadataResourcesWithoutOpeningThem() throws IOException {
+        AtomicBoolean opened = new AtomicBoolean();
+        URL nonLocalResource = new URL(null, "https://example.invalid/" + GraalPyVfsMetadataReader.RESOURCE_PATH, new URLStreamHandler() {
+            @Override
+            protected URLConnection openConnection(URL url) {
+                opened.set(true);
+                throw new AssertionError("Non-local VFS metadata URL must not be opened");
+            }
+        });
+        ClassLoader classLoader = new ClassLoader(null) {
+            @Override
+            public Enumeration<URL> getResources(String name) {
+                assertEquals(GraalPyVfsMetadataReader.RESOURCE_PATH, name);
+                return Collections.enumeration(Collections.singleton(nonLocalResource));
+            }
+        };
+
+        var metadata = new GraalPyVfsMetadataReader().read(classLoader);
+
+        assertTrue(metadata.hasResources());
+        assertEquals(1, metadata.resourceCount());
+        assertFalse(metadata.hasEntries());
+        assertTrue(metadata.resources().get(0).unreadable());
+        assertTrue(metadata.warnings().stream().anyMatch(warning -> warning.contains("Skipped non-local GraalPy VFS metadata")));
+        assertFalse(opened.get());
+    }
+
+    @Test
+    void skipsOversizedSingleLineMetadataWithoutDisplayingIt() throws IOException {
+        writeFilesList("src/" + "a".repeat(5000) + ".py");
+
+        var metadata = read();
+
+        assertEquals(1, metadata.resourceCount());
+        assertFalse(metadata.hasEntries());
+        assertTrue(metadata.warnings().stream().anyMatch(warning -> warning.contains("Skipped an over-sized VFS metadata line")));
     }
 
     private GraalPyVfsMetadataReader.GraalPyVfsMetadata read() {

--- a/control-panel-graalpy/src/test/java/io/micronaut/controlpanel/panels/graalpy/GraalPyVfsMetadataReaderTest.java
+++ b/control-panel-graalpy/src/test/java/io/micronaut/controlpanel/panels/graalpy/GraalPyVfsMetadataReaderTest.java
@@ -103,6 +103,19 @@ class GraalPyVfsMetadataReaderTest {
     }
 
     @Test
+    void exactEntryCapIsNotReportedAsTruncatedWhenNoEntriesAreOmitted() throws IOException {
+        writeFilesList(IntStream.range(0, GraalPyVfsMetadataReader.MAX_ENTRIES)
+            .mapToObj(index -> "src/file" + index + ".py")
+            .collect(Collectors.joining("\n")));
+
+        var metadata = read();
+
+        assertEquals(GraalPyVfsMetadataReader.MAX_ENTRIES, metadata.entryCount());
+        assertFalse(metadata.truncated());
+        assertEquals(0, metadata.omittedEntries());
+    }
+
+    @Test
     @SuppressWarnings("deprecation")
     void skipsNonLocalMetadataResourcesWithoutOpeningThem() throws IOException {
         AtomicBoolean opened = new AtomicBoolean();

--- a/control-panel-ui/src/main/resources/static/css/dashboard.css
+++ b/control-panel-ui/src/main/resources/static/css/dashboard.css
@@ -1697,6 +1697,23 @@ dl.row dt {
     table-layout: fixed;
 }
 
+.cp-graalpy-tabs > .tabs-list {
+    width: 100%;
+    flex-wrap: wrap;
+}
+
+.cp-graalpy-module-table {
+    min-width: 64rem;
+}
+
+.cp-graalpy-vfs-table {
+    min-width: 48rem;
+}
+
+.cp-graalpy-method-list {
+    min-width: 18rem;
+}
+
 .cp-data-table-table th {
     height: 2.5rem;
     background: var(--card);

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ micronaut-testresources = "4.0.0"
 micronaut-gradle-plugin = "5.0.0-M1"
 micronaut-openapi = "7.0.0"
 micronaut-kafka = "6.0.0"
+micronaut-graal-languages = "2.0.0-RC2"
 kotlin-gradle-plugin = "2.3.21"
 micronaut-shared-settings = "8.0.0"
 playwright = "1.59.0"
@@ -58,6 +59,7 @@ micronaut-sql = { module = "io.micronaut.sql:micronaut-sql-bom", version.ref = "
 micronaut-data = { module = "io.micronaut.data:micronaut-data-bom", version.ref = "micronaut-data" }
 micronaut-testresources = { module = 'io.micronaut.testresources:micronaut-test-resources-bom', version.ref = "micronaut-testresources" }
 micronaut-kafka = { module = "io.micronaut.kafka:micronaut-kafka-bom", version.ref = "micronaut-kafka" }
+micronaut-graalpy = { module = "io.micronaut.graal-languages:micronaut-graalpy", version.ref = "micronaut-graal-languages" }
 avro = { module = "org.apache.avro:avro", version.ref = "avro" }
 avro-serde = { module = "io.confluent:kafka-streams-avro-serde", version.ref = "avro-serde" }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,6 +22,7 @@ include("control-panel-datasource")
 include("control-panel-hibernate")
 include("control-panel-ui")
 include("control-panel-kafka")
+include("control-panel-graalpy")
 
 include("doc-examples:example-java")
 

--- a/src/main/docs/guide/controlPanels/graalpy.adoc
+++ b/src/main/docs/guide/controlPanels/graalpy.adoc
@@ -1,0 +1,56 @@
+The GraalPy Control Panel provides a read-only diagnostics view for applications that use
+https://micronaut-projects.github.io/micronaut-graal-languages/latest/guide/[Micronaut Graal Languages] and
+`@GraalPyModule` interfaces.
+
+To add the GraalPy panel, add the following module as a development-time dependency:
+
+dependency:io.micronaut.controlpanel:micronaut-control-panel-graalpy[scope=developmentOnly]
+
+Your application must still include the GraalPy integration dependency:
+
+dependency:io.micronaut.graal-languages:micronaut-graalpy[scope=implementation]
+
+The panel is available when Control Panel is enabled and `micronaut-graalpy` is on the classpath. It does not require an
+annotated module interface to be present; in that case it shows an empty state.
+
+You can disable the panel with:
+
+[configuration]
+----
+micronaut:
+  control-panel:
+    panels:
+      graalpy:
+        enabled: false
+----
+
+=== Module Interfaces
+
+The panel inspects Micronaut bean definitions annotated with `@GraalPyModule`. For each definition it shows the bean
+name, Java interface type, Python module name, Java method signatures, scope and qualifier metadata when available, and
+an instantiation state of `Unknown` when that cannot be observed without creating the bean.
+
+This inspection uses annotation and method metadata. It does not call `BeanContext.getBean(...)`, inject the
+`@GraalPyModule` interface, import the configured Python module, or invoke any Python-backed Java method.
+
+=== Runtime Metadata
+
+The runtime section shows `GraalPyContextBuilderFactory` bean definition candidates and whether the shared internal
+`GraalPyContext` bean definition is present. The panel does not call `GraalPyContextBuilderFactory.createBuilder()`,
+build a polyglot `Context`, initialize Python, or evaluate Python code.
+
+Micronaut GraalPy's default introduction advice uses one shared polyglot context for `@GraalPyModule` interfaces. Python
+execution can serialize on the global interpreter lock. If an application needs multiple isolated contexts, use custom
+GraalVM `Context` APIs outside the Control Panel.
+
+=== Python VFS Metadata
+
+The panel looks for `org.graalvm.python.vfs/fileslist.txt` classpath resources created by the GraalPy Maven or Gradle
+plugin. When the resource is present, the panel shows sanitized classpath resource labels and a capped, searchable list
+of packaged paths. It reads only `fileslist.txt`; it does not read listed Python files, package contents, package indexes,
+or local filesystem paths.
+
+When no metadata is found, verify that the GraalPy build plugin is configured to package your Python sources and
+dependencies and that `org.graalvm.python.vfs/fileslist.txt` is present in the built application resources or jar. If the
+metadata is too large or a resource is unreadable, the panel shows partial data with a warning instead of failing the
+whole page.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -10,6 +10,7 @@ controlPanels:
   datasource: Datasource
   hibernate: Hibernate
   kafka: Kafka
+  graalpy: GraalPy
 
 custom: Creating Custom Control Panels
 repository: Repository


### PR DESCRIPTION
## Summary

- Adds an optional `micronaut-control-panel-graalpy` module for read-only GraalPy diagnostics.
- Lists `@GraalPyModule` bean-definition metadata, Java method signatures, context-builder candidates, shared-context state, and packaged VFS `fileslist.txt` entries without importing Python modules or invoking Python-backed methods.
- Adds focused tests and user guide documentation for setup, inspected data, no-execution boundaries, shared-context/GIL notes, and VFS packaging troubleshooting.

## Issue Linkage

Paperclip issue: DEV-482. No linked GitHub issue exists for this manual Paperclip enhancement, so a GitHub closing keyword and linked GitHub issue creator reviewer request are not applicable.

## Release Projects

QA selected these open Micronaut organization projects for the PR: `5.0.0-M3` and `5.0.0 Release`.

Ambiguity note from QA intake: `5.0.1 Release`, `5.1.0 Release`, and `6.0.0 Release` are also open, but Control Panel `2.0.0` aligns with the Micronaut 5.0 generation, so the 5.0.0 boards are the best fit.

## Verification

- `./gradlew :micronaut-control-panel-graalpy:test :micronaut-control-panel-ui:processResources`
- `./gradlew :micronaut-control-panel-graalpy:checkstyleMain :micronaut-control-panel-graalpy:test --rerun-tasks`
- `git diff --check`
- Browser verification with a temporary GraalPy screenshot app under `build/tmp`: populated panel, tab switching, desktop `1440x900`, and mobile `390x844`.

## PR Assets

![Desktop GraalPy panel](https://raw.githubusercontent.com/micronaut-projects/micronaut-control-panel/fbb3e6a5548ec820beb3030e09061fc79fb64949/assets/pr-572/0fb2eef49183/graalpy-panel-desktop-1440x900.png)

![Mobile GraalPy panel](https://raw.githubusercontent.com/micronaut-projects/micronaut-control-panel/8e239c1692b73f2ace70059749d9f60a119f0c35/assets/pr-572/0fb2eef49183/graalpy-panel-mobile-390x844.png)

---
###### ✨ This message was AI-generated using gpt-5