### PR TITLE
docs: fix custom panel guide snippets

### DIFF
--- a/src/main/docs/guide/custom.adoc
+++ b/src/main/docs/guide/custom.adoc
@@ -29,7 +29,10 @@ a default category called `Dashboard` that is used for all control panels that d
 The easiest way to implement a custom panel is to extend from
 api:controlpanel.core.AbstractControlPanel[]. For example:
 
-snippet::example.MyApplicationControlPanel[project-base="doc-examples/example", source="main", indent="0", tags="class"]
+[source,java]
+----
+include::doc-examples/example-java/src/main/java/example/MyApplicationControlPanel.java[tags=class]
+----
 
 <1> The type parameter indicates the object type of the body. You can use your own classes or records to return
     custom data to the view.
@@ -44,16 +47,13 @@ to display a badge in the control panel header.
 
 == Configuration
 
-There are some values for the UI that can be configured:
+There are some values for the UI that can be configured, including the title displayed in the control panel header, the
+Font Awesome icon class, and the order in which the control panel is displayed in the UI:
 
 [configuration]
 ----
 include::doc-examples/example-java/src/main/resources/application.yml[tags=control-panel]
 ----
-
-<1> Title to be displayed in the control panel header.
-<2> Icon class (from Font Awesome) of the control panel.
-<3> The order in which the control panel will be displayed in the UI.
 
 == Views
 


### PR DESCRIPTION
## Summary

- Replace the custom control panel multi-language snippet macro with a direct tagged Java include that matches the repository's maintained example.
- Move configuration callout explanations into prose so the rendered guide no longer reports missing callouts.

## Validation

- `npm_config_include=dev ./gradlew publishGuide`
- `npm_config_include=dev ./gradlew :micronaut-doc-examples:micronaut-example-java:test --tests example.MyApplicationControlPanelTest -x :micronaut-doc-examples:micronaut-example-java:playwrightInstall`

## Notes

- The first plain `./gradlew publishGuide` attempt failed because the workspace npm configuration omits dev dependencies, leaving Rollup unavailable. Re-running with `npm_config_include=dev` assembled the guide successfully.
- The selected example unit test needs `-x :micronaut-doc-examples:micronaut-example-java:playwrightInstall` in this environment because the browser installer attempts privileged dependency installation and fails with `su: Authentication failure`.

---
###### ✨ This message was AI-generated using openai/gpt-5.5