### PR TITLE
Fix Oracle UCP datasource inspector compile

### DIFF
--- a/control-panel-datasource/src/main/java/io/micronaut/controlpanel/panels/datasource/OracleUcpConnectionPoolInspector.java
+++ b/control-panel-datasource/src/main/java/io/micronaut/controlpanel/panels/datasource/OracleUcpConnectionPoolInspector.java
@@ -117,7 +117,6 @@ final class OracleUcpConnectionPoolInspector implements ConnectionPoolInspector 
             PoolInfoSupport.group(
                 "Behavior",
                 option("Fast connection failover", safeBoolean(dataSource::getFastConnectionFailoverEnabled)),
-                option("Fail fast on chunk unavailable", safeBoolean(dataSource::getFailFastOnChunkUnavailable)),
                 option("Read-only instances", dataSource.isReadOnlyInstanceAllowed()),
                 option("Create in borrow thread", dataSource.isCreateConnectionInBorrowThread()),
                 option("Commit on return", dataSource.isCommitOnConnectionReturn()),


### PR DESCRIPTION
## Summary
- Remove the Oracle UCP diagnostic option that calls the removed `PoolDataSource#getFailFastOnChunkUnavailable()` API.
- Restore `control-panel-datasource` compilation on `2.0.x` after the dependency refresh.

## Verification
- `./gradlew :micronaut-control-panel-datasource:compileJava`
- `./gradlew :micronaut-control-panel-datasource:test --tests io.micronaut.controlpanel.panels.datasource.DataSourceServiceTest`
- `./gradlew :micronaut-control-panel-datasource:check`

## Screenshots
Not applicable. This is a compile-only datasource module fix with no UI-visible behavior change.

---
###### ✨ This message was AI-generated using gpt-5.5
