### PR TITLE
Fix custom control panel guide snippets

### DIFF
--- a/src/main/docs/guide/custom.adoc
+++ b/src/main/docs/guide/custom.adoc
@@ -29,7 +29,10 @@ a default category called `Dashboard` that is used for all control panels that d
 The easiest way to implement a custom panel is to extend from
 api:controlpanel.core.AbstractControlPanel[]. For example:
 
-snippet::example.MyApplicationControlPanel[project-base="doc-examples/example", source="main", indent="0", tags="class"]
+[source,java]
+----
+include::doc-examples/example-java/src/main/java/example/MyApplicationControlPanel.java[tags=class]
+----
 
 <1> The type parameter indicates the object type of the body. You can use your own classes or records to return
     custom data to the view.
@@ -46,7 +49,7 @@ to display a badge in the control panel header.
 
 There are some values for the UI that can be configured:
 
-[configuration]
+[source,yaml]
 ----
 include::doc-examples/example-java/src/main/resources/application.yml[tags=control-panel]
 ----


### PR DESCRIPTION
## Summary
- Replace the broken multi-language custom panel snippet with the validated Java example include.
- Render the custom panel configuration include as YAML so callouts attach cleanly and `publishGuide` no longer emits snippet/callout warnings for this page.

## Validation
- `env -u NODE_ENV ./gradlew publishGuide`
- `env -u NODE_ENV ./gradlew :micronaut-doc-examples:micronaut-example-java:test --tests example.MyApplicationControlPanelTest -x :micronaut-doc-examples:micronaut-example-java:playwrightInstall`
- `git diff --check`
- Confirmed generated `guide/custom.html` contains `class MyApplicationControlPanel extends AbstractControlPanel` and the YAML configuration callouts.

Paperclip: DEV-1309 Weekly User Guide Review: micronaut-control-panel

---
###### ✨ This message was AI-generated using gpt-5.5
