### PR TITLE
Disable binary compatibility checks until 2.0.0

### DIFF
--- a/buildSrc/src/main/kotlin/io.micronaut.build.internal.control-panel-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/io.micronaut.build.internal.control-panel-module.gradle.kts
@@ -19,3 +19,7 @@ dependencies {
 tasks.withType<Test> {
     jvmArgs("-XX:+EnableDynamicAgentLoading")
 }
+
+micronautBuild {
+    binaryCompatibility.enabledAfter("2.0.0")
+}

--- a/control-panel-bom/build.gradle.kts
+++ b/control-panel-bom/build.gradle.kts
@@ -1,3 +1,7 @@
 plugins {
     io.micronaut.build.internal.bom
 }
+
+micronautBuild {
+    binaryCompatibility.enabledAfter("2.0.0")
+}

--- a/control-panel-cache/build.gradle.kts
+++ b/control-panel-cache/build.gradle.kts
@@ -37,10 +37,6 @@ dependencies {
     testImplementation(mnCache.micronaut.cache.infinispan)
 }
 
-micronautBuild {
-    binaryCompatibility.enabledAfter("2.0.0")
-}
-
 tasks.named("internalStartTestResourcesService") {
     setProperty("useClassDataSharing", false)
 }

--- a/control-panel-datasource/build.gradle.kts
+++ b/control-panel-datasource/build.gradle.kts
@@ -32,10 +32,6 @@ dependencies {
     testRuntimeOnly(mnTest.bytebuddy.agent)
 }
 
-micronautBuild {
-    binaryCompatibility.enabledAfter("2.0.0")
-}
-
 tasks.named("internalStartTestResourcesService") {
     setProperty("useClassDataSharing", false)
 }

--- a/control-panel-hibernate/build.gradle.kts
+++ b/control-panel-hibernate/build.gradle.kts
@@ -13,7 +13,3 @@ dependencies {
     testImplementation(mnSql.hibernate.core)
     testRuntimeOnly(mnTest.junit.jupiter.engine)
 }
-
-micronautBuild {
-    binaryCompatibility.enabledAfter("2.0.0")
-}

--- a/control-panel-kafka/build.gradle.kts
+++ b/control-panel-kafka/build.gradle.kts
@@ -33,10 +33,6 @@ dependencies {
     testImplementation(mn.micronaut.http.client)
 }
 
-micronautBuild {
-    binaryCompatibility.enabledAfter("2.0.0")
-}
-
 tasks.named("internalStartTestResourcesService") {
     setProperty("useClassDataSharing", false)
 }

--- a/control-panel-object-storage/build.gradle.kts
+++ b/control-panel-object-storage/build.gradle.kts
@@ -24,7 +24,3 @@ dependencies {
     testRuntimeOnly(mnTest.junit.jupiter.engine)
     testAnnotationProcessor(mn.micronaut.inject.java)
 }
-
-micronautBuild {
-    binaryCompatibility.enabledAfter("1.10.0")
-}


### PR DESCRIPTION
## Summary
- Configure binary compatibility checks for all Control Panel modules through the shared module convention.
- Disable BOM and module compatibility checks until after the first 2.0.0 release.
- Remove per-module compatibility thresholds that caused 2.0.x snapshots to compare against pre-2.0 baselines.

## Validation
- `env -u NODE_OPTIONS ./gradlew japiCmp :micronaut-control-panel-bom:checkVersionCatalogCompatibility --continue`

No UI changes; screenshots are not applicable.
