### PR TITLE
docs: fix custom control panel guide rendering

### DIFF
--- a/src/main/docs/guide/custom.adoc
+++ b/src/main/docs/guide/custom.adoc
@@ -29,7 +29,10 @@ a default category called `Dashboard` that is used for all control panels that d
 The easiest way to implement a custom panel is to extend from
 api:controlpanel.core.AbstractControlPanel[]. For example:
 
-snippet::example.MyApplicationControlPanel[project-base="doc-examples/example", source="main", indent="0", tags="class"]
+[source,java]
+----
+include::doc-examples/example-java/src/main/java/example/MyApplicationControlPanel.java[tags=class]
+----
 
 <1> The type parameter indicates the object type of the body. You can use your own classes or records to return
     custom data to the view.
@@ -51,9 +54,8 @@ There are some values for the UI that can be configured:
 include::doc-examples/example-java/src/main/resources/application.yml[tags=control-panel]
 ----
 
-<1> Title to be displayed in the control panel header.
-<2> Icon class (from Font Awesome) of the control panel.
-<3> The order in which the control panel will be displayed in the UI.
+The example configures the title displayed in the control panel header, the Font Awesome icon class, and the order in
+which the control panel is displayed in the UI.
 
 == Views
 


### PR DESCRIPTION
## Summary

- Replace the custom control panel multi-language snippet macro with the maintained Java example include.
- Replace orphaned configuration callouts with prose so the rendered guide no longer emits custom-panel callout warnings.

## Validation

- `git fetch origin 2.0.x` and `git rebase origin/2.0.x`
- `NODE_ENV=development ./gradlew publishGuide`
- `NODE_ENV=development ./gradlew docs :micronaut-doc-examples:micronaut-example-java:test --tests example.MyApplicationControlPanelTest` (the combined run passed `docs`; the example test first hit the existing Playwright browser dependency installer, then passed with the Playwright installer excluded for this non-browser unit test)
- `./gradlew :micronaut-doc-examples:micronaut-example-java:test --tests example.MyApplicationControlPanelTest -x :micronaut-doc-examples:micronaut-example-java:playwrightInstall`
- `git diff --check`
- Rendered `build/working/02-docs-raw/all/guide/custom.html` scan confirmed no `NO FILE`, no `no callout`, and the Java example plus configuration prose are present.

Paperclip: DEV-1378

---
###### ✨ This message was AI-generated using gpt-5.5
