### PR TITLE
Allow hiding individual datasources from control panel

### DIFF
--- a/control-panel-datasource/src/main/java/io/micronaut/controlpanel/panels/datasource/DataSourceControlPanel.java
+++ b/control-panel-datasource/src/main/java/io/micronaut/controlpanel/panels/datasource/DataSourceControlPanel.java
@@ -25,6 +25,7 @@ import io.micronaut.controlpanel.panels.datasource.model.DataSourceInfo;
 import io.micronaut.controlpanel.panels.datasource.model.DatabaseType;
 import io.micronaut.controlpanel.panels.datasource.model.Table;
 import jakarta.inject.Named;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,12 +42,14 @@ public class DataSourceControlPanel extends AbstractEachBeanControlPanel<Body> {
 
     public static final String NAME = "datasource";
     public static final String DEFAULT_ICON_CLASS = "fas fa-database";
+    public static final String DATASOURCE_ENABLED_PROPERTY = "datasources.%s.control-panel.enabled";
     private static final Logger LOG = LoggerFactory.getLogger(DataSourceControlPanel.class);
 
     private final String beanName;
     private final List<Table> tables;
     private final Body body;
     private final DataSourceInfo dataSourceInfo;
+    private final boolean enabled;
 
     public DataSourceControlPanel(@Parameter String beanName,
                                   @Parameter DataSourceService dataSourceService,
@@ -57,26 +60,36 @@ public class DataSourceControlPanel extends AbstractEachBeanControlPanel<Body> {
         if (LOG.isDebugEnabled()) {
             LOG.debug("Initializing DataSourceControlPanel for bean='{}'", beanName);
         }
-        this.tables = dataSourceService.getTables();
-        this.dataSourceInfo = createDataSourceInfo(environment, beanName, dataSourceService);
-        this.body = new Body(dataSourceInfo, tables, dataSourceService.generateMermaidER(tables), dataSourceService.getPoolInfo().orElse(null));
+        this.enabled = isDataSourceControlPanelEnabled(environment, beanName);
+        this.dataSourceInfo = createDataSourceInfo(environment, beanName, enabled ? dataSourceService : null);
+        this.tables = enabled ? dataSourceService.getTables() : List.of();
+        this.body = enabled
+            ? new Body(dataSourceInfo, tables, dataSourceService.generateMermaidER(tables), dataSourceService.getPoolInfo().orElse(null))
+            : new Body(dataSourceInfo, tables, EMPTY_STRING, null);
         if (LOG.isDebugEnabled()) {
             LOG.debug("DataSourceControlPanel initialized: bean='{}', tables={}, dbType={} URL='{}' user='{}'", beanName, tables.size(), dataSourceInfo.type(), safeUrl(dataSourceInfo.jdbcUrl()), safeUser(dataSourceInfo.username()));
         }
     }
 
-    private DataSourceInfo createDataSourceInfo(Environment env, String beanName, DataSourceService dataSourceService) {
+    private static boolean isDataSourceControlPanelEnabled(Environment env, String beanName) {
+        Boolean enabled = env.getProperty(DATASOURCE_ENABLED_PROPERTY.formatted(beanName), Boolean.class, Boolean.TRUE);
+        return enabled == null || enabled;
+    }
+
+    private DataSourceInfo createDataSourceInfo(Environment env, String beanName, @Nullable DataSourceService dataSourceService) {
         var jdbUrl = env.getProperty("datasources.%s.url".formatted(beanName), String.class, "");
         var username = env.getProperty("datasources.%s.username".formatted(beanName), String.class, "");
         var password = env.getProperty("datasources.%s.password".formatted(beanName), String.class, "");
         var dialect = env.getProperty("datasources.%s.dialect".formatted(beanName), String.class, "");
         var dbType = env.getProperty("datasources.%s.db-type".formatted(beanName), String.class, "");
-        var jdbcInfo = dataSourceService.getJdbcInfo();
 
         if (LOG.isDebugEnabled()) {
             LOG.debug("Resolved datasource props for bean='{}': url='{}', user='{}', dialect='{}', dbType='{}'", beanName, safeUrl(jdbUrl), safeUser(username), dialect, dbType);
         }
-        return new DataSourceInfo(beanName, jdbUrl, username, password, DatabaseType.of(dialect, dbType), jdbcInfo);
+        if (dataSourceService == null) {
+            return new DataSourceInfo(beanName, jdbUrl, username, password, DatabaseType.of(dialect, dbType));
+        }
+        return new DataSourceInfo(beanName, jdbUrl, username, password, DatabaseType.of(dialect, dbType), dataSourceService.getJdbcInfo());
     }
 
     @Override
@@ -100,6 +113,11 @@ public class DataSourceControlPanel extends AbstractEachBeanControlPanel<Body> {
     @Override
     public String getBadge() {
         return EMPTY_STRING;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return enabled && super.isEnabled();
     }
 
     @Override

--- a/control-panel-datasource/src/main/java/io/micronaut/controlpanel/panels/datasource/DataSourceController.java
+++ b/control-panel-datasource/src/main/java/io/micronaut/controlpanel/panels/datasource/DataSourceController.java
@@ -52,6 +52,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * REST controller to execute SQL queries against a specific DataSource for the Control Panel.
@@ -84,7 +85,11 @@ public final class DataSourceController {
     public DataSourceController(BeanLocator locator, JsonMapper jsonMapper) {
         // Map keyed by bean name (datasource name)
         this.services = locator.mapOfType(SERVICE_ARGUMENT);
-        this.panels = locator.mapOfType(PANEL_ARGUMENT);
+        this.panels = locator.mapOfType(PANEL_ARGUMENT)
+            .entrySet()
+            .stream()
+            .filter(entry -> entry.getValue().isEnabled())
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (existing, replacement) -> existing, LinkedHashMap::new));
         this.schemas = computeSchemas();
         this.jsonMapper = jsonMapper;
         if (LOG.isDebugEnabled()) {
@@ -219,6 +224,12 @@ public final class DataSourceController {
      */
     @Get(value = "/{dataSource}/pool/status", produces = MediaType.TEXT_HTML)
     public HttpResponse<Object> poolStatus(String dataSource) {
+        if (!panels.containsKey(dataSource)) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(NO_CONTROL_PANEL_LOG_MESSAGE, dataSource);
+            }
+            return HttpResponse.notFound();
+        }
         var service = services.get(dataSource);
         if (service == null) {
             if (LOG.isDebugEnabled()) {
@@ -247,7 +258,7 @@ public final class DataSourceController {
             LOG.debug("query requested for dataSource='{}' (start={}, length={}, draw={}) sql='{}'", dataSource, body.start(), body.length(), body.draw(), body.sql());
         }
         var service = services.get(dataSource);
-        if (service == null) {
+        if (service == null || !panels.containsKey(dataSource)) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("No service found for dataSource='{}'", dataSource);
             }

--- a/control-panel-datasource/src/test/java/io/micronaut/controlpanel/panels/datasource/DataSourceControlPanelTest.java
+++ b/control-panel-datasource/src/test/java/io/micronaut/controlpanel/panels/datasource/DataSourceControlPanelTest.java
@@ -23,6 +23,7 @@ import io.micronaut.controlpanel.panels.datasource.model.DataSourceInfo;
 import io.micronaut.controlpanel.panels.datasource.model.DatabaseType;
 import io.micronaut.controlpanel.panels.datasource.model.PoolInfo;
 import io.micronaut.controlpanel.panels.datasource.model.Table;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -51,6 +52,11 @@ class DataSourceControlPanelTest {
     private static final String BEAN_NAME = "testDataSource";
     private static final List<Table> EMPTY_TABLE_LIST = List.of();
     private static final String MERMAID_ER = "erDiagram\n  TABLE1 ||--o{ TABLE2 : \"has\"";
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(environment.getProperty(DataSourceControlPanel.DATASOURCE_ENABLED_PROPERTY.formatted(BEAN_NAME), Boolean.class, Boolean.TRUE)).thenReturn(true);
+    }
 
     @Test
     void constructorInitializesFieldsCorrectly() {
@@ -99,6 +105,25 @@ class DataSourceControlPanelTest {
         assertEquals(expectedUsername, info.username());
         assertEquals(expectedPassword, info.password());
         assertEquals(DatabaseType.POSTGRES, info.type());
+    }
+
+    @Test
+    void constructorDoesNotInspectDisabledDatasource() {
+        // Given
+        when(environment.getProperty(DataSourceControlPanel.DATASOURCE_ENABLED_PROPERTY.formatted(BEAN_NAME), Boolean.class, Boolean.TRUE)).thenReturn(false);
+        when(environment.getProperty(anyString(), eq(String.class), eq(""))).thenReturn("");
+
+        // When
+        DataSourceControlPanel panel = new DataSourceControlPanel(BEAN_NAME, dataSourceService, environment, configuration);
+
+        // Then
+        assertFalse(panel.isEnabled());
+        assertEquals(EMPTY_TABLE_LIST, panel.getBody().tables());
+        assertEquals("", panel.getBody().mermaidEr());
+        verify(dataSourceService, never()).getTables();
+        verify(dataSourceService, never()).getJdbcInfo();
+        verify(dataSourceService, never()).getPoolInfo();
+        verify(dataSourceService, never()).generateMermaidER(any());
     }
 
     @Test

--- a/control-panel-datasource/src/test/java/io/micronaut/controlpanel/panels/datasource/DataSourceControllerTest.java
+++ b/control-panel-datasource/src/test/java/io/micronaut/controlpanel/panels/datasource/DataSourceControllerTest.java
@@ -485,6 +485,25 @@ class DataSourceControllerTest {
     }
 
     @Test
+    void query_returnsNotFound_whenPanelDisabled() {
+        // Given
+        var service = mock(DataSourceService.class);
+        var panel = mock(DataSourceControlPanel.class);
+        doReturn(Map.of(DATA_SOURCE, service)).when(beanLocator).mapOfType(SERVICE_ARGUMENT);
+        doReturn(Map.of(DATA_SOURCE, panel)).when(beanLocator).mapOfType(PANEL_ARGUMENT);
+        when(panel.isEnabled()).thenReturn(false);
+
+        // When
+        DataSourceController controller = new DataSourceController(beanLocator, jsonMapper);
+        var request = new DataSourceController.QueryRequest("SELECT 1", 0, 10, 1);
+        HttpResponse<?> response = controller.query(DATA_SOURCE, request);
+
+        // Then
+        assertEquals(404, response.getStatus().getCode());
+        verifyNoInteractions(service);
+    }
+
+    @Test
     void query_returnsBadRequest_whenSqlEmpty() {
         // Given
         var service = mock(DataSourceService.class);
@@ -612,6 +631,7 @@ class DataSourceControllerTest {
         var dataSourceInfo = new DataSourceInfo("test", "", "", "", databaseType);
         var body = new Body(dataSourceInfo, tables, "");
         var panel = mock(DataSourceControlPanel.class);
+        when(panel.isEnabled()).thenReturn(true);
         when(panel.getBody()).thenReturn(body);
         when(panel.getBeanName()).thenReturn(DATA_SOURCE);
         doReturn(Map.of(DATA_SOURCE, panel)).when(beanLocator).mapOfType(PANEL_ARGUMENT);

--- a/src/main/docs/guide/controlPanels/datasource.adoc
+++ b/src/main/docs/guide/controlPanels/datasource.adoc
@@ -67,3 +67,14 @@ micronaut:
       datasource:
         enabled: false
 ----
+
+You can also hide one datasource while leaving the datasource control panel available for the rest of the application.
+This prevents the panel from connecting to that datasource for metadata, schema, pool, or query operations:
+
+[configuration]
+----
+datasources:
+  reporting:
+    control-panel:
+      enabled: false
+----


### PR DESCRIPTION
Disposable staging CodeGraph MCP pilot artifact for alvarosanchez/hermes-backup#20 follow-up.

This PR was produced by a corrected CodeGraph MCP pilot on **staging Paperclip** (`https://staging.cliponaut.micronaut.fun`) using the `hermes-agent@cliponaut.local` account path.

Pilot evidence from staging issue `DEV-1443`:
- CodeGraph PR #973 build installed in isolated staging path.
- `codegraph init .` indexed the Micronaut Control Panel repo: 224 files, 3,658 nodes, 6,953 edges.
- Hermes MCP server `codegraph` configured for this repository.
- Native MCP tool `codegraph_explore` was called before edits (run log has `2` occurrences).
- Staging run id: `60b01c78-c3d9-4039-b9d1-6e0f09ef1ce9`.

Implementation summary:
- Adds per-datasource opt-out via `datasources.<name>.control-panel.enabled=false`.
- Disabled datasource panels no longer inspect JDBC metadata/tables/pool info.
- Datasource helper routes return 404 for disabled datasources.
- Documents the new per-datasource config option.

Staging verification reported by the agent:
- `./gradlew :micronaut-control-panel-datasource:test --tests 'io.micronaut.controlpanel.panels.datasource.DataSourceControlPanelTest' --tests 'io.micronaut.controlpanel.panels.datasource.DataSourceControllerTest'`
- `./gradlew :micronaut-control-panel-datasource:test` — 61 tests passed.
- `git diff --check`

Not intended for merge without maintainer review; this is an evaluation artifact.

Fixes #598