### PR TITLE
Fix custom control panel guide examples

### DIFF
--- a/doc-examples/example-java/src/main/resources/application.yml
+++ b/doc-examples/example-java/src/main/resources/application.yml
@@ -5,9 +5,9 @@ micronaut:
   control-panel:
     panels:
       my-application:
-        title: My Application Control Panel # <1>
-        icon: fa-plug # <2>
-        order: 10 # <3>
+        title: My Application Control Panel
+        icon: fa-plug
+        order: 10
 #end::control-panel[]
     env:
       show-values: true

--- a/src/main/docs/guide/custom.adoc
+++ b/src/main/docs/guide/custom.adoc
@@ -29,7 +29,10 @@ a default category called `Dashboard` that is used for all control panels that d
 The easiest way to implement a custom panel is to extend from
 api:controlpanel.core.AbstractControlPanel[]. For example:
 
-snippet::example.MyApplicationControlPanel[project-base="doc-examples/example", source="main", indent="0", tags="class"]
+[source,java]
+----
+include::doc-examples/example-java/src/main/java/example/MyApplicationControlPanel.java[tags=class,indent=0]
+----
 
 <1> The type parameter indicates the object type of the body. You can use your own classes or records to return
     custom data to the view.
@@ -44,16 +47,14 @@ to display a badge in the control panel header.
 
 == Configuration
 
-There are some values for the UI that can be configured:
+There are some values for the UI that can be configured. In this example, `title` is displayed in the control panel
+header, `icon` is the Font Awesome icon class for the control panel, and `order` controls where the panel appears in the
+UI.
 
 [configuration]
 ----
 include::doc-examples/example-java/src/main/resources/application.yml[tags=control-panel]
 ----
-
-<1> Title to be displayed in the control panel header.
-<2> Icon class (from Font Awesome) of the control panel.
-<3> The order in which the control panel will be displayed in the UI.
 
 == Views
 
@@ -71,10 +72,10 @@ on the classpath, and named `body.hbs` and `detail.hbs`, respectively. For examp
 include::doc-examples/example-java/src/main/resources/views/my-application/body.hbs[]
 ----
 
-The api:controlpanel.core.ControlPanel[] instance (`MyApplicationControlPanel` in this case) is stored on the Handlebars
-context, so you can implicitly access its methods and properties. For example, to access the badge:
+The api:controlpanel.core.ControlPanel[] instance is stored on the Handlebars context, so templates can access its
+methods and properties. For example, the built-in Beans panel accesses its body data from the implicit context:
 
-.`src/main/resources/views/my-application/body.hbs`.
+.`control-panel-management/src/main/resources/views/beans/body.hbs`.
 [source, html]
 ----
 include::control-panel-management/src/main/resources/views/beans/body.hbs[]


### PR DESCRIPTION
## Summary
- Fixes the custom control panel guide so the Java example is included from the runnable `doc-examples/example-java` source instead of asking the docs snippet macro for non-existent Kotlin, Groovy, and Python example projects.
- Moves the configuration callout explanations into prose and removes inline callout markers from the runnable YAML snippet, eliminating `publishGuide` callout warnings.
- Corrects the Handlebars example caption to match the built-in Beans template that is actually included.

## Validation
- `unset NODE_ENV && ./gradlew publishGuide` — passed; generated guide at `build/working/02-docs-raw/all/index.html` with no missing snippet or callout warnings.
- `unset NODE_ENV && ./gradlew publishGuide :micronaut-doc-examples:micronaut-example-java:test --tests example.MyApplicationControlPanelTest -x playwrightInstall` — passed; the runnable custom panel example still binds its `title`, `icon`, `order`, category, and body as documented.
- First `publishGuide` attempt with inherited `NODE_ENV=production` failed because npm omitted Rollup dev dependencies; reran with `NODE_ENV` unset so the documented Gradle guide assembly path could install the UI build tooling.

Fixes DEV-1361

---
###### ✨ This message was AI-generated using gpt-5.5
