### PR TITLE
Guard cache control panels against absent cache implementations

### DIFF
--- a/control-panel-cache/build.gradle.kts
+++ b/control-panel-cache/build.gradle.kts
@@ -40,3 +40,25 @@ dependencies {
 tasks.named("internalStartTestResourcesService") {
     setProperty("useClassDataSharing", false)
 }
+
+// Verifies that the context starts cleanly when Ehcache is absent from the classpath.
+// The standard test task has all cache implementations on the classpath; this task strips
+// Ehcache JARs to reproduce the NoClassDefFoundError that occurs without the
+// @Requires(classes = EhcacheSyncCache.class) guard on EhcacheControlPanel.
+val testWithoutEhcache by tasks.registering(Test::class) {
+    description = "Verifies the control panel repository is queryable when Ehcache is absent from the classpath"
+    group = "verification"
+    classpath = configurations.named("testRuntimeClasspath").get()
+        .filter { !it.name.contains("ehcache") }
+        .plus(sourceSets.main.get().output)
+        .plus(sourceSets.test.get().output)
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    filter {
+        includeTestsMatching("io.micronaut.controlpanel.panels.cache.EhcacheAbsentFromClasspathTest")
+    }
+}
+
+tasks.named("check") {
+    dependsOn(testWithoutEhcache)
+}
+

--- a/control-panel-cache/src/main/java/io/micronaut/controlpanel/panels/cache/CaffeineCacheControlPanel.java
+++ b/control-panel-cache/src/main/java/io/micronaut/controlpanel/panels/cache/CaffeineCacheControlPanel.java
@@ -18,6 +18,7 @@ package io.micronaut.controlpanel.panels.cache;
 import io.micronaut.cache.caffeine.DefaultSyncCache;
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Parameter;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.controlpanel.core.config.ControlPanelConfiguration;
 import jakarta.inject.Named;
 
@@ -31,6 +32,7 @@ import java.util.Optional;
  * @author Álvaro Sánchez-Mariscal
  * @since 2.0.0
  */
+@Requires(classes = DefaultSyncCache.class)
 @EachBean(DefaultSyncCache.class)
 public class CaffeineCacheControlPanel extends AbstractCacheControlPanel<DefaultSyncCache> {
 

--- a/control-panel-cache/src/main/java/io/micronaut/controlpanel/panels/cache/EhcacheControlPanel.java
+++ b/control-panel-cache/src/main/java/io/micronaut/controlpanel/panels/cache/EhcacheControlPanel.java
@@ -18,6 +18,7 @@ package io.micronaut.controlpanel.panels.cache;
 import io.micronaut.cache.ehcache.EhcacheSyncCache;
 import io.micronaut.context.annotation.EachBean;
 import io.micronaut.context.annotation.Parameter;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.controlpanel.core.config.ControlPanelConfiguration;
 import jakarta.inject.Named;
 import org.ehcache.Cache;
@@ -33,6 +34,7 @@ import java.util.stream.StreamSupport;
  * @author Álvaro Sánchez-Mariscal
  * @since 2.0.0
  */
+@Requires(classes = EhcacheSyncCache.class)
 @EachBean(EhcacheSyncCache.class)
 public class EhcacheControlPanel extends AbstractCacheControlPanel<EhcacheSyncCache> {
 

--- a/control-panel-cache/src/test/java/io/micronaut/controlpanel/panels/cache/EhcacheAbsentFromClasspathTest.java
+++ b/control-panel-cache/src/test/java/io/micronaut/controlpanel/panels/cache/EhcacheAbsentFromClasspathTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.cache;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.controlpanel.core.ControlPanelRepository;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that the control panel repository is queryable when Ehcache is absent from the
+ * runtime classpath.
+ *
+ * <p>Without {@code @Requires(classes = EhcacheSyncCache.class)} on {@link EhcacheControlPanel},
+ * Micronaut's service loader fails with {@code NoClassDefFoundError} for {@code EhcacheSyncCache}
+ * while loading the generated bean definition. This surfaces as a {@code BeanInstantiationException}
+ * when {@link ControlPanelRepository} first calls {@code getBeansOfType(ControlPanel.class)}.
+ *
+ * <p>This test is run by the {@code testWithoutEhcache} Gradle task, which strips Ehcache JARs
+ * from the test classpath.
+ */
+@MicronautTest
+@Property(name = "micronaut.caches.mycache.initialCapacity", value = "1")
+class EhcacheAbsentFromClasspathTest {
+
+    @Test
+    void controlPanelRepositoryIsQueryableWithoutEhcache(ControlPanelRepository repository) {
+        // Triggers getBeansOfType(ControlPanel.class), the code path that loads
+        // $EhcacheControlPanel$Definition. Without @Requires(classes = EhcacheSyncCache.class),
+        // this throws BeanInstantiationException wrapping NoClassDefFoundError.
+        assertTrue(
+            repository.findByName("cache-mycache").isPresent(),
+            "Caffeine cache panel must be registered even when Ehcache is absent from the classpath"
+        );
+    }
+}


### PR DESCRIPTION
Fixes #628.

`EhcacheControlPanel` and `CaffeineCacheControlPanel` both use `@EachBean(SomeClass.class)` where `SomeClass` is a `compileOnly` dependency. `@EachBean` prevents instantiation when no matching beans exist, but the service loader still loads the generated `$*Definition` class — whose static initializer directly references `SomeClass`. When the implementation JAR is absent, this produces a `NoClassDefFoundError` wrapped in `BeanInstantiationException`, breaking the entire control panel.

Adding `@Requires(classes = SomeClass.class)` causes the bean definition to be skipped before loading when the class is absent.

**Commits:**

The first commit adds a regression test and a `testWithoutEhcache` Gradle task that strips Ehcache JARs from the test classpath to reproduce the failure. The primary purpose of this commit is to demonstrate the problem; if the custom test task doesn't fit the project's conventions, it can be dropped or reworked before merge — the fix in the second commit stands on its own.