### PR TITLE
Stop the datasource panel from forcing micronaut-data onto consumers

### DIFF
--- a/control-panel-datasource/build.gradle.kts
+++ b/control-panel-datasource/build.gradle.kts
@@ -22,9 +22,12 @@ dependencies {
     annotationProcessor(mnSerde.micronaut.serde.processor)
 
     implementation(mnSql.micronaut.jdbc)
-    implementation(mnData.micronaut.data.connection.jdbc)
     implementation(mnSerde.micronaut.serde.api)
 
+    // Used only by DataSourceUnwrapper, guarded by @Requires(classes = DelegatingDataSource.class).
+    // compileOnly (not implementation) so the panel does not force Micronaut Data's connection
+    // advice onto applications that do not use Micronaut Data.
+    compileOnly(mnData.micronaut.data.connection.jdbc)
     compileOnly(mnSql.micronaut.jdbc.hikari)
     compileOnly(mnSql.micronaut.jdbc.ucp)
 

--- a/control-panel-datasource/build.gradle.kts
+++ b/control-panel-datasource/build.gradle.kts
@@ -48,3 +48,25 @@ dependencies {
 tasks.named("internalStartTestResourcesService") {
     setProperty("useClassDataSharing", false)
 }
+
+// Verifies the datasource panel works when micronaut-data-connection-jdbc is absent from the
+// classpath, as it is for applications that do not use Micronaut Data. The standard test task has
+// the module present; this task strips it to reproduce the NoClassDefFoundError that occurred while
+// DataSourceService referenced DelegatingDataSource directly and the module was an `implementation`
+// dependency.
+val testWithoutDataConnection by tasks.registering(Test::class) {
+    description = "Verifies the datasource panel instantiates when micronaut-data-connection-jdbc is absent"
+    group = "verification"
+    classpath = configurations.named("testRuntimeClasspath").get()
+        .filter { !it.name.contains("micronaut-data-connection") }
+        .plus(sourceSets.main.get().output)
+        .plus(sourceSets.test.get().output)
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    filter {
+        includeTestsMatching("io.micronaut.controlpanel.panels.datasource.DataConnectionJdbcAbsentFromClasspathTest")
+    }
+}
+
+tasks.named("check") {
+    dependsOn(testWithoutDataConnection)
+}

--- a/control-panel-datasource/src/main/java/io/micronaut/controlpanel/panels/datasource/ConnectionPoolInspector.java
+++ b/control-panel-datasource/src/main/java/io/micronaut/controlpanel/panels/datasource/ConnectionPoolInspector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2025 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,8 @@ import java.util.Optional;
 interface ConnectionPoolInspector {
 
     /**
-     * @param dataSource The unwrapped datasource
+     * @param dataSource The datasource, possibly wrapped; implementations locate their pool via the
+     *                   JDBC {@link java.sql.Wrapper} API
      * @return The pool metadata when this inspector supports the datasource
      */
     Optional<PoolInfo> inspect(DataSource dataSource);

--- a/control-panel-datasource/src/main/java/io/micronaut/controlpanel/panels/datasource/DataSourceService.java
+++ b/control-panel-datasource/src/main/java/io/micronaut/controlpanel/panels/datasource/DataSourceService.java
@@ -62,6 +62,12 @@ public class DataSourceService {
     private final List<ConnectionPoolInspector> connectionPoolInspectors;
 
     /**
+     * Unwraps the datasource when a {@link DataSourceUnwrapper} is available, so that
+     * micronaut-data is not forced onto consumers.
+     *
+     * @param dataSource the datasource this service inspects
+     * @param unwrapper optional unwrapper, absent when no unwrapping strategy is on the classpath
+     * @param connectionPoolInspectors inspectors contributing connection pool metadata
      * @since 2.0.1
      */
     @Inject

--- a/control-panel-datasource/src/main/java/io/micronaut/controlpanel/panels/datasource/DataSourceService.java
+++ b/control-panel-datasource/src/main/java/io/micronaut/controlpanel/panels/datasource/DataSourceService.java
@@ -61,6 +61,9 @@ public class DataSourceService {
     private final DataSource dataSource;
     private final List<ConnectionPoolInspector> connectionPoolInspectors;
 
+    /**
+     * @since 2.0.1
+     */
     @Inject
     public DataSourceService(@Parameter DataSource dataSource,
                              @Nullable DataSourceUnwrapper unwrapper,

--- a/control-panel-datasource/src/main/java/io/micronaut/controlpanel/panels/datasource/DataSourceService.java
+++ b/control-panel-datasource/src/main/java/io/micronaut/controlpanel/panels/datasource/DataSourceService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2025 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@ import io.micronaut.controlpanel.panels.datasource.model.ForeignKey;
 import io.micronaut.controlpanel.panels.datasource.model.JdbcInfo;
 import io.micronaut.controlpanel.panels.datasource.model.PoolInfo;
 import io.micronaut.controlpanel.panels.datasource.model.Table;
-import io.micronaut.data.connection.jdbc.advice.DelegatingDataSource;
 import io.micronaut.serde.annotation.Serdeable;
 import jakarta.inject.Inject;
 import org.jspecify.annotations.NonNull;
@@ -63,8 +62,14 @@ public class DataSourceService {
     private final List<ConnectionPoolInspector> connectionPoolInspectors;
 
     @Inject
+    public DataSourceService(@Parameter DataSource dataSource,
+                             @Nullable DataSourceUnwrapper unwrapper,
+                             List<ConnectionPoolInspector> connectionPoolInspectors) {
+        this(unwrapper == null ? dataSource : unwrapper.unwrap(dataSource), connectionPoolInspectors);
+    }
+
     public DataSourceService(@Parameter DataSource dataSource, List<ConnectionPoolInspector> connectionPoolInspectors) {
-        this.dataSource = DelegatingDataSource.unwrapDataSource(dataSource);
+        this.dataSource = dataSource;
         this.connectionPoolInspectors = connectionPoolInspectors;
     }
 

--- a/control-panel-datasource/src/main/java/io/micronaut/controlpanel/panels/datasource/DataSourceUnwrapper.java
+++ b/control-panel-datasource/src/main/java/io/micronaut/controlpanel/panels/datasource/DataSourceUnwrapper.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.datasource;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.data.connection.jdbc.advice.DelegatingDataSource;
+import jakarta.inject.Singleton;
+
+import javax.sql.DataSource;
+
+/**
+ * Strips Micronaut Data's {@link DelegatingDataSource} connection-management advice so the panel can
+ * reach the underlying pool and open connections outside a Micronaut connection scope.
+ *
+ * <p>Registered only when {@code micronaut-data-connection-jdbc} is on the classpath — i.e. the
+ * application uses Micronaut Data, whose {@code ContextualAwareDataSource} wraps every datasource.
+ * Otherwise no such advice exists and {@link DataSourceService} uses the datasource directly. The
+ * {@code @Requires(classes = ...)} guard keeps the dependency optional ({@code compileOnly}): when
+ * the class is absent this bean definition is skipped without a {@code NoClassDefFoundError}.
+ */
+@Internal
+@Singleton
+@Requires(classes = DelegatingDataSource.class)
+final class DataSourceUnwrapper {
+
+    DataSource unwrap(DataSource dataSource) {
+        return DelegatingDataSource.unwrapDataSource(dataSource);
+    }
+}

--- a/control-panel-datasource/src/main/java/io/micronaut/controlpanel/panels/datasource/HikariConnectionPoolInspector.java
+++ b/control-panel-datasource/src/main/java/io/micronaut/controlpanel/panels/datasource/HikariConnectionPoolInspector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2025 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,8 @@ final class HikariConnectionPoolInspector implements ConnectionPoolInspector {
 
     @Override
     public Optional<PoolInfo> inspect(DataSource dataSource) {
-        if (!(dataSource instanceof HikariDataSource hikariDataSource)) {
+        HikariDataSource hikariDataSource = PoolInfoSupport.unwrap(dataSource, HikariDataSource.class);
+        if (hikariDataSource == null) {
             return Optional.empty();
         }
         var poolMxBean = hikariDataSource.getHikariPoolMXBean();

--- a/control-panel-datasource/src/main/java/io/micronaut/controlpanel/panels/datasource/OracleUcpConnectionPoolInspector.java
+++ b/control-panel-datasource/src/main/java/io/micronaut/controlpanel/panels/datasource/OracleUcpConnectionPoolInspector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2025 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,8 @@ final class OracleUcpConnectionPoolInspector implements ConnectionPoolInspector 
 
     @Override
     public Optional<PoolInfo> inspect(DataSource dataSource) {
-        if (!(dataSource instanceof PoolDataSource poolDataSource)) {
+        PoolDataSource poolDataSource = PoolInfoSupport.unwrap(dataSource, PoolDataSource.class);
+        if (poolDataSource == null) {
             return Optional.empty();
         }
         var stats = poolDataSource.getStatistics();

--- a/control-panel-datasource/src/main/java/io/micronaut/controlpanel/panels/datasource/PoolInfoSupport.java
+++ b/control-panel-datasource/src/main/java/io/micronaut/controlpanel/panels/datasource/PoolInfoSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2025 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,9 @@ package io.micronaut.controlpanel.panels.datasource;
 
 import io.micronaut.controlpanel.panels.datasource.model.PoolInfo;
 import io.micronaut.core.annotation.Internal;
+import org.jspecify.annotations.Nullable;
 
+import javax.sql.DataSource;
 import java.sql.SQLException;
 import java.time.Duration;
 import java.util.List;
@@ -33,6 +35,32 @@ final class PoolInfoSupport {
     static final String UNKNOWN = "Unknown";
 
     private PoolInfoSupport() {
+    }
+
+    /**
+     * Locates a pool of {@code type} within {@code dataSource}, seeing through any wrapping
+     * {@link DataSource} (Micronaut Data's connection advice, OpenTelemetry tracing, ...) via the
+     * JDBC {@link java.sql.Wrapper} API. Returns {@code null} when the datasource neither is, nor
+     * wraps, that type — including when it cannot be inspected.
+     *
+     * @param dataSource the datasource, possibly wrapped
+     * @param type       the provider-specific pool type to locate
+     * @param <T>        the pool type
+     * @return the pool, or {@code null} if not present
+     */
+    @SuppressWarnings("unchecked")
+    static <T> @Nullable T unwrap(DataSource dataSource, Class<T> type) {
+        if (type.isInstance(dataSource)) {
+            return (T) dataSource;
+        }
+        try {
+            if (dataSource.isWrapperFor(type)) {
+                return dataSource.unwrap(type);
+            }
+        } catch (SQLException ignored) {
+            // An un-inspectable datasource is treated as "not this pool type".
+        }
+        return null;
     }
 
     static PoolInfo.PoolOptionGroup group(String title, PoolInfo.PoolOption... options) {

--- a/control-panel-datasource/src/test/java/io/micronaut/controlpanel/panels/datasource/ConnectionPoolInspectorWrapperTest.java
+++ b/control-panel-datasource/src/test/java/io/micronaut/controlpanel/panels/datasource/ConnectionPoolInspectorWrapperTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.datasource;
+
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import javax.sql.DataSource;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A {@link ConnectionPoolInspector} must locate its provider's pool even when the pool is behind a
+ * wrapping {@link DataSource} — e.g. micronaut-data's {@code ContextualAwareDataSource} or
+ * OpenTelemetry's tracing datasource. Relying on {@code instanceof} against the concrete pool type
+ * misses the pool whenever such a wrapper is present, leaving the panel with no pool statistics.
+ *
+ * <p>The fix is to locate the pool via the JDBC {@link java.sql.Wrapper} API ({@code isWrapperFor} /
+ * {@code unwrap}), which sees through any conformant wrapper.
+ */
+class ConnectionPoolInspectorWrapperTest {
+
+    @Test
+    @DisplayName("Hikari inspector finds the pool when it is wrapped by another DataSource")
+    void hikariInspectorSeesThroughWrapper() {
+        try (HikariDataSource hikari = new HikariDataSource()) {
+            hikari.setPoolName("wrapped-pool");
+            HikariConnectionPoolInspector inspector = new HikariConnectionPoolInspector();
+
+            assertTrue(
+                inspector.inspect(hikari).isPresent(),
+                "Inspector must report the pool for a bare HikariDataSource"
+            );
+
+            DataSource wrapped = new DelegatingTestDataSource(hikari);
+            assertTrue(
+                inspector.inspect(wrapped).isPresent(),
+                "Inspector must report the pool when the HikariDataSource is behind a wrapper"
+            );
+        }
+    }
+}

--- a/control-panel-datasource/src/test/java/io/micronaut/controlpanel/panels/datasource/DataConnectionJdbcAbsentFromClasspathTest.java
+++ b/control-panel-datasource/src/test/java/io/micronaut/controlpanel/panels/datasource/DataConnectionJdbcAbsentFromClasspathTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.datasource;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Singleton;
+import org.junit.jupiter.api.Test;
+
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Map;
+import java.util.logging.Logger;
+import javax.sql.DataSource;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Verifies the datasource control panel works when {@code micronaut-data-connection-jdbc} is absent
+ * from the runtime classpath — the common case for applications that do not use Micronaut Data
+ * (raw JDBC, or a standalone SQL layer).
+ *
+ * <p>The panel is a generic JDBC inspection tool, yet it used to take a runtime ({@code implementation})
+ * dependency on {@code micronaut-data-connection-jdbc} solely for {@code DelegatingDataSource}. That
+ * forced Micronaut Data's {@code ContextualAwareDataSource} advice onto every consumer and made
+ * {@link DataSourceService}'s constructor reference a class that is not present for non-data apps,
+ * so instantiating the {@code @EachBean(DataSource.class)} service threw {@code NoClassDefFoundError}.
+ *
+ * <p>This test is run by the {@code testWithoutDataConnection} Gradle task, which strips
+ * {@code micronaut-data-connection-jdbc} from the test classpath.
+ */
+class DataConnectionJdbcAbsentFromClasspathTest {
+
+    @Test
+    void datasourcePanelInstantiatesWithoutDataConnectionJdbc() {
+        try (ApplicationContext context = ApplicationContext.run(
+            Map.of("spec.name", "DataConnectionJdbcAbsentFromClasspathTest")
+        )) {
+            // Resolving DataSourceService (@EachBean(DataSource.class)) runs its constructor. While the
+            // constructor referenced DelegatingDataSource directly, this threw NoClassDefFoundError once
+            // micronaut-data-connection-jdbc was stripped from the classpath.
+            assertFalse(
+                context.getBeansOfType(DataSourceService.class).isEmpty(),
+                "DataSourceService must instantiate when micronaut-data-connection-jdbc is absent"
+            );
+        }
+    }
+
+    @Factory
+    @Requires(property = "spec.name", value = "DataConnectionJdbcAbsentFromClasspathTest")
+    static class StubDataSourceFactory {
+
+        @Singleton
+        DataSource dataSource() {
+            return new StubDataSource();
+        }
+    }
+
+    /**
+     * A no-op {@link DataSource}; the test only needs a bean to exist so the {@code @EachBean}
+     * {@link DataSourceService} is instantiated. No connection is opened.
+     */
+    private static final class StubDataSource implements DataSource {
+
+        @Override
+        public Connection getConnection() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Connection getConnection(String username, String password) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public PrintWriter getLogWriter() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setLogWriter(PrintWriter out) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setLoginTimeout(int seconds) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int getLoginTimeout() {
+            return 0;
+        }
+
+        @Override
+        public Logger getParentLogger() {
+            return Logger.getLogger(Logger.GLOBAL_LOGGER_NAME);
+        }
+
+        @Override
+        public <T> T unwrap(Class<T> iface) throws SQLException {
+            throw new SQLException("Not a wrapper for " + iface);
+        }
+
+        @Override
+        public boolean isWrapperFor(Class<?> iface) {
+            return false;
+        }
+    }
+}

--- a/control-panel-datasource/src/test/java/io/micronaut/controlpanel/panels/datasource/DelegatingTestDataSource.java
+++ b/control-panel-datasource/src/test/java/io/micronaut/controlpanel/panels/datasource/DelegatingTestDataSource.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.controlpanel.panels.datasource;
+
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.logging.Logger;
+import javax.sql.DataSource;
+
+/**
+ * A {@link DataSource} that delegates to a target, standing in for any framework wrapper layered
+ * over a pool (micronaut-data's {@code ContextualAwareDataSource}, OpenTelemetry's tracing
+ * datasource, etc.). It is deliberately <em>not</em> the concrete pool type, so {@code instanceof}
+ * checks against the pool fail while the JDBC {@link java.sql.Wrapper} API still sees through it.
+ */
+final class DelegatingTestDataSource implements DataSource {
+
+    private final DataSource target;
+
+    DelegatingTestDataSource(DataSource target) {
+        this.target = target;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+        if (iface.isInstance(this)) {
+            return (T) this;
+        }
+        if (iface.isInstance(target)) {
+            return iface.cast(target);
+        }
+        return target.unwrap(iface);
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
+        return iface.isInstance(this) || iface.isInstance(target) || target.isWrapperFor(iface);
+    }
+
+    @Override
+    public Connection getConnection() throws SQLException {
+        return target.getConnection();
+    }
+
+    @Override
+    public Connection getConnection(String username, String password) throws SQLException {
+        return target.getConnection(username, password);
+    }
+
+    @Override
+    public PrintWriter getLogWriter() throws SQLException {
+        return target.getLogWriter();
+    }
+
+    @Override
+    public void setLogWriter(PrintWriter out) throws SQLException {
+        target.setLogWriter(out);
+    }
+
+    @Override
+    public void setLoginTimeout(int seconds) throws SQLException {
+        target.setLoginTimeout(seconds);
+    }
+
+    @Override
+    public int getLoginTimeout() throws SQLException {
+        return target.getLoginTimeout();
+    }
+
+    @Override
+    public Logger getParentLogger() {
+        return Logger.getLogger(Logger.GLOBAL_LOGGER_NAME);
+    }
+}


### PR DESCRIPTION
Fixes #632.

The datasource panel is a generic JDBC inspection tool, but it coupled to Micronaut Data in two ways that break applications which don't use it.

### 1. Forced `micronaut-data-connection-jdbc` dependency

The module declared `micronaut-data-connection-jdbc` as `implementation`, used solely for `DelegatingDataSource.unwrapDataSource`. That forced Micronaut Data's `ContextualAwareDataSource` advice onto every consumer's runtime classpath — wrapping all `DataSource` beans in a context-bound proxy so unmanaged `getConnection()` calls throw `NoConnectionException` — and made `DataSourceService` reference a class absent for non-data apps (`NoClassDefFoundError`).

This moves the dependency to `compileOnly` (mirroring the existing treatment of the Hikari/UCP pool libraries) and isolates the `DelegatingDataSource` call behind a new `DataSourceUnwrapper` guarded by `@Requires(classes = DelegatingDataSource.class)`. When Micronaut Data is present the panel unwraps the advice exactly as before; when absent there is nothing to unwrap and the datasource is used directly.

### 2. Pool inspectors missed wrapped pools

`ConnectionPoolInspector` implementations used `instanceof` against the concrete pool type, which fails whenever the pool is behind a wrapping `DataSource` (Micronaut Data's advice, OpenTelemetry tracing, etc.). They now locate the pool through the JDBC `Wrapper` API (`isWrapperFor`/`unwrap`) via a shared `PoolInfoSupport.unwrap` helper, so any conformant wrapper is seen through.

### Tests

- `ConnectionPoolInspectorWrapperTest` — the Hikari inspector finds the pool both bare and behind a wrapper.
- `DataConnectionJdbcAbsentFromClasspathTest` + a `testWithoutDataConnection` task (mirroring `testWithoutEhcache` from #628) — strips `micronaut-data-connection-jdbc` and asserts the panel still instantiates. Both tests fail on the parent commit and pass with the fix.

No UI changes, so no screenshots.
