### PR TITLE
Add HTTP client diagnostics control panel

### DIFF
--- a/control-panel-http-client/build.gradle.kts
+++ b/control-panel-http-client/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins {
+    io.micronaut.build.internal.`control-panel-module`
+}
+
+dependencies {
+    api(projects.micronautControlPanelCore)
+    implementation(mn.micronaut.discovery.core)
+    implementation(mn.micronaut.http.client)
+
+    testImplementation(mnTest.micronaut.test.junit5)
+    testImplementation(mnReactor.micronaut.reactor)
+    testImplementation(mnSerde.micronaut.serde.jackson)
+    testImplementation(mn.micronaut.http.server.netty)
+    testImplementation(mn.micronaut.http.client)
+    testRuntimeOnly(mnTest.junit.jupiter.engine)
+    testAnnotationProcessor(mn.micronaut.inject.java)
+}
+
+micronautBuild {
+    binaryCompatibility.enabledAfter("2.1.0")
+}

--- a/control-panel-http-client/src/main/java/io/micronaut/controlpanel/panels/httpclient/HttpClientDiagnostics.java
+++ b/control-panel-http-client/src/main/java/io/micronaut/controlpanel/panels/httpclient/HttpClientDiagnostics.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.httpclient;
+
+import io.micronaut.core.annotation.ReflectiveAccess;
+
+import java.util.List;
+
+/**
+ * Read-only HTTP client diagnostics view model.
+ *
+ * @param clients clients visible to the running application
+ * @param clientCount number of clients
+ * @param discoveryClientAvailable whether Micronaut discovery is available
+ */
+@ReflectiveAccess
+public record HttpClientDiagnostics(
+    List<HttpClientInfo> clients,
+    int clientCount,
+    boolean discoveryClientAvailable) {
+
+    public boolean hasClients() {
+        return !clients.isEmpty();
+    }
+
+    public static HttpClientDiagnostics of(List<HttpClientInfo> clients, boolean discoveryClientAvailable) {
+        return new HttpClientDiagnostics(List.copyOf(clients), clients.size(), discoveryClientAvailable);
+    }
+
+    /**
+     * A single declarative or named Micronaut HTTP client.
+     *
+     * @param id client id or bean name
+     * @param beanType Java type when available
+     * @param source source classification
+     * @param target target summary
+     * @param configuration safe configuration summary
+     * @param discovery discovery or fixed-target state
+     * @param filters matching filter metadata
+     */
+    @ReflectiveAccess
+    public record HttpClientInfo(
+        String id,
+        String beanType,
+        String source,
+        TargetInfo target,
+        ConfigurationInfo configuration,
+        DiscoveryInfo discovery,
+        List<FilterInfo> filters) {
+
+        public boolean hasFilters() {
+            return !filters.isEmpty();
+        }
+    }
+
+    /**
+     * Target information.
+     *
+     * @param kind fixed URL, service id, discovery, or unknown
+     * @param value masked target value
+     * @param badgeClass badge CSS class
+     */
+    @ReflectiveAccess
+    public record TargetInfo(String kind, String value, String badgeClass) {
+    }
+
+    /**
+     * Safe HTTP client configuration subset.
+     *
+     * @param path configured context path
+     * @param connectTimeout connect timeout summary
+     * @param readTimeout read timeout summary
+     * @param requestTimeout request timeout summary
+     * @param followRedirects redirect policy summary
+     * @param maxRedirects redirect limit summary
+     * @param httpVersion HTTP version summary
+     * @param plaintextMode plaintext mode summary
+     * @param alpnModes ALPN mode summary
+     * @param proxy masked proxy summary
+     * @param proxyCredentials proxy credential visibility summary
+     * @param tls TLS configuration summary
+     * @param connectionPool connection pool summary
+     */
+    @ReflectiveAccess
+    public record ConfigurationInfo(
+        String path,
+        String connectTimeout,
+        String readTimeout,
+        String requestTimeout,
+        String followRedirects,
+        String maxRedirects,
+        String httpVersion,
+        String plaintextMode,
+        String alpnModes,
+        String proxy,
+        String proxyCredentials,
+        String tls,
+        String connectionPool) {
+    }
+
+    /**
+     * Discovery information visible through Micronaut service-instance lists.
+     *
+     * @param available whether instance details are available
+     * @param message explanation for the state
+     * @param instances safe instance list
+     */
+    @ReflectiveAccess
+    public record DiscoveryInfo(boolean available, String message, List<ServiceInstanceInfo> instances) {
+
+        public boolean hasInstances() {
+            return !instances.isEmpty();
+        }
+    }
+
+    /**
+     * Safe service instance summary.
+     *
+     * @param id service instance id
+     * @param uri masked service instance URI
+     * @param status service instance status
+     * @param zone service instance zone
+     * @param region service instance region
+     */
+    @ReflectiveAccess
+    public record ServiceInstanceInfo(String id, String uri, String status, String zone, String region) {
+    }
+
+    /**
+     * Safe outbound filter metadata.
+     *
+     * @param type filter bean type
+     * @param order filter order
+     * @param patterns filter URL patterns
+     * @param methods filter HTTP methods
+     */
+    @ReflectiveAccess
+    public record FilterInfo(String type, String order, String patterns, String methods) {
+    }
+}

--- a/control-panel-http-client/src/main/java/io/micronaut/controlpanel/panels/httpclient/HttpClientDiagnosticsControlPanel.java
+++ b/control-panel-http-client/src/main/java/io/micronaut/controlpanel/panels/httpclient/HttpClientDiagnosticsControlPanel.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.httpclient;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.controlpanel.core.AbstractControlPanel;
+import io.micronaut.controlpanel.core.ControlPanel;
+import io.micronaut.controlpanel.core.config.ControlPanelConfiguration;
+import io.micronaut.core.annotation.ReflectiveAccess;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.runtime.context.scope.Refreshable;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+/**
+ * Control panel that displays read-only diagnostics for Micronaut HTTP clients.
+ */
+@Singleton
+@Refreshable
+@Requires(classes = HttpClient.class)
+@Requires(property = HttpClientDiagnosticsControlPanel.ENABLED_PROPERTY, notEquals = StringUtils.FALSE)
+@SuppressWarnings("InjectMoreThanOneScopeAnnotationOnClass")
+public class HttpClientDiagnosticsControlPanel extends AbstractControlPanel<HttpClientDiagnosticsControlPanel.Body> {
+
+    public static final String NAME = "http-client";
+    public static final String ENABLED_PROPERTY = ControlPanelConfiguration.PREFIX + "." + NAME + ".enabled";
+    public static final ControlPanel.Category CATEGORY = new ControlPanel.Category("http", "HTTP", "fas fa-network-wired");
+
+    private final HttpClientDiagnosticsService diagnosticsService;
+
+    public HttpClientDiagnosticsControlPanel(HttpClientDiagnosticsService diagnosticsService,
+                                             @Named(NAME) ControlPanelConfiguration configuration) {
+        super(NAME, configuration);
+        this.diagnosticsService = diagnosticsService;
+    }
+
+    @Override
+    public Body getBody() {
+        return new Body(diagnosticsService.collect());
+    }
+
+    @Override
+    public String getBadge() {
+        return String.valueOf(diagnosticsService.collect().clients().size());
+    }
+
+    @Override
+    public ControlPanel.Category getCategory() {
+        return CATEGORY;
+    }
+
+    /**
+     * The body of the HTTP client diagnostics panel.
+     *
+     * @param diagnostics collected diagnostics
+     */
+    @ReflectiveAccess
+    public record Body(HttpClientDiagnostics diagnostics) {
+    }
+}

--- a/control-panel-http-client/src/main/java/io/micronaut/controlpanel/panels/httpclient/HttpClientDiagnosticsService.java
+++ b/control-panel-http-client/src/main/java/io/micronaut/controlpanel/panels/httpclient/HttpClientDiagnosticsService.java
@@ -68,6 +68,8 @@ public class HttpClientDiagnosticsService {
 
     private static final String NOT_CONFIGURED = "Not configured";
     private static final String MASKED = "Masked";
+    private static final String FIXED_URL = "Fixed URL";
+    private static final String SERVICE_ID = "Service ID";
     private static final Set<String> LOCAL_TARGETS = Set.of("/", "");
 
     private final BeanContext beanContext;
@@ -122,7 +124,7 @@ public class HttpClientDiagnosticsService {
         for (BeanDefinition<ServiceHttpClientConfiguration> definition : beanContext.getBeanDefinitions(ServiceHttpClientConfiguration.class)) {
             ServiceHttpClientConfiguration configuration = beanContext.getBean(definition);
             String id = configuration.getServiceId();
-            if (id == null || id.isBlank()) {
+            if (id.isBlank()) {
                 id = definition.getName();
             }
             ClientBuilder builder = builders.computeIfAbsent(id, ClientBuilder::new);
@@ -293,16 +295,16 @@ public class HttpClientDiagnosticsService {
             List<URI> urls = configuration == null ? List.of() : configuration.getUrls();
             if (!urls.isEmpty()) {
                 String joined = urls.stream().map(URI::toString).map(HttpClientDiagnosticsService::sanitizeTarget).reduce((left, right) -> left + ", " + right).orElse(NOT_CONFIGURED);
-                return new TargetInfo("Fixed URL", joined, "badge-success");
+                return new TargetInfo(FIXED_URL, joined, "badge-success");
             }
             if (annotationTarget != null && !annotationTarget.isBlank() && !LOCAL_TARGETS.contains(annotationTarget)) {
                 if (annotationTarget.startsWith("http://") || annotationTarget.startsWith("https://")) {
-                    return new TargetInfo("Fixed URL", sanitizeTarget(annotationTarget), "badge-success");
+                    return new TargetInfo(FIXED_URL, sanitizeTarget(annotationTarget), "badge-success");
                 }
-                return new TargetInfo("Service ID", annotationTarget, "badge-warning");
+                return new TargetInfo(SERVICE_ID, annotationTarget, "badge-warning");
             }
             if (configuration != null) {
-                return new TargetInfo("Service ID", configuration.getServiceId(), "badge-warning");
+                return new TargetInfo(SERVICE_ID, configuration.getServiceId(), "badge-warning");
             }
             if (annotationTarget != null && LOCAL_TARGETS.contains(annotationTarget)) {
                 return new TargetInfo("Local", annotationTarget.isBlank() ? "/" : annotationTarget, "badge-secondary");
@@ -341,7 +343,7 @@ public class HttpClientDiagnosticsService {
         }
 
         private DiscoveryInfo discoveryInfo(TargetInfo target, boolean discoveryAvailable, List<ServiceInstanceList> serviceInstanceLists) {
-            if (!Objects.equals(target.kind(), "Service ID")) {
+            if (!Objects.equals(target.kind(), SERVICE_ID)) {
                 return new DiscoveryInfo(false, "Fixed or local targets do not use service discovery.", List.of());
             }
             if (!discoveryAvailable && serviceInstanceLists.isEmpty()) {

--- a/control-panel-http-client/src/main/java/io/micronaut/controlpanel/panels/httpclient/HttpClientDiagnosticsService.java
+++ b/control-panel-http-client/src/main/java/io/micronaut/controlpanel/panels/httpclient/HttpClientDiagnosticsService.java
@@ -1,0 +1,376 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.httpclient;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.BeanProvider;
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.naming.NameUtils;
+import io.micronaut.core.order.Ordered;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.discovery.DiscoveryClient;
+import io.micronaut.discovery.ServiceInstance;
+import io.micronaut.discovery.ServiceInstanceList;
+import io.micronaut.http.HttpMethod;
+import io.micronaut.http.client.HttpClientConfiguration;
+import io.micronaut.http.client.ServiceHttpClientConfiguration;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.http.client.filter.ClientFilterResolutionContext;
+import io.micronaut.http.filter.GenericHttpFilter;
+import io.micronaut.http.filter.HttpClientFilterResolver;
+import io.micronaut.http.filter.HttpFilterResolver;
+import io.micronaut.http.ssl.SslConfiguration;
+import io.micronaut.inject.BeanDefinition;
+import jakarta.inject.Singleton;
+import org.jspecify.annotations.Nullable;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.SocketAddress;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.StringJoiner;
+
+import static io.micronaut.controlpanel.panels.httpclient.HttpClientDiagnostics.ConfigurationInfo;
+import static io.micronaut.controlpanel.panels.httpclient.HttpClientDiagnostics.DiscoveryInfo;
+import static io.micronaut.controlpanel.panels.httpclient.HttpClientDiagnostics.FilterInfo;
+import static io.micronaut.controlpanel.panels.httpclient.HttpClientDiagnostics.HttpClientInfo;
+import static io.micronaut.controlpanel.panels.httpclient.HttpClientDiagnostics.ServiceInstanceInfo;
+import static io.micronaut.controlpanel.panels.httpclient.HttpClientDiagnostics.TargetInfo;
+
+/**
+ * Collects read-only diagnostics for Micronaut HTTP clients from bean definitions and named client configuration.
+ */
+@Singleton
+public class HttpClientDiagnosticsService {
+
+    private static final String NOT_CONFIGURED = "Not configured";
+    private static final String MASKED = "Masked";
+    private static final Set<String> LOCAL_TARGETS = Set.of("/", "");
+
+    private final BeanContext beanContext;
+    private final BeanProvider<DiscoveryClient> discoveryClientProvider;
+    private final BeanProvider<HttpClientFilterResolver<ClientFilterResolutionContext>> filterResolverProvider;
+
+    public HttpClientDiagnosticsService(BeanContext beanContext,
+                                        BeanProvider<DiscoveryClient> discoveryClientProvider,
+                                        BeanProvider<HttpClientFilterResolver<ClientFilterResolutionContext>> filterResolverProvider) {
+        this.beanContext = beanContext;
+        this.discoveryClientProvider = discoveryClientProvider;
+        this.filterResolverProvider = filterResolverProvider;
+    }
+
+    /**
+     * Collect diagnostics without issuing HTTP test requests or mutating application state.
+     *
+     * @return diagnostics
+     */
+    public HttpClientDiagnostics collect() {
+        Map<String, ClientBuilder> builders = new LinkedHashMap<>();
+        collectClientBeanDefinitions(builders);
+        collectServiceConfigurations(builders);
+        boolean discoveryAvailable = discoveryClientProvider.isResolvable();
+        List<ServiceInstanceList> serviceInstanceLists = beanContext.getBeansOfType(ServiceInstanceList.class).stream()
+            .sorted(Comparator.comparing(ServiceInstanceList::getID))
+            .toList();
+
+        List<HttpClientInfo> clients = builders.values().stream()
+            .map(builder -> builder.toInfo(discoveryAvailable, serviceInstanceLists, resolveFilters(builder.id)))
+            .sorted(Comparator.comparing(HttpClientInfo::id))
+            .toList();
+        return HttpClientDiagnostics.of(clients, discoveryAvailable);
+    }
+
+    private void collectClientBeanDefinitions(Map<String, ClientBuilder> builders) {
+        for (BeanDefinition<Object> definition : beanContext.getAllBeanDefinitions()) {
+            Optional<AnnotationValue<Client>> client = definition.findAnnotation(Client.class);
+            if (client.isEmpty()) {
+                continue;
+            }
+            String id = clientId(client.get(), definition);
+            ClientBuilder builder = builders.computeIfAbsent(id, ClientBuilder::new);
+            builder.beanType = definition.getBeanType().getName();
+            builder.source = mergeSource(builder.source, "Declarative @Client");
+            builder.annotationTarget = client.get().stringValue().orElse(StringUtils.EMPTY_STRING);
+            builder.annotationPath = client.get().stringValue("path").orElse(StringUtils.EMPTY_STRING);
+        }
+    }
+
+    private void collectServiceConfigurations(Map<String, ClientBuilder> builders) {
+        for (BeanDefinition<ServiceHttpClientConfiguration> definition : beanContext.getBeanDefinitions(ServiceHttpClientConfiguration.class)) {
+            ServiceHttpClientConfiguration configuration = beanContext.getBean(definition);
+            String id = configuration.getServiceId();
+            if (id == null || id.isBlank()) {
+                id = definition.getName();
+            }
+            ClientBuilder builder = builders.computeIfAbsent(id, ClientBuilder::new);
+            builder.source = mergeSource(builder.source, "Named configuration");
+            builder.configuration = configuration;
+        }
+    }
+
+    private List<FilterInfo> resolveFilters(String clientId) {
+        if (!filterResolverProvider.isResolvable()) {
+            return List.of();
+        }
+        ClientFilterResolutionContext context = new ClientFilterResolutionContext(List.of(clientId), AnnotationMetadata.EMPTY_METADATA);
+        try {
+            return filterResolverProvider.get().resolveFilterEntries(context).stream()
+                .map(HttpClientDiagnosticsService::toFilterInfo)
+                .sorted(Comparator.comparing(FilterInfo::type).thenComparing(FilterInfo::order))
+                .toList();
+        } catch (RuntimeException e) {
+            return List.of();
+        }
+    }
+
+    private static FilterInfo toFilterInfo(HttpFilterResolver.FilterEntry entry) {
+        GenericHttpFilter filter = entry.getFilter();
+        String order = filter instanceof Ordered ordered ? String.valueOf(ordered.getOrder()) : NOT_CONFIGURED;
+        String patterns = entry.hasPatterns() ? String.join(", ", entry.getPatterns()) : "All paths";
+        String methods = entry.hasMethods() ? joinMethods(entry.getFilterMethods()) : "All methods";
+        return new FilterInfo(filter.getClass().getName(), order, patterns, methods);
+    }
+
+    private static String joinMethods(Collection<HttpMethod> methods) {
+        return methods.stream()
+            .map(HttpMethod::name)
+            .sorted()
+            .reduce((left, right) -> left + ", " + right)
+            .orElse("All methods");
+    }
+
+    private static String clientId(AnnotationValue<Client> client, BeanDefinition<?> definition) {
+        String id = client.stringValue("id").orElse(StringUtils.EMPTY_STRING);
+        if (id.isBlank()) {
+            id = client.stringValue().orElse(StringUtils.EMPTY_STRING);
+        }
+        if (id.isBlank()) {
+            id = definition.getName();
+        }
+        return NameUtils.hyphenate(id.replace("${", StringUtils.EMPTY_STRING).replace("}", StringUtils.EMPTY_STRING));
+    }
+
+    private static String mergeSource(String existing, String source) {
+        if (existing == null || existing.isBlank()) {
+            return source;
+        }
+        if (existing.contains(source)) {
+            return existing;
+        }
+        return existing + ", " + source;
+    }
+
+    private static String sanitizeTarget(String target) {
+        if (target == null || target.isBlank()) {
+            return NOT_CONFIGURED;
+        }
+        try {
+            URI uri = new URI(target);
+            if (uri.getUserInfo() == null && uri.getQuery() == null && uri.getFragment() == null) {
+                return target;
+            }
+            String authority = uri.getHost();
+            if (uri.getPort() > -1) {
+                authority += ":" + uri.getPort();
+            }
+            URI sanitized = new URI(
+                uri.getScheme(),
+                uri.getUserInfo() == null ? null : MASKED,
+                authority,
+                uri.getPort(),
+                uri.getPath(),
+                uri.getQuery() == null ? null : MASKED,
+                uri.getFragment() == null ? null : MASKED
+            );
+            return sanitized.toString();
+        } catch (URISyntaxException e) {
+            return target
+                .replaceAll("//[^/@]+@", "//" + MASKED + "@")
+                .replaceAll("\\?[^#]*", "?" + MASKED)
+                .replaceAll("#.*", "#" + MASKED);
+        }
+    }
+
+    private static String duration(Optional<Duration> duration) {
+        return duration.map(Duration::toString).orElse(NOT_CONFIGURED);
+    }
+
+    private static String duration(@Nullable Duration duration) {
+        return duration == null ? NOT_CONFIGURED : duration.toString();
+    }
+
+    private static String optionalString(Optional<?> value) {
+        return value.map(Object::toString).orElse(NOT_CONFIGURED);
+    }
+
+    private static String socketAddress(Optional<SocketAddress> value) {
+        return value.map(Object::toString).orElse(NOT_CONFIGURED);
+    }
+
+    private static String tlsSummary(SslConfiguration sslConfiguration) {
+        if (sslConfiguration == null) {
+            return NOT_CONFIGURED;
+        }
+        StringJoiner joiner = new StringJoiner(", ");
+        joiner.add("enabled=" + sslConfiguration.isEnabled());
+        sslConfiguration.getClientAuthentication().ifPresent(auth -> joiner.add("client-auth=" + auth));
+        sslConfiguration.getProtocol().ifPresent(protocol -> joiner.add("protocol=" + protocol));
+        if (sslConfiguration.getKey().getPassword().isPresent()
+            || sslConfiguration.getKeyStore().getPassword().isPresent()
+            || sslConfiguration.getKeyStore().getPath().isPresent()
+            || sslConfiguration.getTrustStore().getPassword().isPresent()
+            || sslConfiguration.getTrustStore().getPath().isPresent()) {
+            joiner.add("key/trust material=" + MASKED.toLowerCase(Locale.ROOT));
+        }
+        return joiner.toString();
+    }
+
+    private static String connectionPool(HttpClientConfiguration.ConnectionPoolConfiguration pool) {
+        if (pool == null) {
+            return NOT_CONFIGURED;
+        }
+        return "enabled=" + pool.isEnabled()
+            + ", version=" + pool.getVersion()
+            + ", max-pending-acquires=" + pool.getMaxPendingAcquires()
+            + ", max-http1=" + pool.getMaxConcurrentHttp1Connections()
+            + ", max-http2=" + pool.getMaxConcurrentHttp2Connections();
+    }
+
+    private static String alpnModes(List<String> modes) {
+        return modes == null || modes.isEmpty() ? NOT_CONFIGURED : String.join(", ", modes);
+    }
+
+    private static final class ClientBuilder {
+        private final String id;
+        private String beanType = NOT_CONFIGURED;
+        private String source = "Unknown";
+        private String annotationTarget = StringUtils.EMPTY_STRING;
+        private String annotationPath = StringUtils.EMPTY_STRING;
+        @Nullable
+        private ServiceHttpClientConfiguration configuration;
+
+        private ClientBuilder(String id) {
+            this.id = id;
+        }
+
+        private HttpClientInfo toInfo(boolean discoveryAvailable, List<ServiceInstanceList> serviceInstanceLists, List<FilterInfo> filters) {
+            TargetInfo target = targetInfo();
+            return new HttpClientInfo(
+                id,
+                beanType,
+                source,
+                target,
+                configurationInfo(),
+                discoveryInfo(target, discoveryAvailable, serviceInstanceLists),
+                filters
+            );
+        }
+
+        private TargetInfo targetInfo() {
+            List<URI> urls = configuration == null ? List.of() : configuration.getUrls();
+            if (!urls.isEmpty()) {
+                String joined = urls.stream().map(URI::toString).map(HttpClientDiagnosticsService::sanitizeTarget).reduce((left, right) -> left + ", " + right).orElse(NOT_CONFIGURED);
+                return new TargetInfo("Fixed URL", joined, "badge-success");
+            }
+            if (annotationTarget != null && !annotationTarget.isBlank() && !LOCAL_TARGETS.contains(annotationTarget)) {
+                if (annotationTarget.startsWith("http://") || annotationTarget.startsWith("https://")) {
+                    return new TargetInfo("Fixed URL", sanitizeTarget(annotationTarget), "badge-success");
+                }
+                return new TargetInfo("Service ID", annotationTarget, "badge-warning");
+            }
+            if (configuration != null) {
+                return new TargetInfo("Service ID", configuration.getServiceId(), "badge-warning");
+            }
+            if (annotationTarget != null && LOCAL_TARGETS.contains(annotationTarget)) {
+                return new TargetInfo("Local", annotationTarget.isBlank() ? "/" : annotationTarget, "badge-secondary");
+            }
+            return new TargetInfo("Unknown", NOT_CONFIGURED, "badge-secondary");
+        }
+
+        private ConfigurationInfo configurationInfo() {
+            HttpClientConfiguration cfg = configuration;
+            String path = configuration == null ? annotationPath : configuration.getPath().orElse(annotationPath);
+            if (path == null || path.isBlank()) {
+                path = NOT_CONFIGURED;
+            }
+            return new ConfigurationInfo(
+                path,
+                cfg == null ? NOT_CONFIGURED : duration(cfg.getConnectTimeout()),
+                cfg == null ? NOT_CONFIGURED : duration(cfg.getReadTimeout()),
+                cfg == null ? NOT_CONFIGURED : duration(cfg.getRequestTimeout()),
+                cfg == null ? NOT_CONFIGURED : String.valueOf(cfg.isFollowRedirects()),
+                NOT_CONFIGURED,
+                cfg == null ? NOT_CONFIGURED : String.valueOf(cfg.getHttpVersion()),
+                cfg == null ? NOT_CONFIGURED : String.valueOf(cfg.getPlaintextMode()),
+                cfg == null ? NOT_CONFIGURED : alpnModes(cfg.getAlpnModes()),
+                cfg == null ? NOT_CONFIGURED : cfg.getProxyType() + " " + socketAddress(cfg.getProxyAddress()),
+                cfg == null ? NOT_CONFIGURED : proxyCredentials(cfg),
+                cfg == null ? NOT_CONFIGURED : tlsSummary(cfg.getSslConfiguration()),
+                cfg == null ? NOT_CONFIGURED : connectionPool(cfg.getConnectionPoolConfiguration())
+            );
+        }
+
+        private static String proxyCredentials(HttpClientConfiguration cfg) {
+            if (cfg.getProxyUsername().isPresent() || cfg.getProxyPassword().isPresent()) {
+                return MASKED;
+            }
+            return NOT_CONFIGURED;
+        }
+
+        private DiscoveryInfo discoveryInfo(TargetInfo target, boolean discoveryAvailable, List<ServiceInstanceList> serviceInstanceLists) {
+            if (!Objects.equals(target.kind(), "Service ID")) {
+                return new DiscoveryInfo(false, "Fixed or local targets do not use service discovery.", List.of());
+            }
+            if (!discoveryAvailable && serviceInstanceLists.isEmpty()) {
+                return new DiscoveryInfo(false, "No discovery client or service instance list is available in this application context.", List.of());
+            }
+            Optional<ServiceInstanceList> matchingList = serviceInstanceLists.stream()
+                .filter(list -> Objects.equals(list.getID(), id) || Objects.equals(list.getID(), target.value()))
+                .findFirst();
+            if (matchingList.isEmpty()) {
+                return new DiscoveryInfo(false, "No application-visible service instances were reported for this service id.", List.of());
+            }
+            List<ServiceInstanceInfo> instances = matchingList.get().getInstances().stream()
+                .map(ClientBuilder::toServiceInstanceInfo)
+                .sorted(Comparator.comparing(ServiceInstanceInfo::uri))
+                .toList();
+            if (instances.isEmpty()) {
+                return new DiscoveryInfo(false, "A service instance list exists, but it currently reports no instances.", List.of());
+            }
+            return new DiscoveryInfo(true, "Instances are read from Micronaut service-instance lists visible to this application.", instances);
+        }
+
+        private static ServiceInstanceInfo toServiceInstanceInfo(ServiceInstance instance) {
+            return new ServiceInstanceInfo(
+                optionalString(instance.getInstanceId()).equals(NOT_CONFIGURED) ? instance.getId() : optionalString(instance.getInstanceId()),
+                sanitizeTarget(instance.getURI().toString()),
+                String.valueOf(instance.getHealthStatus()),
+                optionalString(instance.getZone()),
+                optionalString(instance.getRegion())
+            );
+        }
+    }
+}

--- a/control-panel-http-client/src/main/resources/micronaut-control-panel/micronaut-control-panel.properties
+++ b/control-panel-http-client/src/main/resources/micronaut-control-panel/micronaut-control-panel.properties
@@ -1,0 +1,4 @@
+micronaut.control-panel.panels.http-client.enabled = true
+micronaut.control-panel.panels.http-client.icon = fas fa-network-wired
+micronaut.control-panel.panels.http-client.order = 80
+micronaut.control-panel.panels.http-client.title = HTTP Clients

--- a/control-panel-http-client/src/main/resources/views/http-client/body.hbs
+++ b/control-panel-http-client/src/main/resources/views/http-client/body.hbs
@@ -1,0 +1,36 @@
+<div class="cp-data-table">
+    <div class="cp-data-table-container">
+        <table class="table cp-data-table-table">
+            <thead>
+                <tr>
+                    <th scope="col">Client</th>
+                    <th scope="col">Target</th>
+                    <th scope="col">Source</th>
+                    <th scope="col">Discovery</th>
+                </tr>
+            </thead>
+            <tbody>
+            {{#if body.diagnostics.hasClients}}
+                {{#each body.diagnostics.clients as |client|}}
+                    <tr tabindex="0">
+                        <td data-label="Client"><code class="cp-table-code">{{client.id}}</code></td>
+                        <td data-label="Target"><span class="badge {{client.target.badgeClass}}">{{client.target.kind}}</span> {{client.target.value}}</td>
+                        <td data-label="Source">{{client.source}}</td>
+                        <td data-label="Discovery">
+                            {{#if client.discovery.available}}
+                                <span class="badge badge-success">{{client.discovery.instances.size}} instances</span>
+                            {{else}}
+                                <span class="badge badge-secondary">Unavailable</span>
+                            {{/if}}
+                        </td>
+                    </tr>
+                {{/each}}
+            {{else}}
+                <tr>
+                    <td colspan="4">No Micronaut HTTP clients are visible in this application context.</td>
+                </tr>
+            {{/if}}
+            </tbody>
+        </table>
+    </div>
+</div>

--- a/control-panel-http-client/src/main/resources/views/http-client/detail.hbs
+++ b/control-panel-http-client/src/main/resources/views/http-client/detail.hbs
@@ -1,0 +1,126 @@
+<section aria-labelledby="http-client-summary-heading">
+    <div class="cp-data-table">
+        <div class="cp-data-table-container">
+            <table class="table cp-data-table-table">
+                <thead>
+                    <tr>
+                        <th scope="col">Client</th>
+                        <th scope="col">Java type</th>
+                        <th scope="col">Target</th>
+                        <th scope="col">Path</th>
+                    </tr>
+                </thead>
+                <tbody>
+                {{#if body.diagnostics.hasClients}}
+                    {{#each body.diagnostics.clients as |client|}}
+                        <tr tabindex="0">
+                            <td data-label="Client"><code class="cp-table-code">{{client.id}}</code></td>
+                            <td data-label="Java type"><code class="cp-table-code">{{abbreviate client.beanType 70}}</code></td>
+                            <td data-label="Target"><span class="badge {{client.target.badgeClass}}">{{client.target.kind}}</span> {{client.target.value}}</td>
+                            <td data-label="Path"><code class="cp-table-code">{{client.configuration.path}}</code></td>
+                        </tr>
+                    {{/each}}
+                {{else}}
+                    <tr>
+                        <td colspan="4">No Micronaut HTTP clients are visible in this application context.</td>
+                    </tr>
+                {{/if}}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</section>
+
+{{#each body.diagnostics.clients as |client|}}
+<section aria-labelledby="http-client-{{client.id}}-heading">
+    <div class="cp-section-header">
+        <div>
+            <h5 id="http-client-{{client.id}}-heading">{{client.id}}</h5>
+            <p>Source: {{client.source}}. This panel is read-only and does not send test requests.</p>
+        </div>
+        <span class="badge {{client.target.badgeClass}}">{{client.target.kind}}</span>
+    </div>
+
+    <div class="cp-data-table">
+        <div class="cp-data-table-container">
+            <table class="table cp-data-table-table">
+                <tbody>
+                    <tr><th scope="row">Target</th><td>{{client.target.value}}</td></tr>
+                    <tr><th scope="row">Connect timeout</th><td>{{client.configuration.connectTimeout}}</td></tr>
+                    <tr><th scope="row">Read timeout</th><td>{{client.configuration.readTimeout}}</td></tr>
+                    <tr><th scope="row">Request timeout</th><td>{{client.configuration.requestTimeout}}</td></tr>
+                    <tr><th scope="row">Redirects</th><td>follow={{client.configuration.followRedirects}}, max={{client.configuration.maxRedirects}}</td></tr>
+                    <tr><th scope="row">HTTP version</th><td>{{client.configuration.httpVersion}}</td></tr>
+                    <tr><th scope="row">Plaintext mode</th><td>{{client.configuration.plaintextMode}}</td></tr>
+                    <tr><th scope="row">ALPN modes</th><td>{{client.configuration.alpnModes}}</td></tr>
+                    <tr><th scope="row">Proxy</th><td>{{client.configuration.proxy}}; credentials={{client.configuration.proxyCredentials}}</td></tr>
+                    <tr><th scope="row">TLS</th><td>{{client.configuration.tls}}</td></tr>
+                    <tr><th scope="row">Connection pool</th><td>{{client.configuration.connectionPool}}</td></tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <h6>Discovery / instances</h6>
+    {{#if client.discovery.available}}
+        <div class="cp-data-table">
+            <div class="cp-data-table-container">
+                <table class="table cp-data-table-table">
+                    <thead>
+                        <tr>
+                            <th scope="col">Instance</th>
+                            <th scope="col">URI</th>
+                            <th scope="col">Status</th>
+                            <th scope="col">Zone</th>
+                            <th scope="col">Region</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                    {{#each client.discovery.instances as |instance|}}
+                        <tr tabindex="0">
+                            <td data-label="Instance"><code class="cp-table-code">{{instance.id}}</code></td>
+                            <td data-label="URI"><code class="cp-table-code">{{instance.uri}}</code></td>
+                            <td data-label="Status">{{instance.status}}</td>
+                            <td data-label="Zone">{{instance.zone}}</td>
+                            <td data-label="Region">{{instance.region}}</td>
+                        </tr>
+                    {{/each}}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    {{else}}
+        <p>{{client.discovery.message}}</p>
+    {{/if}}
+
+    <h6>Outbound filters</h6>
+    {{#if client.hasFilters}}
+        <div class="cp-data-table">
+            <div class="cp-data-table-container">
+                <table class="table cp-data-table-table">
+                    <thead>
+                        <tr>
+                            <th scope="col">Filter type</th>
+                            <th scope="col">Order</th>
+                            <th scope="col">Patterns</th>
+                            <th scope="col">Methods</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                    {{#each client.filters as |filter|}}
+                        <tr tabindex="0">
+                            <td data-label="Filter type"><code class="cp-table-code">{{abbreviate filter.type 80}}</code></td>
+                            <td data-label="Order">{{filter.order}}</td>
+                            <td data-label="Patterns">{{filter.patterns}}</td>
+                            <td data-label="Methods">{{filter.methods}}</td>
+                        </tr>
+                    {{/each}}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    {{else}}
+        <p>No matching outbound filters were reported for this client.</p>
+    {{/if}}
+</section>
+{{/each}}

--- a/control-panel-http-client/src/test/java/io/micronaut/controlpanel/panels/httpclient/HttpClientDiagnosticsControlPanelTest.java
+++ b/control-panel-http-client/src/test/java/io/micronaut/controlpanel/panels/httpclient/HttpClientDiagnosticsControlPanelTest.java
@@ -55,7 +55,12 @@ final class HttpClientDiagnosticsControlPanelTest {
             entry("micronaut.http.services.orders.proxy-username", "proxy-user"),
             entry("micronaut.http.services.orders.proxy-password", "proxy-secret"),
             entry("micronaut.http.services.orders.ssl.enabled", true),
-            entry("micronaut.http.services.orders.ssl.key-store.password", "changeit")
+            entry("micronaut.http.services.orders.ssl.key-store.password", "changeit"),
+            entry("micronaut.http.services.shipping.path", "/shipments"),
+            entry("micronaut.http.services.shipping.follow-redirects", false),
+            entry("micronaut.http.services.shipping.http-version", "HTTP_2_0"),
+            entry("micronaut.http.services.shipping.alpn-modes", List.of("h2", "http/1.1")),
+            entry("micronaut.http.services.shipping.pool.enabled", false)
         ))) {
             HttpClientDiagnostics diagnostics = context.getBean(HttpClientDiagnosticsService.class).collect();
 
@@ -80,6 +85,14 @@ final class HttpClientDiagnosticsControlPanelTest {
             assertEquals("https://inventory.example.test/api?Masked#Masked", inventory.discovery().instances().getFirst().uri());
             assertFalse(inventory.discovery().instances().getFirst().uri().contains("instance-secret"));
             assertFalse(inventory.discovery().instances().getFirst().uri().contains("fragment-secret"));
+
+            HttpClientDiagnostics.HttpClientInfo shipping = find(diagnostics, "shipping");
+            assertEquals("Service ID", shipping.target().kind());
+            assertEquals("/shipments", shipping.configuration().path());
+            assertEquals("false", shipping.configuration().followRedirects());
+            assertEquals("HTTP_2_0", shipping.configuration().httpVersion());
+            assertEquals("h2, http/1.1", shipping.configuration().alpnModes());
+            assertTrue(shipping.configuration().connectionPool().contains("enabled=false"));
         }
     }
 
@@ -91,6 +104,36 @@ final class HttpClientDiagnosticsControlPanelTest {
             assertEquals("Service ID", payments.target().kind());
             assertFalse(payments.discovery().available());
             assertTrue(payments.discovery().message().contains("No application-visible service instances"));
+        }
+    }
+
+    @Test
+    void rendersUnavailableDiscoveryStateWhenDiscoveryBeansAreAbsent() {
+        try (ApplicationContext context = ApplicationContext.run(Map.of("disable.inventory.instances", true))) {
+            HttpClientDiagnostics.HttpClientInfo payments = find(context.getBean(HttpClientDiagnosticsService.class).collect(), "payments");
+
+            assertEquals("Service ID", payments.target().kind());
+            assertFalse(payments.discovery().available());
+            assertTrue(payments.discovery().message().contains("No application-visible service instances"));
+        }
+    }
+
+    @Test
+    void rendersLocalAndInvalidFixedTargetsSafely() {
+        try (ApplicationContext context = ApplicationContext.run()) {
+            HttpClientDiagnostics diagnostics = context.getBean(HttpClientDiagnosticsService.class).collect();
+
+            HttpClientDiagnostics.HttpClientInfo local = find(diagnostics, "/");
+            assertEquals("Local", local.target().kind());
+            assertEquals("/", local.target().value());
+            assertFalse(local.discovery().available());
+
+            HttpClientDiagnostics.HttpClientInfo invalid = find(diagnostics, "https://user:secret@@example.com/path?api-key=secret#token");
+            assertEquals("Fixed URL", invalid.target().kind());
+            assertTrue(invalid.target().value().contains("Masked"));
+            assertFalse(invalid.target().value().contains("user:secret"));
+            assertFalse(invalid.target().value().contains("api-key=secret"));
+            assertFalse(invalid.target().value().contains("token"));
         }
     }
 
@@ -128,6 +171,14 @@ final class HttpClientDiagnosticsControlPanelTest {
 
     @Client("payments")
     interface PaymentsClient {
+    }
+
+    @Client("/")
+    interface LocalClient {
+    }
+
+    @Client("https://user:secret@@example.com/path?api-key=secret#token")
+    interface InvalidFixedUrlClient {
     }
 
     @Factory

--- a/control-panel-http-client/src/test/java/io/micronaut/controlpanel/panels/httpclient/HttpClientDiagnosticsControlPanelTest.java
+++ b/control-panel-http-client/src/test/java/io/micronaut/controlpanel/panels/httpclient/HttpClientDiagnosticsControlPanelTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.httpclient;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.discovery.ServiceInstanceList;
+import io.micronaut.discovery.StaticServiceInstanceList;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.MutableHttpRequest;
+import io.micronaut.http.annotation.Filter;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.http.filter.ClientFilterChain;
+import io.micronaut.http.filter.HttpClientFilter;
+import jakarta.inject.Singleton;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Publisher;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static java.util.Map.entry;
+
+final class HttpClientDiagnosticsControlPanelTest {
+
+    @Test
+    void collectsFixedUrlAndServiceIdClientsWithSafeConfiguration() {
+        try (ApplicationContext context = ApplicationContext.run(Map.ofEntries(
+            entry("micronaut.http.services.orders.url", "https://user:secret@example.com:8443/api?api_key=dev-secret#access-token"),
+            entry("micronaut.http.services.orders.path", "/v1"),
+            entry("micronaut.http.services.orders.connect-timeout", "2s"),
+            entry("micronaut.http.services.orders.read-timeout", "3s"),
+            entry("micronaut.http.services.orders.request-timeout", "4s"),
+            entry("micronaut.http.services.orders.proxy-type", "HTTP"),
+            entry("micronaut.http.services.orders.proxy-address", "localhost:8080"),
+            entry("micronaut.http.services.orders.proxy-username", "proxy-user"),
+            entry("micronaut.http.services.orders.proxy-password", "proxy-secret"),
+            entry("micronaut.http.services.orders.ssl.enabled", true),
+            entry("micronaut.http.services.orders.ssl.key-store.password", "changeit")
+        ))) {
+            HttpClientDiagnostics diagnostics = context.getBean(HttpClientDiagnosticsService.class).collect();
+
+            HttpClientDiagnostics.HttpClientInfo orders = find(diagnostics, "orders");
+            assertEquals("Fixed URL", orders.target().kind());
+            assertFalse(orders.target().value().contains("user:secret"));
+            assertFalse(orders.target().value().contains("dev-secret"));
+            assertFalse(orders.target().value().contains("access-token"));
+            assertTrue(orders.target().value().contains("Masked"));
+            assertEquals("/v1", orders.configuration().path());
+            assertEquals("PT2S", orders.configuration().connectTimeout());
+            assertEquals("PT3S", orders.configuration().readTimeout());
+            assertEquals("PT4S", orders.configuration().requestTimeout());
+            assertEquals("Masked", orders.configuration().proxyCredentials());
+            assertTrue(orders.configuration().tls().contains("key/trust material=masked"));
+            assertTrue(orders.hasFilters());
+
+            HttpClientDiagnostics.HttpClientInfo inventory = find(diagnostics, "inventory");
+            assertEquals("Service ID", inventory.target().kind());
+            assertTrue(inventory.discovery().available());
+            assertEquals(1, inventory.discovery().instances().size());
+            assertEquals("https://inventory.example.test/api?Masked#Masked", inventory.discovery().instances().getFirst().uri());
+            assertFalse(inventory.discovery().instances().getFirst().uri().contains("instance-secret"));
+            assertFalse(inventory.discovery().instances().getFirst().uri().contains("fragment-secret"));
+        }
+    }
+
+    @Test
+    void rendersUnavailableDiscoveryStateWhenNoInstancesAreVisible() {
+        try (ApplicationContext context = ApplicationContext.run()) {
+            HttpClientDiagnostics.HttpClientInfo payments = find(context.getBean(HttpClientDiagnosticsService.class).collect(), "payments");
+
+            assertEquals("Service ID", payments.target().kind());
+            assertFalse(payments.discovery().available());
+            assertTrue(payments.discovery().message().contains("No application-visible service instances"));
+        }
+    }
+
+    @Test
+    void panelCanBeDisabled() {
+        try (ApplicationContext context = ApplicationContext.run(Map.of(HttpClientDiagnosticsControlPanel.ENABLED_PROPERTY, false))) {
+            assertFalse(context.containsBean(HttpClientDiagnosticsControlPanel.class));
+        }
+    }
+
+    @Test
+    void panelBodyExposesCollectedDiagnostics() {
+        try (ApplicationContext context = ApplicationContext.run()) {
+            HttpClientDiagnosticsControlPanel panel = context.getBean(HttpClientDiagnosticsControlPanel.class);
+
+            assertNotNull(panel.getBody().diagnostics());
+            assertTrue(Integer.parseInt(panel.getBadge()) >= 2);
+        }
+    }
+
+    private static HttpClientDiagnostics.HttpClientInfo find(HttpClientDiagnostics diagnostics, String id) {
+        return diagnostics.clients().stream()
+            .filter(client -> id.equals(client.id()))
+            .findFirst()
+            .orElseThrow();
+    }
+
+    @Client("orders")
+    interface OrdersClient {
+    }
+
+    @Client("inventory")
+    interface InventoryClient {
+    }
+
+    @Client("payments")
+    interface PaymentsClient {
+    }
+
+    @Factory
+    static class TestDiscoveryFactory {
+        @Singleton
+        @Requires(missingProperty = "disable.inventory.instances")
+        ServiceInstanceList inventoryInstances() {
+            return new StaticServiceInstanceList("inventory", List.of(URI.create("https://inventory.example.test/api?token=instance-secret#fragment-secret")));
+        }
+    }
+
+    @Filter(serviceId = "orders")
+    static class OrdersFilter implements HttpClientFilter {
+        @Override
+        public Publisher<? extends HttpResponse<?>> doFilter(MutableHttpRequest<?> request, ClientFilterChain chain) {
+            return chain.proceed(request);
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,6 +20,7 @@ include("control-panel-object-storage")
 include("control-panel-cache")
 include("control-panel-datasource")
 include("control-panel-hibernate")
+include("control-panel-http-client")
 include("control-panel-ui")
 include("control-panel-kafka")
 

--- a/src/main/docs/guide/controlPanels/httpClient.adoc
+++ b/src/main/docs/guide/controlPanels/httpClient.adoc
@@ -1,0 +1,67 @@
+= HTTP Client Control Panel
+
+The HTTP Client control panel shows read-only diagnostics for Micronaut HTTP clients that are visible in the running application context.
+
+Add the module as a development-time dependency:
+
+dependency:io.micronaut.controlpanel:micronaut-control-panel-http-client[scope=developmentOnly]
+
+== Enabling and disabling
+
+The panel is enabled when the module and Micronaut HTTP client support are present. You can disable it with:
+
+[configuration]
+----
+micronaut:
+  control-panel:
+    panels:
+      http-client:
+        enabled: false
+----
+
+Disabling the panel prevents the HTTP client diagnostics control panel bean from being registered.
+
+== What the panel shows
+
+The first version is read-only. It does not send test requests, replay traffic, capture request or response bodies, or mutate configuration.
+
+For each detected client, the panel shows safe metadata such as:
+
+* declarative `@Client` interfaces and named HTTP client configuration entries;
+* the client id or bean name and Java type when available;
+* whether the target is a fixed URL, local target, service id, or unknown;
+* configured path, connect/read/request timeouts, redirect policy, HTTP version, ALPN/plaintext mode, proxy summary, TLS mode summary, and connection-pool summary where those values are available;
+* service instances from Micronaut `ServiceInstanceList` beans visible to the application, or an unavailable-state message when discovery/instances are not visible;
+* outbound filter metadata such as filter type, order, methods, and patterns when Micronaut can resolve it safely.
+
+Fixed URL clients show the configured URL with embedded user-info masked and query string or fragment values replaced with `Masked`. Service-id clients show discovery state only from Micronaut abstractions available inside the application; discovered instance URIs receive the same user-info, query, and fragment masking before display. The panel does not query external registries through a privileged side channel.
+
+== Masking and limitations
+
+The panel uses a safe-field approach. Values that commonly contain credentials or sensitive material are masked or omitted, including:
+
+* embedded URL credentials;
+* fixed URL and discovered service-instance URI query strings and fragments;
+* proxy usernames and passwords;
+* TLS key, key-store, trust-store, certificate, and password material;
+* authorization, cookie, token, and header values;
+* request bodies, response bodies, and captured traffic.
+
+If a value is not clearly safe to display, the panel renders a masked or unavailable summary instead of the raw value. Discovery details can also be unavailable when the application has no discovery client, no service instance list for a service id, or a discovery implementation hides instance details.
+
+== Verification
+
+A development application can verify the panel by adding both the Control Panel UI and HTTP Client module, then declaring a fixed-url or service-id client:
+
+[configuration]
+----
+micronaut:
+  http:
+    services:
+      orders:
+        url: https://orders.example.test
+      inventory:
+        path: /api
+----
+
+Open the Control Panel and select the HTTP Clients panel. The fixed URL client should render as a fixed target. A service-id client renders service-instance rows only when the application exposes matching Micronaut service-instance information; otherwise it renders an explanatory unavailable state.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -9,6 +9,7 @@ controlPanels:
   objectStorage: Object Storage
   datasource: Datasource
   hibernate: Hibernate
+  httpClient: HTTP Client
   kafka: Kafka
 
 custom: Creating Custom Control Panels


### PR DESCRIPTION
## Summary
- Adds a new optional `micronaut-control-panel-http-client` module for read-only outbound HTTP client diagnostics.
- Lists declarative/named clients, fixed URL vs service-id targets, safe configuration summaries, visible service instances, and outbound filter metadata.
- Documents enablement, disablement, read-only behavior, discovery limitations, and masking boundaries.

## Review notes
- Target branch/release line: `2.1.x` / next minor Control Panel release.
- Type label: `type: enhancement`.
- Paperclip issue linkage: DEV-1251.
- Closing keyword: Fixes DEV-1251.
- Micronaut organization project guidance: `5.2.0 Release`; upstream noted ambiguity that maintainers may revise if an earlier `2.1.x` consumption vehicle is chosen.
- No linked GitHub issue exists for this Paperclip-originated work, so there is no GitHub issue creator to request as a reviewer.
- PR-visible assets: no screenshot asset was captured upstream; the change is server-rendered templates plus docs and is covered by module tests. If maintainers want a live browser screenshot, the follow-up owner should add the module to an example app and capture it before merge.

## Test plan
- `JAVA_HOME=/opt/sdkman/candidates/java/current ./gradlew :micronaut-control-panel-http-client:check --rerun-tasks`
- `git diff --check`

---
###### ✨ This message was AI-generated using gpt-5.5
