### PR TITLE
Exclude Nashorn from Handlebars dependencies

### DIFF
--- a/control-panel-datasource/build.gradle.kts
+++ b/control-panel-datasource/build.gradle.kts
@@ -37,7 +37,9 @@ dependencies {
     testAnnotationProcessor(mn.micronaut.inject.java)
     testImplementation(mn.micronaut.http.server.netty)
     testImplementation(mn.micronaut.http.client)
-    testImplementation(mnViews.micronaut.views.handlebars)
+    testImplementation(mnViews.micronaut.views.handlebars) {
+        exclude(group = "org.openjdk.nashorn", module = "nashorn-core")
+    }
     testImplementation(mnSql.micronaut.jdbc.hikari)
     testImplementation(mnSql.micronaut.jdbc.ucp)
     testImplementation(mnSerde.micronaut.serde.jackson)

--- a/control-panel-ui/build.gradle.kts
+++ b/control-panel-ui/build.gradle.kts
@@ -5,7 +5,11 @@ plugins {
 
 dependencies {
     api(projects.micronautControlPanelCore)
-    api(mnViews.micronaut.views.handlebars)
+    // The Control Panel uses Java helpers and ordinary Handlebars compilation; Nashorn is only
+    // required by Handlebars' optional JavaScript helper/precompilation APIs.
+    api(mnViews.micronaut.views.handlebars) {
+        exclude(group = "org.openjdk.nashorn", module = "nashorn-core")
+    }
     implementation(mn.micronaut.http.server)
     compileOnly(mn.micronaut.management)
 

--- a/src/main/docs/guide/custom.adoc
+++ b/src/main/docs/guide/custom.adoc
@@ -61,6 +61,10 @@ For rendering the views, the Control Panel uses
 https://micronaut-projects.github.io/micronaut-views/latest/guide/[Micronaut Views] with
 https://micronaut-projects.github.io/micronaut-views/latest/guide/#handlebars[Handlebars.java] templates.
 
+The Control Panel uses Java helpers and ordinary Handlebars template rendering, so it excludes the optional Nashorn
+JavaScript engine from its dependency graph. If your application registers Handlebars JavaScript helpers or uses
+Handlebars' JavaScript precompilation APIs, declare `org.openjdk.nashorn:nashorn-core` explicitly.
+
 Each control panel needs to provide two views: one for the control panel list, that can contain a summary of the
 information to be displayed, and another one for the detailed view. They must be placed in a `views/<panel-name>` directory
 on the classpath, and named `body.hbs` and `detail.hbs`, respectively. For example, in the above example:


### PR DESCRIPTION
## Summary

- Exclude the optional Nashorn JavaScript engine from the Control Panel Handlebars dependency graph.
- Apply the exclusion to datasource template tests as well.
- Document when consumers must add Nashorn explicitly.

## Verification

- `dependencyInsight` reports no `nashorn-core` in UI runtime or datasource test runtime.
- Generated Maven POM and Gradle Module Metadata contain the exclusion.
- A temporary Maven consumer resolved `micronaut-control-panel-ui` and Handlebars successfully with no Nashorn in its dependency tree.
- Focused UI helper/precompile tests: 14 passed.
- Datasource template tests: 8 passed.
- `publishGuide`, `docs`, `spotlessCheck`, and `git diff --check` passed.

The broader UI suite encountered unrelated missing Oracle Cloud test configuration (`Missing user in config`). This change does not alter provider setup or rendering behavior.