### PR TITLE
Allow hiding individual datasource panels

### DIFF
--- a/control-panel-core/src/main/java/io/micronaut/controlpanel/core/DefaultControlPanelRepository.java
+++ b/control-panel-core/src/main/java/io/micronaut/controlpanel/core/DefaultControlPanelRepository.java
@@ -113,7 +113,8 @@ public class DefaultControlPanelRepository implements ControlPanelRepository {
         return Stream.concat(
             beanContext.getBeansOfType(ControlPanel.class).stream(),
             loadDynamicControlPanels().stream()
-        ).sorted(byOrderAndName);
+        ).filter(ControlPanel::isEnabled)
+            .sorted(byOrderAndName);
     }
 
     private Stream<ControlPanel.Category> getCategories() {

--- a/control-panel-core/src/test/java/io/micronaut/controlpanel/core/DefaultControlPanelRepositoryTest.java
+++ b/control-panel-core/src/test/java/io/micronaut/controlpanel/core/DefaultControlPanelRepositoryTest.java
@@ -80,6 +80,12 @@ class DefaultControlPanelRepositoryTest {
     }
 
     @Test
+    void itDoesNotFindDisabledControlPanels() {
+        ControlPanelRepository repository = ctx.getBean(ControlPanelRepository.class);
+        assertFalse(repository.findByName("disabled-test").isPresent());
+    }
+
+    @Test
     void itCanFindAllCategories() {
         ControlPanelRepository repository = ctx.getBean(ControlPanelRepository.class);
         var categories = repository.findAllCategories();
@@ -158,6 +164,39 @@ class DefaultControlPanelRepositoryTest {
         @Override
         public String getName() {
             return "test";
+        }
+    }
+
+    @Singleton
+    static class DisabledDummyControlPanel implements ControlPanel<String> {
+        @Override
+        public String getIcon() {
+            return ControlPanelConfiguration.DEFAULT_ICON;
+        }
+
+        @Override
+        public boolean isEnabled() {
+            return false;
+        }
+
+        @Override
+        public String getTitle() {
+            return "Disabled Test Control Panel";
+        }
+
+        @Override
+        public String getBody() {
+            return "Disabled Test Control Panel Body";
+        }
+
+        @Override
+        public Category getCategory() {
+            return new Category("application", "My Application", "fas fa-copy");
+        }
+
+        @Override
+        public String getName() {
+            return "disabled-test";
         }
     }
 }

--- a/control-panel-datasource/src/main/java/io/micronaut/controlpanel/panels/datasource/DataSourceControlPanel.java
+++ b/control-panel-datasource/src/main/java/io/micronaut/controlpanel/panels/datasource/DataSourceControlPanel.java
@@ -23,6 +23,7 @@ import io.micronaut.controlpanel.core.config.ControlPanelConfiguration;
 import io.micronaut.controlpanel.panels.datasource.model.Body;
 import io.micronaut.controlpanel.panels.datasource.model.DataSourceInfo;
 import io.micronaut.controlpanel.panels.datasource.model.DatabaseType;
+import io.micronaut.controlpanel.panels.datasource.model.JdbcInfo;
 import io.micronaut.controlpanel.panels.datasource.model.Table;
 import jakarta.inject.Named;
 import org.slf4j.Logger;
@@ -40,10 +41,12 @@ import static io.micronaut.core.util.StringUtils.EMPTY_STRING;
 public class DataSourceControlPanel extends AbstractEachBeanControlPanel<Body> {
 
     public static final String NAME = "datasource";
+    public static final String DATASOURCES_CONFIGURATION_PREFIX = ControlPanelConfiguration.PREFIX + "." + NAME + ".datasources";
     public static final String DEFAULT_ICON_CLASS = "fas fa-database";
     private static final Logger LOG = LoggerFactory.getLogger(DataSourceControlPanel.class);
 
     private final String beanName;
+    private final boolean dataSourceEnabled;
     private final List<Table> tables;
     private final Body body;
     private final DataSourceInfo dataSourceInfo;
@@ -57,12 +60,32 @@ public class DataSourceControlPanel extends AbstractEachBeanControlPanel<Body> {
         if (LOG.isDebugEnabled()) {
             LOG.debug("Initializing DataSourceControlPanel for bean='{}'", beanName);
         }
-        this.tables = dataSourceService.getTables();
-        this.dataSourceInfo = createDataSourceInfo(environment, beanName, dataSourceService);
-        this.body = new Body(dataSourceInfo, tables, dataSourceService.generateMermaidER(tables), dataSourceService.getPoolInfo().orElse(null));
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("DataSourceControlPanel initialized: bean='{}', tables={}, dbType={} URL='{}' user='{}'", beanName, tables.size(), dataSourceInfo.type(), safeUrl(dataSourceInfo.jdbcUrl()), safeUser(dataSourceInfo.username()));
+        this.dataSourceEnabled = isDataSourceEnabled(environment, beanName);
+        if (dataSourceEnabled) {
+            this.tables = dataSourceService.getTables();
+            this.dataSourceInfo = createDataSourceInfo(environment, beanName, dataSourceService);
+            this.body = new Body(dataSourceInfo, tables, dataSourceService.generateMermaidER(tables), dataSourceService.getPoolInfo().orElse(null));
+        } else {
+            this.tables = List.of();
+            this.dataSourceInfo = createDisabledDataSourceInfo(environment, beanName);
+            this.body = new Body(dataSourceInfo, tables, EMPTY_STRING, null);
         }
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("DataSourceControlPanel initialized: bean='{}', enabled={}, tables={}, dbType={} URL='{}' user='{}'", beanName, dataSourceEnabled, tables.size(), dataSourceInfo.type(), safeUrl(dataSourceInfo.jdbcUrl()), safeUser(dataSourceInfo.username()));
+        }
+    }
+
+    private static boolean isDataSourceEnabled(Environment env, String beanName) {
+        var enabled = env.getProperty("%s.%s.enabled".formatted(DATASOURCES_CONFIGURATION_PREFIX, beanName), Boolean.class, ControlPanelConfiguration.DEFAULT_ENABLED);
+        return enabled == null || enabled;
+    }
+
+    private static DataSourceInfo createDisabledDataSourceInfo(Environment env, String beanName) {
+        var jdbUrl = env.getProperty("datasources.%s.url".formatted(beanName), String.class, "");
+        var username = env.getProperty("datasources.%s.username".formatted(beanName), String.class, "");
+        var dialect = env.getProperty("datasources.%s.dialect".formatted(beanName), String.class, "");
+        var dbType = env.getProperty("datasources.%s.db-type".formatted(beanName), String.class, "");
+        return new DataSourceInfo(beanName, jdbUrl, username, EMPTY_STRING, DatabaseType.of(dialect, dbType), JdbcInfo.EMPTY);
     }
 
     private DataSourceInfo createDataSourceInfo(Environment env, String beanName, DataSourceService dataSourceService) {
@@ -100,6 +123,11 @@ public class DataSourceControlPanel extends AbstractEachBeanControlPanel<Body> {
     @Override
     public String getBadge() {
         return EMPTY_STRING;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return super.isEnabled() && dataSourceEnabled;
     }
 
     @Override

--- a/control-panel-datasource/src/main/java/io/micronaut/controlpanel/panels/datasource/DataSourceController.java
+++ b/control-panel-datasource/src/main/java/io/micronaut/controlpanel/panels/datasource/DataSourceController.java
@@ -51,7 +51,9 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * REST controller to execute SQL queries against a specific DataSource for the Control Panel.
@@ -83,8 +85,16 @@ public final class DataSourceController {
 
     public DataSourceController(BeanLocator locator, JsonMapper jsonMapper) {
         // Map keyed by bean name (datasource name)
-        this.services = locator.mapOfType(SERVICE_ARGUMENT);
-        this.panels = locator.mapOfType(PANEL_ARGUMENT);
+        this.panels = locator.mapOfType(PANEL_ARGUMENT)
+            .values()
+            .stream()
+            .filter(DataSourceControlPanel::isEnabled)
+            .collect(Collectors.toUnmodifiableMap(DataSourceControlPanel::getBeanName, Function.identity()));
+        this.services = locator.mapOfType(SERVICE_ARGUMENT)
+            .entrySet()
+            .stream()
+            .filter(entry -> panels.containsKey(entry.getKey()))
+            .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue));
         this.schemas = computeSchemas();
         this.jsonMapper = jsonMapper;
         if (LOG.isDebugEnabled()) {

--- a/control-panel-datasource/src/test/java/io/micronaut/controlpanel/panels/datasource/DataSourceControlPanelTest.java
+++ b/control-panel-datasource/src/test/java/io/micronaut/controlpanel/panels/datasource/DataSourceControlPanelTest.java
@@ -23,6 +23,7 @@ import io.micronaut.controlpanel.panels.datasource.model.DataSourceInfo;
 import io.micronaut.controlpanel.panels.datasource.model.DatabaseType;
 import io.micronaut.controlpanel.panels.datasource.model.PoolInfo;
 import io.micronaut.controlpanel.panels.datasource.model.Table;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -32,9 +33,17 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.lenient;
 
 @ExtendWith(MockitoExtension.class)
 class DataSourceControlPanelTest {
@@ -51,6 +60,15 @@ class DataSourceControlPanelTest {
     private static final String BEAN_NAME = "testDataSource";
     private static final List<Table> EMPTY_TABLE_LIST = List.of();
     private static final String MERMAID_ER = "erDiagram\n  TABLE1 ||--o{ TABLE2 : \"has\"";
+
+    @BeforeEach
+    void defaultDataSourcePanelEnabled() {
+        lenient().when(environment.getProperty(
+            DataSourceControlPanel.DATASOURCES_CONFIGURATION_PREFIX + "." + BEAN_NAME + ".enabled",
+            Boolean.class,
+            ControlPanelConfiguration.DEFAULT_ENABLED
+        )).thenReturn(true);
+    }
 
     @Test
     void constructorInitializesFieldsCorrectly() {
@@ -78,11 +96,14 @@ class DataSourceControlPanelTest {
     @Test
     void createDataSourceInfoExtractsPropertiesCorrectly() {
         // Given
-        String expectedUrl = "jdbc:postgresql://localhost:5432/test";
-        String expectedUsername = "user";
-        String expectedPassword = "pass";
+        String expectedUrl = "jdbc:postgresql://localhost:5432/testdb";
+        String expectedUsername = "testuser";
+        String expectedPassword = "testpass";
         String expectedDialect = "POSTGRES";
-        String expectedDbType = "postgres";
+        String expectedDbType = "";
+
+        when(dataSourceService.getTables()).thenReturn(EMPTY_TABLE_LIST);
+        when(dataSourceService.generateMermaidER(EMPTY_TABLE_LIST)).thenReturn(MERMAID_ER);
         when(environment.getProperty("datasources." + BEAN_NAME + ".url", String.class, "")).thenReturn(expectedUrl);
         when(environment.getProperty("datasources." + BEAN_NAME + ".username", String.class, "")).thenReturn(expectedUsername);
         when(environment.getProperty("datasources." + BEAN_NAME + ".password", String.class, "")).thenReturn(expectedPassword);
@@ -99,6 +120,32 @@ class DataSourceControlPanelTest {
         assertEquals(expectedUsername, info.username());
         assertEquals(expectedPassword, info.password());
         assertEquals(DatabaseType.POSTGRES, info.type());
+    }
+
+    @Test
+    void disabledDataSourceDoesNotInspectMetadata() {
+        // Given
+        when(environment.getProperty(
+            DataSourceControlPanel.DATASOURCES_CONFIGURATION_PREFIX + "." + BEAN_NAME + ".enabled",
+            Boolean.class,
+            ControlPanelConfiguration.DEFAULT_ENABLED
+        )).thenReturn(false);
+        when(environment.getProperty("datasources." + BEAN_NAME + ".url", String.class, "")).thenReturn("jdbc:h2:mem:disabled");
+        when(environment.getProperty("datasources." + BEAN_NAME + ".username", String.class, "")).thenReturn("sa");
+        when(environment.getProperty("datasources." + BEAN_NAME + ".dialect", String.class, "")).thenReturn("H2");
+        when(environment.getProperty("datasources." + BEAN_NAME + ".db-type", String.class, "")).thenReturn("");
+
+        // When
+        DataSourceControlPanel panel = new DataSourceControlPanel(BEAN_NAME, dataSourceService, environment, configuration);
+
+        // Then
+        assertFalse(panel.isEnabled());
+        assertEquals(EMPTY_TABLE_LIST, panel.getBody().tables());
+        assertEquals("", panel.getBody().mermaidEr());
+        verify(dataSourceService, never()).getTables();
+        verify(dataSourceService, never()).getJdbcInfo();
+        verify(dataSourceService, never()).getPoolInfo();
+        verify(dataSourceService, never()).generateMermaidER(EMPTY_TABLE_LIST);
     }
 
     @Test

--- a/control-panel-datasource/src/test/java/io/micronaut/controlpanel/panels/datasource/DataSourceControllerTest.java
+++ b/control-panel-datasource/src/test/java/io/micronaut/controlpanel/panels/datasource/DataSourceControllerTest.java
@@ -59,6 +59,24 @@ class DataSourceControllerTest {
     }
 
     @Test
+    void routesReturnNotFoundForDisabledPanel() {
+        // Given
+        var service = mock(DataSourceService.class);
+        doReturn(Map.of(DATA_SOURCE, service)).when(beanLocator).mapOfType(SERVICE_ARGUMENT);
+        var panel = mock(DataSourceControlPanel.class);
+        when(panel.isEnabled()).thenReturn(false);
+        doReturn(Map.of(DATA_SOURCE, panel)).when(beanLocator).mapOfType(PANEL_ARGUMENT);
+
+        // When
+        DataSourceController controller = new DataSourceController(beanLocator, jsonMapper);
+
+        // Then
+        assertEquals(404, controller.schemaJs(DATA_SOURCE).getStatus().getCode());
+        assertEquals(404, controller.tables(DATA_SOURCE, 1, 10, null, null).getStatus().getCode());
+        assertEquals(404, controller.query(DATA_SOURCE, new DataSourceController.QueryRequest("SELECT 1", 0, 10, 1)).getStatus().getCode());
+    }
+
+    @Test
     void schemaJs_returnsJavaScript_whenPanelExists() throws Exception {
         // Given
         var service = mock(DataSourceService.class);
@@ -614,6 +632,7 @@ class DataSourceControllerTest {
         var panel = mock(DataSourceControlPanel.class);
         when(panel.getBody()).thenReturn(body);
         when(panel.getBeanName()).thenReturn(DATA_SOURCE);
+        when(panel.isEnabled()).thenReturn(true);
         doReturn(Map.of(DATA_SOURCE, panel)).when(beanLocator).mapOfType(PANEL_ARGUMENT);
     }
 

--- a/src/main/docs/guide/controlPanels/datasource.adoc
+++ b/src/main/docs/guide/controlPanels/datasource.adoc
@@ -67,3 +67,19 @@ micronaut:
       datasource:
         enabled: false
 ----
+
+You can also hide an individual datasource from the panel. This is useful when a datasource is present in the application
+but its user does not have permission to inspect schema metadata or run ad hoc queries:
+
+[configuration]
+----
+micronaut:
+  control-panel:
+    panels:
+      datasource:
+        datasources:
+          reporting:
+            enabled: false
+----
+
+With this configuration, the `reporting` datasource is omitted from the datasource panel and datasource helper routes.


### PR DESCRIPTION
Disposable staging baseline/no-CodeGraph pilot artifact for alvarosanchez/hermes-backup#20 follow-up.

This PR was produced by the baseline control run on **staging Paperclip** (`https://staging.cliponaut.micronaut.fun`) using the `hermes-agent@cliponaut.local` account path.

Baseline constraints/evidence:
- No CodeGraph MCP server was configured for the `paperclip` Hermes profile.
- Run log contains `0` `codegraph_explore` occurrences.
- Staging issue: `DEV-1444`.
- Staging run id: `0451a373-23a4-4a78-92d3-1f01bf30f76a`.

Implementation summary:
- Adds per-datasource opt-out via `micronaut.control-panel.panels.datasource.datasources.<name>.enabled=false`.
- Disabled datasources skip metadata/pool inspection during panel construction.
- Disabled datasources are filtered out of repository/UI category listings.
- Datasource helper routes return 404 for disabled datasources.
- Documents the new datasource-specific configuration.

Staging verification reported by the agent:
- `./gradlew :micronaut-control-panel-datasource:test --tests 'io.micronaut.controlpanel.panels.datasource.DataSourceControlPanelTest' --tests 'io.micronaut.controlpanel.panels.datasource.DataSourceControllerTest'` — passed.
- `./gradlew :micronaut-control-panel-core:test --tests 'io.micronaut.controlpanel.core.DefaultControlPanelRepositoryTest' :micronaut-control-panel-datasource:test` — passed.
- `./gradlew :micronaut-control-panel-core:spotlessCheck :micronaut-control-panel-datasource:spotlessCheck` — passed.
- `git diff --check` — passed.

Not intended for merge without maintainer review; this is an evaluation artifact.

Fixes #598